### PR TITLE
fix: allure1 ignores nested steps and attachments of nested steps that consist of a single element

### DIFF
--- a/packages/reader/src/allure1/index.ts
+++ b/packages/reader/src/allure1/index.ts
@@ -51,11 +51,12 @@ const arrayTags: Set<string> = new Set([
   "test-suite.labels.label",
   "test-suite.test-cases.test-case",
   "test-suite.test-cases.test-case.labels.label",
-  "test-suite.test-cases.test-case.attachments.attachment",
   "test-suite.test-cases.test-case.parameters.parameter",
-  "test-suite.test-cases.test-case.steps.step.attachments.attachment",
 ]);
-const arrayTagPatterns = [/^test-suite\.test-cases\.test-case(\.steps\.step)+$/];
+const arrayTagPatterns = [
+  /^test-suite\.test-cases\.test-case(?:\.steps\.step)+$/,
+  /^test-suite\.test-cases\.test-case(?:\.steps\.step)*\.attachments\.attachment$/,
+];
 
 const xmlParser = new XMLParser({
   parseTagValue: false,

--- a/packages/reader/src/allure1/index.ts
+++ b/packages/reader/src/allure1/index.ts
@@ -47,16 +47,7 @@ const RESERVER_LABEL_NAMES = new Set<string>([
   STATUS_DETAILS_LABEL_NAME,
 ]);
 
-const arrayTags: Set<string> = new Set([
-  "test-suite.labels.label",
-  "test-suite.test-cases.test-case",
-  "test-suite.test-cases.test-case.labels.label",
-  "test-suite.test-cases.test-case.parameters.parameter",
-]);
-const arrayTagPatterns = [
-  /^test-suite\.test-cases\.test-case(?:\.steps\.step)+$/,
-  /^test-suite\.test-cases\.test-case(?:\.steps\.step)*\.attachments\.attachment$/,
-];
+const arrayTags: Set<string> = new Set(["attachment", "label", "parameter", "step", "test-case"]);
 
 const xmlParser = new XMLParser({
   parseTagValue: false,
@@ -64,7 +55,7 @@ const xmlParser = new XMLParser({
   attributeNamePrefix: "",
   removeNSPrefix: true,
   allowBooleanAttributes: true,
-  isArray: (tagName, jPath) => arrayTags.has(jPath) || arrayTagPatterns.some((p) => p.test(jPath)),
+  isArray: arrayTags.has.bind(arrayTags),
 });
 
 const readerId = "allure1";

--- a/packages/reader/src/allure1/index.ts
+++ b/packages/reader/src/allure1/index.ts
@@ -51,11 +51,11 @@ const arrayTags: Set<string> = new Set([
   "test-suite.labels.label",
   "test-suite.test-cases.test-case",
   "test-suite.test-cases.test-case.labels.label",
-  "test-suite.test-cases.test-case.steps.step",
   "test-suite.test-cases.test-case.attachments.attachment",
   "test-suite.test-cases.test-case.parameters.parameter",
   "test-suite.test-cases.test-case.steps.step.attachments.attachment",
 ]);
+const arrayTagPatterns = [/^test-suite\.test-cases\.test-case(\.steps\.step)+$/];
 
 const xmlParser = new XMLParser({
   parseTagValue: false,
@@ -63,7 +63,7 @@ const xmlParser = new XMLParser({
   attributeNamePrefix: "",
   removeNSPrefix: true,
   allowBooleanAttributes: true,
-  isArray: (tagName, jPath) => arrayTags.has(jPath),
+  isArray: (tagName, jPath) => arrayTags.has(jPath) || arrayTagPatterns.some((p) => p.test(jPath)),
 });
 
 const readerId = "allure1";

--- a/packages/reader/test/allure1.test.ts
+++ b/packages/reader/test/allure1.test.ts
@@ -1452,6 +1452,19 @@ describe("allure1 reader", () => {
       ]);
     });
 
+    it("should parse one nested step", async () => {
+      const visitor = await readResults(allure1, {
+        "allure1data/steps/oneNestedStep.xml": randomTestsuiteFileName(),
+      });
+
+      expect(visitor.visitTestResult).toHaveBeenCalledTimes(1);
+
+      const trs = visitor.visitTestResult.mock.calls.map((c) => c[0]);
+      const tr = trs[0];
+
+      expect(tr.steps).toMatchObject([{ steps: [expect.anything()] }]);
+    });
+
     it("should ignore an invalid steps collection", async () => {
       const visitor = await readResults(allure1, {
         "allure1data/steps/collectionInvalid.xml": randomTestsuiteFileName(),

--- a/packages/reader/test/allure1.test.ts
+++ b/packages/reader/test/allure1.test.ts
@@ -1792,6 +1792,15 @@ describe("allure1 reader", () => {
         });
       });
 
+      it("should parse a single attachment of a nested step", async () => {
+        const visitor = await readResults(allure1, {
+          "allure1data/steps/attachments/oneAttachmentInNestedStep.xml": randomTestsuiteFileName(),
+        });
+
+        expect(visitor.visitTestResult).toHaveBeenCalledTimes(1);
+        expect(visitor.visitTestResult.mock.calls[0][0]).toMatchObject({ steps: [{ steps: [{ steps: [expect.anything()] }] }] });
+      });
+
       it("should ignore a missing title", async () => {
         const visitor = await readResults(allure1, {
           "allure1data/steps/attachments/titleMissing.xml": randomTestsuiteFileName(),

--- a/packages/reader/test/resources/allure1data/steps/attachments/oneAttachmentInNestedStep.xml
+++ b/packages/reader/test/resources/allure1data/steps/attachments/oneAttachmentInNestedStep.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<test-suite xmlns="urn:model.allure.qatools.yandex.ru">
+    <test-cases>
+        <test-case>
+            <steps>
+                <step>
+                    <steps>
+                        <step>
+                            <attachments>
+                                <attachment title="foo" source="bar" type="text/plain"/>
+                            </attachments>
+                        </step>
+                    </steps>
+                </step>
+            </steps>
+        </test-case>
+    </test-cases>
+</test-suite>

--- a/packages/reader/test/resources/allure1data/steps/oneNestedStep.xml
+++ b/packages/reader/test/resources/allure1data/steps/oneNestedStep.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<test-suite xmlns="urn:model.allure.qatools.yandex.ru">
+    <test-cases>
+        <test-case>
+            <steps>
+                <step>
+                    <steps>
+                        <step>
+                            <title>foo</title>
+                        </step>
+                    </steps>
+                </step>
+            </steps>
+        </test-case>
+    </test-cases>
+</test-suite>


### PR DESCRIPTION
The PR fixes the following issues with the allure1 reader:

  - A single nested step is ignored
  - A single attachment of a nested step is ignored

The reason is the insufficient check performed by the `isArray` callback of `XMLParser`. Since steps may nest arbitrarily, a set of fixed array element paths is insufficient. The PR adds an extra check with regular expressions.