### PR TITLE
fix: production dependency xss is declared as dev only

### DIFF
--- a/packages/web-commons/package.json
+++ b/packages/web-commons/package.json
@@ -23,7 +23,8 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@allurereport/core-api": "workspace:*"
+    "@allurereport/core-api": "workspace:*",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^2.6.1",
@@ -43,7 +44,6 @@
     "rimraf": "^6.0.1",
     "tslib": "^2.7.0",
     "typescript": "^5.6.3",
-    "vitest": "^2.1.8",
-    "xss": "^1.0.15"
+    "vitest": "^2.1.8"
   }
 }


### PR DESCRIPTION
`web-commons` depends on `xss` in its production code (in `sanitizeHtml.ts`) but lists it in `devDependencies`. The code, therefore, works in a development environment but fails to find `xss` on a user's machine (unless `xss` is installed manually).

Fixes #57