### PR TITLE
Improve attachment processing

### DIFF
--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -143,7 +143,7 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
       // we need to preserve the same object since it's referenced in steps
       const link = maybeLink as AttachmentLinkLinked;
       link.missed = false;
-      link.ext = link?.ext ?? resultFile.getExtension();
+      link.ext = link.ext === undefined || link.ext === "" ? resultFile.getExtension() : link.ext;
       link.contentType = link.contentType ?? resultFile.getContentType();
       link.contentLength = resultFile.getContentLength();
     } else {

--- a/packages/core/test/store/convert.test.ts
+++ b/packages/core/test/store/convert.test.ts
@@ -120,4 +120,38 @@ describe("testResultRawToState", () => {
       historyId: `${md5(testId)}.${md5("")}`,
     });
   });
+
+  it("should detect attachment link content type based on file extension if specified", () => {
+    const result = testResultRawToState(
+      emptyStateData,
+      { steps: [{ type: "attachment", originalFileName: "some-file.txt" }] },
+      { readerId },
+    );
+
+    const [attachment] = result.steps;
+    expect(attachment).toMatchObject({
+      type: "attachment",
+      link: {
+        originalFileName: "some-file.txt",
+        contentType: "text/plain",
+      },
+    });
+  });
+
+  it("should set extension based on file name", () => {
+    const result = testResultRawToState(
+      emptyStateData,
+      { steps: [{ type: "attachment", originalFileName: "some-file.txt" }] },
+      { readerId },
+    );
+
+    const [attachment] = result.steps;
+    expect(attachment).toMatchObject({
+      type: "attachment",
+      link: {
+        originalFileName: "some-file.txt",
+        ext: ".txt",
+      },
+    });
+  });
 });

--- a/packages/core/test/store/store.test.ts
+++ b/packages/core/test/store/store.test.ts
@@ -892,6 +892,172 @@ describe("attachments", () => {
       type: "attachment",
     });
   });
+
+  it("should use extension from original file name if any (link first)", async () => {
+    const store = new DefaultAllureStore();
+    const tr1: RawTestResult = {
+      name: "test result 1",
+      steps: [
+        {
+          name: "attachment 1",
+          type: "attachment",
+          originalFileName: "tr1-source1.txt",
+        },
+      ],
+    };
+
+    const buffer1 = Buffer.from("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>", "utf-8");
+    const rf1 = new BufferResultFile(buffer1, "tr1-source1.txt");
+    await store.visitTestResult(tr1, { readerId });
+    await store.visitAttachmentFile(rf1, { readerId });
+
+    const [attachment] = await store.allAttachments();
+
+    expect(attachment).toMatchObject({
+      name: "attachment 1",
+      originalFileName: "tr1-source1.txt",
+      ext: ".txt"
+    });
+  });
+
+  it("should use extension from original file name if any (file first)", async () => {
+    const store = new DefaultAllureStore();
+    const tr1: RawTestResult = {
+      name: "test result 1",
+      steps: [
+        {
+          name: "attachment 1",
+          type: "attachment",
+          originalFileName: "tr1-source1.txt",
+        },
+      ],
+    };
+
+    const buffer1 = Buffer.from("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>", "utf-8");
+    const rf1 = new BufferResultFile(buffer1, "tr1-source1.txt");
+    await store.visitAttachmentFile(rf1, { readerId });
+    await store.visitTestResult(tr1, { readerId });
+
+    const [attachment] = await store.allAttachments();
+
+    expect(attachment).toMatchObject({
+      name: "attachment 1",
+      originalFileName: "tr1-source1.txt",
+      ext: ".txt"
+    });
+  });
+
+  it("should use extension based on content type specified in link if file without extension (link first)", async () => {
+    const store = new DefaultAllureStore();
+    const tr1: RawTestResult = {
+      name: "test result 1",
+      steps: [
+        {
+          name: "attachment 1",
+          type: "attachment",
+          originalFileName: "tr1-source1",
+          contentType: "text/plain"
+        },
+      ],
+    };
+
+    const buffer1 = Buffer.from("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>", "utf-8");
+    const rf1 = new BufferResultFile(buffer1, "tr1-source1");
+    await store.visitTestResult(tr1, { readerId });
+    await store.visitAttachmentFile(rf1, { readerId });
+
+    const [attachment] = await store.allAttachments();
+
+    expect(attachment).toMatchObject({
+      name: "attachment 1",
+      originalFileName: "tr1-source1",
+      ext: ".txt"
+    });
+  });
+
+  it("should use extension based on content type specified in link if file without extension (file first)", async () => {
+    const store = new DefaultAllureStore();
+    const tr1: RawTestResult = {
+      name: "test result 1",
+      steps: [
+        {
+          name: "attachment 1",
+          type: "attachment",
+          originalFileName: "tr1-source1",
+          contentType: "text/plain"
+        },
+      ],
+    };
+
+    const buffer1 = Buffer.from("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>", "utf-8");
+    const rf1 = new BufferResultFile(buffer1, "tr1-source1");
+    await store.visitAttachmentFile(rf1, { readerId });
+    await store.visitTestResult(tr1, { readerId });
+
+    const [attachment] = await store.allAttachments();
+
+    expect(attachment).toMatchObject({
+      name: "attachment 1",
+      originalFileName: "tr1-source1",
+      ext: ".txt"
+    });
+  });
+
+  it("should use extension based on detected content type if no extension and content type is provided (link first)", async () => {
+    const store = new DefaultAllureStore();
+    const tr1: RawTestResult = {
+      name: "test result 1",
+      steps: [
+        {
+          name: "attachment 1",
+          type: "attachment",
+          originalFileName: "tr1-source1",
+        },
+      ],
+    };
+
+    const buffer1 = Buffer.from("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>", "utf-8");
+    const rf1 = new BufferResultFile(buffer1, "tr1-source1");
+    await store.visitTestResult(tr1, { readerId });
+    await store.visitAttachmentFile(rf1, { readerId });
+
+    const [attachment] = await store.allAttachments();
+
+    expect(attachment).toMatchObject({
+      name: "attachment 1",
+      originalFileName: "tr1-source1",
+      contentType: "image/svg+xml",
+      ext: ".svg"
+    });
+  });
+
+  it("should use extension based on detected content type if no extension and content type is provided (file first)", async () => {
+    const store = new DefaultAllureStore();
+    const tr1: RawTestResult = {
+      name: "test result 1",
+      steps: [
+        {
+          name: "attachment 1",
+          type: "attachment",
+          originalFileName: "tr1-source1",
+        },
+      ],
+    };
+
+    const buffer1 = Buffer.from("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>", "utf-8");
+    const rf1 = new BufferResultFile(buffer1, "tr1-source1");
+    await store.visitAttachmentFile(rf1, { readerId });
+    await store.visitTestResult(tr1, { readerId });
+
+    const [attachment] = await store.allAttachments();
+
+    expect(attachment).toMatchObject({
+      name: "attachment 1",
+      originalFileName: "tr1-source1",
+      contentType: "image/svg+xml",
+      ext: ".svg"
+    });
+  });
 });
 
 describe("history", () => {

--- a/packages/reader-api/src/detect.ts
+++ b/packages/reader-api/src/detect.ts
@@ -491,7 +491,7 @@ class MagicMatchClause implements Clause {
     private end: number = start,
   ) {}
   eval = (data: Uint8Array): boolean => {
-    if (data.length < this.pattern.length + this.end - this.start) {
+    if (data.length < this.pattern.length + this.start) {
       return false;
     }
 

--- a/packages/reader-api/src/index.ts
+++ b/packages/reader-api/src/index.ts
@@ -1,3 +1,5 @@
 export type * from "./model.js";
 export type * from "./reader.js";
 export * from "./resultFile.js";
+export { detectContentType } from "./detect.js";
+export { extension, lookupContentType } from "./utils.js";

--- a/packages/reader-api/src/utils.ts
+++ b/packages/reader-api/src/utils.ts
@@ -1,0 +1,25 @@
+import { extension as extensionFromContentType, lookup } from "mime-types";
+import { extname } from "node:path";
+
+export const extension = (fileName: string, contentType?: string) => {
+  const ext = extname(fileName);
+  if (ext !== "") {
+    return ext;
+  }
+  if (contentType) {
+    const result = extensionFromContentType(contentType);
+    if (result === false) {
+      return undefined;
+    }
+    return `.${result}`;
+  }
+  return undefined;
+};
+
+export const lookupContentType = (fileName: string) => {
+  const res = lookup(fileName);
+  if (res === false) {
+    return undefined;
+  }
+  return res;
+};

--- a/packages/reader-api/test/resources/short.svg
+++ b/packages/reader-api/test/resources/short.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/packages/reader-api/test/utils.test.ts
+++ b/packages/reader-api/test/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { extension } from "../src/utils.js";
+
+describe("extension", () => {
+  it("should return original extension if any", () => {
+    const result = extension("some.json", "text/plain");
+    expect(result).toEqual(".json");
+  });
+
+  it("should return extension based on content type if no file extension", () => {
+    const result = extension("without-extension", "text/plain");
+    expect(result).toEqual(".txt");
+  });
+});

--- a/packages/reader-api/test/utils.ts
+++ b/packages/reader-api/test/utils.ts
@@ -12,4 +12,5 @@ export const resources = [
   ["sample.tiff", "image/tiff"],
   ["sample.jpeg", "image/jpeg"],
   ["sample.svg", "image/svg+xml"],
+  ["short.svg", "image/svg+xml"],
 ];


### PR DESCRIPTION
1. cache detected content type
2. cache calculated file extensions
3. fix file extension calculation for attachments
4. now all the attachments files in the report have proper file extensions