### PR TITLE
fix: CodeQL - polynomial regular expression on uncontrolled user data

### DIFF
--- a/packages/reader/src/allure2/index.ts
+++ b/packages/reader/src/allure2/index.ts
@@ -48,7 +48,7 @@ export const allure2: ResultsReader = {
   read: async (visitor, data) => {
     // this is essential in case we need to attach valid result files
     // e.g. like in allure2.test.ts
-    if (data.getOriginalFileName().match(/.*-attachment(\..+)?/)) {
+    if (data.getOriginalFileName().match(/-attachment(?:\..+)?/)) {
       await visitor.visitAttachmentFile(data, { readerId });
       return true;
     }


### PR DESCRIPTION
The CodeQL check result:

https://github.com/allure-framework/allure3/security/code-scanning/4

The error was first reported in #100, but it has existed in the repo for quite a long.

The RE in question is `/.*-attachment(\..+)?/`. Here are some timings for a string of `N` repetitions of character `'a'`:

|N|ms|
|--|--|
|1000|2|
|10000|79|
|50000|1143|
|100000|4504|
|150000|10283|

The issue is that the RE starts with the `.*` sub-pattern. It forces the engine to utilize backtracking, which leads to polynomial complexity in many negative cases.

Removing leading `.*` makes the pattern bound at the beginning. The complexity becomes linear, while the result of `String.prototype.match` remains the same (it matches a substring anyway).

Additionally, the PR makes the `(\..+)` group a non-capturing (the capture result is not used).