### PR TITLE
fix(reader-api): remove utf-8 decoding from BufferResultFile

### DIFF
--- a/packages/reader-api/src/resultFile.ts
+++ b/packages/reader-api/src/resultFile.ts
@@ -99,7 +99,7 @@ export class BufferResultFile extends BaseResultFile {
   }
 
   protected getContent(): ReadStream {
-    return ReadStream.from(this.buffer, { encoding: "utf8" }) as ReadStream;
+    return ReadStream.from(this.buffer) as ReadStream;
   }
 
   protected readMagicHeader(): Uint8Array {

--- a/packages/reader-api/test/resultFile.test.ts
+++ b/packages/reader-api/test/resultFile.test.ts
@@ -38,6 +38,15 @@ describe("BufferResultFile", () => {
     const result = resultFile.getExtension();
     expect(result).toEqual(".mp4");
   });
+
+  it("should return the same bytes when read as buffer", async () => {
+    const inputBuffer = await readResource("sample.png");
+    const resultFile = new BufferResultFile(inputBuffer, "sample.png");
+
+    const outputBuffer = await resultFile.asBuffer();
+
+    expect(outputBuffer?.equals(inputBuffer)).toBeTruthy();
+  });
 });
 
 describe("PathResultFile", () => {


### PR DESCRIPTION
`BufferResultFile`'s `getContent` creates a textual stream from the underlying buffer. In case of binary files, the resulting byte sequence may differ from the original one, which makes the file corrupted.

We use `BufferResultFile` in tests and in the following readers:

  - `cucumberjson` - to attach embeddings
  - `junitxml` - to attach stdout/stderr
  - `xcresult` - for all attachments (subject to change, see #112)

Since `junitxml` only adds text attachments via `BufferResultFile`, it's not affected by the bug. Other readers will attach corrupt binary files (e.g., screenshots that can't be viewed, etc).

The PR removes the decoding from the `ReadStream.from` call. Hence, `asBuffer` will return the original content of the underlying buffer. Calling `asUtf8String` on the other hand will apply the `utf-8` decoding on top of it.