### PR TITLE
fix(core): step attachments can't be accessed from the test body area

### DIFF
--- a/packages/core/src/store/convert.ts
+++ b/packages/core/src/store/convert.ts
@@ -277,7 +277,7 @@ const convertStep = (
       stepId: md5(`${step.name}${step.start}`),
       name: step.name ?? __unknown,
       status: step.status ?? defaultStatus,
-      steps: convertSteps(stateData, step.steps),
+      steps: subSteps,
       parameters: convertParameters(step.parameters),
       ...processTimings(step),
       type: "step",

--- a/packages/core/test/store/convert.test.ts
+++ b/packages/core/test/store/convert.test.ts
@@ -1,5 +1,5 @@
 import { md5 } from "@allurereport/plugin-api";
-import { attachment, step } from "allure-js-commons";
+import { attachment, issue, step } from "allure-js-commons";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateData } from "../../src/store/convert.js";
 import { testResultRawToState } from "../../src/store/convert.js";
@@ -183,6 +183,7 @@ describe("testResultRawToState", () => {
 
   describe("a converted step attachment", () => {
     it("should match a visited link", async () => {
+      await issue("171");
       const visitAttachmentLink = vi.fn<StateData["visitAttachmentLink"]>();
 
       const result = await functionUnderTest(

--- a/packages/core/test/store/convert.test.ts
+++ b/packages/core/test/store/convert.test.ts
@@ -1,6 +1,6 @@
 import { md5 } from "@allurereport/plugin-api";
 import { attachment, step } from "allure-js-commons";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateData } from "../../src/store/convert.js";
 import { testResultRawToState } from "../../src/store/convert.js";
 
@@ -178,6 +178,31 @@ describe("testResultRawToState", () => {
         originalFileName: "some-file.txt",
         ext: ".txt",
       },
+    });
+  });
+
+  describe("a converted step attachment", () => {
+    it("should match a visited link", async () => {
+      const visitAttachmentLink = vi.fn<StateData["visitAttachmentLink"]>();
+
+      const result = await functionUnderTest(
+        { ...emptyStateData, visitAttachmentLink },
+        { steps: [{ type: "step", steps: [{ type: "attachment", originalFileName: "some-file.txt" }] }] },
+        { readerId },
+      );
+
+      const { id } = visitAttachmentLink.mock.calls[0][0];
+      expect(result.steps).toMatchObject([
+        {
+          type: "step",
+          steps: [
+            {
+              type: "attachment",
+              link: { id },
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -11,7 +11,16 @@ export default defineConfig({
       "default",
       [
         "allure-vitest/reporter",
-        { resultsDir: "./out/allure-results", globalLabels: [{ name: "module", value: "core" }] },
+        {
+          resultsDir: "./out/allure-results",
+          globalLabels: [{ name: "module", value: "core" }],
+          links: {
+            issue: {
+              urlTemplate: "https://github.com/allure-framework/allure3/issues/%s",
+              nameTemplate: "Issue %s",
+            },
+          },
+        },
       ],
     ],
   },


### PR DESCRIPTION
#149 breaks step-level attachments: they are processed twice in the store, which leads to new IDs being generated for the second pass.

Since the aggregation of attachments for the `Attachments` tab happens once, at the first processing, the links on this tab work correctly with all attachments available. The links in the test body, on the other hand, get invalid IDs; hence, URLs point to non-existent files.

#### Extra changes

  - Set issue template for `core`; link a new test to the issue.

Fixes #171