### PR TITLE
Add programmatic API

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -2,4 +2,4 @@
 import { argv } from "node:process";
 import run from "./dist/index.js";
 
-run(argv);
+run(argv.slice(2));

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -1,2 +1,5 @@
 #!/usr/bin/env node
-import "./dist/index.js";
+import { argv } from "node:process";
+import run from "./dist/index.js";
+
+run(argv);

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -2,4 +2,4 @@
 import { argv } from "node:process";
 import run from "./dist/index.js";
 
-run(argv.slice(2));
+run(argv.slice(2).join(" "));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,38 +18,41 @@ import {
   WatchCommand,
 } from "./commands/index.js";
 
-const pkg: { name: string; description: string; version: string } = JSON.parse(
-  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-);
+const run = (argv: string[]) => {
+  const pkg: { name: string; description: string; version: string } = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const cli = cac(pkg.name).usage(pkg.description).help().version(pkg.version);
+  const commands = [
+    ClassicCommand,
+    AwesomeCommand,
+    CsvCommand,
+    GenerateCommand,
+    HistoryCommand,
+    KnownIssueCommand,
+    LogCommand,
+    OpenCommand,
+    QualityGateCommand,
+    RunCommand,
+    SlackCommand,
+    TestPlanCommand,
+    WatchCommand,
+  ];
 
-const cli = cac(pkg.name).usage(pkg.description).help().version(pkg.version);
-const commands = [
-  ClassicCommand,
-  AwesomeCommand,
-  CsvCommand,
-  GenerateCommand,
-  HistoryCommand,
-  KnownIssueCommand,
-  LogCommand,
-  OpenCommand,
-  QualityGateCommand,
-  RunCommand,
-  SlackCommand,
-  TestPlanCommand,
-  WatchCommand,
-];
+  commands.forEach((command) => {
+    command(cli);
+  });
 
-commands.forEach((command) => {
-  command(cli);
-});
+  cli.on("command:*", () => {
+    console.error("Invalid command: %s", cli.args.join(" "));
+    process.exit(1);
+  });
 
-cli.on("command:*", () => {
-  console.error("Invalid command: %s", cli.args.join(" "));
-  process.exit(1);
-});
+  console.log(cwd());
 
-console.log(cwd());
-
-cli.parse();
+  cli.parse(argv);
+};
 
 export { defineConfig } from "@allurereport/plugin-api";
+
+export default run;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,11 +25,11 @@ import {
  * ```js
  * import allure from "allure";
  *
- * allure(["run", "--", "npm", "test"]);     // equivalent to `allure run -- npm test`
- * allure(["generate", "./allure-results"]); // equivalent to `allure generate ./allure-results`
+ * allure("run -- npm test"]);          // equivalent to `allure run -- npm test`
+ * allure("generate ./allure-results"); // equivalent to `allure generate ./allure-results`
  * ```
  */
-const run = (argv: string[]) => {
+const run = (argv: string) => {
   const pkg: { name: string; description: string; version: string } = JSON.parse(
     readFileSync(new URL("../package.json", import.meta.url), "utf8"),
   );
@@ -61,7 +61,7 @@ const run = (argv: string[]) => {
 
   console.log(cwd());
 
-  cli.parse(["", "", ...argv]);
+  cli.parse(["", "", ...argv.split(" ")]);
 };
 
 export { defineConfig } from "@allurereport/plugin-api";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,17 @@ import {
   WatchCommand,
 } from "./commands/index.js";
 
+/**
+ * Programmatic entry point for the Allure 3 CLI
+ * @param argv the array of arguments which already doesn't includes the node binary and the script path (the first two elements)
+ * @example
+ * ```js
+ * import allure from "allure";
+ *
+ * allure(["run", "--", "npm", "test"]);     // equivalent to `allure run -- npm test`
+ * allure(["generate", "./allure-results"]); // equivalent to `allure generate ./allure-results`
+ * ```
+ */
 const run = (argv: string[]) => {
   const pkg: { name: string; description: string; version: string } = JSON.parse(
     readFileSync(new URL("../package.json", import.meta.url), "utf8"),
@@ -50,7 +61,7 @@ const run = (argv: string[]) => {
 
   console.log(cwd());
 
-  cli.parse(argv);
+  cli.parse(["", "", ...argv]);
 };
 
 export { defineConfig } from "@allurereport/plugin-api";

--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -22,6 +22,7 @@ export const createCommand = (payload: CreateCommandOptions) => {
   if (!payload.name) {
     throw new Error("Command name is not provided!");
   }
+
   if (!payload.action) {
     throw new Error("Command action is not provided!");
   }


### PR DESCRIPTION
fixes #15

This is a basic programmatic API for Allure 3. I don't see any sense in adding more features to it currently because we plan to get rid of CAC due to the many limitations it makes.

Example of the API usage:

```js
import allure from "allure";

allure("run -- npm test");
allure("generate ./allure-results");
allure("awesome --report-name foobar ./allure-results");
```