### PR TITLE
fix(awesome): don't show empty groups when using tree filters

### DIFF
--- a/packages/core-api/src/constants.ts
+++ b/packages/core-api/src/constants.ts
@@ -21,7 +21,15 @@ export const filterIncludedInSuccessRate = filterByStatus(includedInSuccessRate)
 
 export const emptyStatistic: () => Statistic = () => ({ total: 0 });
 
-export const incrementStatistic = (statistic: Statistic, status: TestStatus) => {
-  statistic[status] = (statistic[status] ?? 0) + 1;
-  statistic.total++;
+export const incrementStatistic = (statistic: Statistic, status: TestStatus, count: number = 1) => {
+  statistic[status] = (statistic[status] ?? 0) + count;
+  statistic.total += count;
+};
+
+export const mergeStatistic = (statistic: Statistic, additional: Statistic) => {
+  statusesList.forEach((status) => {
+    if (additional[status]) {
+      incrementStatistic(statistic, status, additional[status]);
+    }
+  });
 };

--- a/packages/core-api/src/utils/comparator.ts
+++ b/packages/core-api/src/utils/comparator.ts
@@ -17,11 +17,24 @@ export const nullsLast = <T extends {}>(compare: Comparator<T>): Comparator<T | 
     a === b ? 0 : a === undefined || a === null ? 1 : b === undefined || b === null ? -1 : compare(a, b);
 };
 
+export const nullsFirst = <T extends {}>(compare: Comparator<T>): Comparator<T | undefined> => {
+  return (a, b) =>
+    a === b ? 0 : a === undefined || a === null ? -1 : b === undefined || b === null ? 1 : compare(a, b);
+};
+
+export const nullsDefault = <T extends {}>(compare: Comparator<T>, defaultValue: T): Comparator<T | undefined> => {
+  return (a, b) => compare(a ?? defaultValue, b ?? defaultValue);
+};
+
 export const compareBy = <T extends Record<string, any> = {}, P extends keyof T = keyof T>(
   property: P,
   compare: Comparator<Value<T, P>>,
+  defaultValue?: T[P],
 ): Comparator<T> => {
   return nullsLast((a, b) => {
+    if (defaultValue !== undefined) {
+      return compare(a[property] ?? defaultValue, b[property] ?? defaultValue);
+    }
     if (property in a && property in b) {
       return compare(a[property], b[property]);
     }
@@ -50,7 +63,7 @@ export const byStatus: SortFunction<TestStatus | undefined> = () => {
   });
 };
 export const byStatistic: SortFunction<Statistic | undefined> = () => {
-  const compares = statusesList.map((status) => compareBy<Statistic>(status, reverse(ordinal())));
+  const compares = statusesList.map((status) => compareBy<Statistic>(status, reverse(ordinal()), 0));
   return nullsLast(andThen(compares));
 };
 

--- a/packages/core-api/test/utils/comparator.test.ts
+++ b/packages/core-api/test/utils/comparator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Statistic, TestStatus } from "../../src/index.js";
+import { nullsDefault, nullsFirst, nullsLast } from "../../src/index.js";
 import { alphabetically, byName, byStatistic, byStatus, ordinal } from "../../src/index.js";
 
 const randomInt = (max: number = 1000): number => {
@@ -7,11 +8,11 @@ const randomInt = (max: number = 1000): number => {
 };
 
 const randomIntOrUndefined = (max: number = 1000): number | undefined => {
-  const number = randomInt(3);
-  if (number === 0) {
+  const rnd = randomInt(3);
+  if (rnd === 0) {
     return undefined;
   }
-  if (number === 1) {
+  if (rnd === 1) {
     return 0;
   }
   return randomInt(max);
@@ -70,6 +71,27 @@ describe("comparator", () => {
     it("should sort undefined last", () => {
       const result = [123, 43, 155, undefined as unknown as number, 24].sort(ordinal());
       expect(result).toEqual([24, 43, 123, 155, undefined]);
+    });
+  });
+
+  describe("nullsLast", () => {
+    it("should sort undefined last", () => {
+      const result = [123, 43, 155, null as unknown as number, 24].sort(nullsLast<number>((a, b) => a - b));
+      expect(result).toEqual([24, 43, 123, 155, null]);
+    });
+  });
+
+  describe("nullsFirst", () => {
+    it("should sort undefined first", () => {
+      const result = [123, 43, 155, null as unknown as number, 24].sort(nullsFirst<number>((a, b) => a - b));
+      expect(result).toEqual([null, 24, 43, 123, 155]);
+    });
+  });
+
+  describe("nullsDefault", () => {
+    it("should sort undefined with specified default value correctly", () => {
+      const result = [123, 43, 155, null as unknown as number, 24].sort(nullsDefault<number>((a, b) => a - b, 50));
+      expect(result).toEqual([24, 43, null, 123, 155]);
     });
   });
 
@@ -267,6 +289,20 @@ describe("comparator", () => {
       };
       const result = [statistic1, undefined as any as Statistic, statistic3, statistic2].sort(byStatistic());
       expect(result).toEqual([statistic3, statistic1, statistic2, undefined]);
+    });
+
+    it("should compare undefined with zero", () => {
+      const statistic1: Statistic = {
+        failed: 0,
+        passed: 3,
+        total: randomInt(),
+      };
+      const statistic2: Statistic = {
+        broken: 12,
+        total: randomInt(),
+      };
+      const result = [statistic1, statistic1, statistic2].sort(byStatistic());
+      expect(result).toEqual([statistic2, statistic1, statistic1]);
     });
   });
 });


### PR DESCRIPTION
Additionaly improves tree sorting