### PR TITLE
fix(core, awesome): remove duplicated step details

### DIFF
--- a/packages/core/test/store/convert.test.ts
+++ b/packages/core/test/store/convert.test.ts
@@ -206,4 +206,88 @@ describe("testResultRawToState", () => {
       ]);
     });
   });
+
+  describe("a converted step", () => {
+    it("should mark the message if it's contained in a sub-step", async () => {
+      const result = await functionUnderTest(
+        emptyStateData,
+        {
+          steps: [
+            {
+              type: "step",
+              message: "Lorem Ipsum",
+              trace: "foo",
+              steps: [
+                {
+                  type: "step",
+                  message: "Lorem Ipsum",
+                  trace: "bar",
+                  steps: [
+                    {
+                      type: "step",
+                      message: "Lorem Ipsum",
+                      trace: "baz",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { readerId },
+      );
+      expect(result.steps).toMatchObject([
+        {
+          hasSimilarErrorInSubSteps: true,
+          steps: [
+            {
+              hasSimilarErrorInSubSteps: true,
+              steps: [{ hasSimilarErrorInSubSteps: false }],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("should not mark the message if it isn't contained in a sub-step", async () => {
+      const result = await functionUnderTest(
+        emptyStateData,
+        {
+          steps: [
+            {
+              type: "step",
+              message: "Lorem Ipsum 1",
+              trace: "foo",
+              steps: [
+                {
+                  type: "step",
+                  message: "Lorem Ipsum 2",
+                  trace: "bar",
+                  steps: [
+                    {
+                      type: "step",
+                      message: "Lorem Ipsum 3",
+                      trace: "baz",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { readerId },
+      );
+      expect(result.steps).toMatchObject([
+        {
+          hasSimilarErrorInSubSteps: false,
+          steps: [
+            {
+              hasSimilarErrorInSubSteps: false,
+              steps: [{ hasSimilarErrorInSubSteps: false }],
+            },
+          ],
+        },
+      ]);
+    });
+  });
 });

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     {
       name: "safari",
       use: { ...devices["Desktop Safari"] },
-    }
+    },
   ],
   reporter: [
     ["line"],
@@ -22,9 +22,13 @@ export default defineConfig({
       "allure-playwright",
       {
         resultsDir: "./out/allure-results",
-        globalLabels: [
-          { name: "module", value: "e2e" },
-        ],
+        globalLabels: [{ name: "module", value: "e2e" }],
+        links: {
+          issue: {
+            urlTemplate: "https://github.com/allure-framework/allure3/issues/%s",
+            nameTemplate: "Issue #%s",
+          },
+        },
       },
     ],
   ],

--- a/packages/e2e/test/allure-awesome/test/environments.test.ts
+++ b/packages/e2e/test/allure-awesome/test/environments.test.ts
@@ -1,12 +1,11 @@
 import { type Page, expect, test } from "@playwright/test";
 import { Stage, Status, label } from "allure-js-commons";
-import { CommonPage, TestResultPage, TreePage } from "../../pageObjects/index.js";
+import { CommonPage, TreePage } from "../../pageObjects/index.js";
 import { type ReportBootstrap, bootstrapReport } from "../utils/index.js";
 
 let bootstrap: ReportBootstrap;
 let commonPage: CommonPage;
 let treePage: TreePage;
-let testResultPage: TestResultPage;
 
 const now = Date.now();
 const fixtures = {
@@ -86,7 +85,6 @@ test.beforeEach(async ({ page, browserName }) => {
 
   commonPage = new CommonPage(page);
   treePage = new TreePage(page);
-  testResultPage = new TestResultPage(page);
 
   bootstrap = await bootstrapReport({
     reportConfig: {

--- a/packages/e2e/test/allure-awesome/test/steps.test.ts
+++ b/packages/e2e/test/allure-awesome/test/steps.test.ts
@@ -1,0 +1,157 @@
+import { Stage, Status, label } from "allure-js-commons";
+import { TestResultPage, TreePage } from "../../pageObjects/index.js";
+import { expect, test } from "../../playwright.js";
+import { type ReportBootstrap, bootstrapReport } from "../utils/index.js";
+
+let bootstrap: ReportBootstrap;
+let treePage: TreePage;
+let testResultPage: TestResultPage;
+
+const now = Date.now();
+const fixtures = {
+  testResults: [
+    {
+      name: "0 sample passed test",
+      fullName: "foo",
+      historyId: "foo",
+      testCaseId: "foo",
+      status: Status.FAILED,
+      stage: Stage.FINISHED,
+      start: now,
+      stop: now + 1000,
+      steps: [
+        {
+          type: "step",
+          name: "level 1 step with bubbled error",
+          status: Status.FAILED,
+          stage: Stage.FINISHED,
+          start: now + 100,
+          stop: now + 200,
+          statusDetails: { message: "Lorem ipsum", trace: "dolor sit amet" },
+          attachments: [],
+          parameters: [],
+          steps: [
+            {
+              type: "step",
+              name: "level 2 step with bubbled error",
+              status: Status.FAILED,
+              stage: Stage.FINISHED,
+              start: now + 110,
+              stop: now + 190,
+              statusDetails: { message: "Lorem ipsum", trace: "dolor sit amet" },
+              attachments: [],
+              parameters: [],
+              steps: [
+                {
+                  type: "step",
+                  name: "level 3 step with bubbled error",
+                  status: Status.FAILED,
+                  stage: Stage.FINISHED,
+                  start: now + 120,
+                  stop: now + 180,
+                  statusDetails: { message: "Lorem ipsum", trace: "dolor sit amet" },
+                  attachments: [],
+                  parameters: [],
+                  steps: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "step",
+          name: "level 1 step with unique error",
+          status: Status.FAILED,
+          stage: Stage.FINISHED,
+          start: now + 300,
+          stop: now + 400,
+          statusDetails: { message: "Lorem ipsum", trace: "dolor sit amet" },
+          attachments: [],
+          parameters: [],
+          steps: [
+            {
+              type: "step",
+              name: "level 2 step with unique error",
+              status: Status.FAILED,
+              stage: Stage.FINISHED,
+              start: now + 310,
+              stop: now + 390,
+              statusDetails: { message: "consectetur adipiscing elit", trace: "sed do eiusmod tempor" },
+              attachments: [],
+              parameters: [],
+              steps: [
+                {
+                  type: "step",
+                  name: "level 3 step with unique error",
+                  status: Status.FAILED,
+                  stage: Stage.FINISHED,
+                  start: now + 320,
+                  stop: now + 380,
+                  statusDetails: { message: "incididunt ut labore", trace: "et dolore magna aliqua" },
+                  attachments: [],
+                  parameters: [],
+                  steps: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+test.describe("Steps in Allure Awesome", () => {
+  test.beforeEach(async ({ page, browserName }) => {
+    await label("env", browserName);
+
+    treePage = new TreePage(page);
+    testResultPage = new TestResultPage(page);
+
+    bootstrap = await bootstrapReport({
+      reportConfig: {
+        name: "Sample allure report",
+        appendHistory: false,
+        knownIssuesPath: undefined,
+      },
+      testResults: fixtures.testResults,
+    });
+
+    await page.goto(bootstrap.url);
+    await treePage.clickNthLeaf(0);
+  });
+
+  test(
+    "the same error is only rendered at the leaf level",
+    { annotation: [{ type: "issue", description: "201" }] },
+    async () => {
+      const level1Step = testResultPage.getStepByName("level 1 step with bubbled error");
+      const level2Step = level1Step.getSubstepByName("level 2 step with bubbled error");
+      const level3Step = level2Step.getSubstepByName("level 3 step with bubbled error");
+
+      await level3Step.toggleDetails();
+
+      await level1Step.attachScreenshot("Steps.png");
+
+      expect(await level1Step.hasDetails()).toBeFalsy();
+      expect(await level2Step.hasDetails()).toBeFalsy();
+      await expect(level3Step).toHaveDetails("Lorem ipsum", "dolor sit amet");
+    },
+  );
+
+  test("unique errors are always rendered", async () => {
+    const level1Step = testResultPage.getStepByName("level 1 step with unique error");
+    const level2Step = level1Step.getSubstepByName("level 2 step with unique error");
+    const level3Step = level2Step.getSubstepByName("level 3 step with unique error");
+
+    await level1Step.toggleDetails();
+    await level2Step.toggleDetails();
+    await level3Step.toggleDetails();
+
+    await level1Step.attachScreenshot("Steps.png");
+
+    await expect(level1Step).toHaveDetails("Lorem ipsum", "dolor sit amet");
+    await expect(level2Step).toHaveDetails("consectetur adipiscing elit", "sed do eiusmod tempor");
+    await expect(level3Step).toHaveDetails("incididunt ut labore", "et dolore magna aliqua");
+  });
+});

--- a/packages/e2e/test/pageObjects/StepResult.ts
+++ b/packages/e2e/test/pageObjects/StepResult.ts
@@ -1,0 +1,108 @@
+import type { Locator } from "@playwright/test";
+import type { TestResultPage } from "./TestResult.js";
+import { PageObject } from "./pageObject.js";
+
+/**
+ * A test fixture to validate test steps.
+ */
+export class StepResultFixture extends PageObject {
+  /**
+   * A locator for the step result.
+   */
+  readonly locator = (this.parent?.substepsLocator ?? this.testResultPage.stepLocator)
+    .filter({ has: this.page.getByText(this.stepName, { exact: true }) })
+    .last();
+
+  /**
+   * A locator for the content of the step. The step's content is visible if and only if the step exists and is
+   * expanded.
+   */
+  readonly contentLocator = this.locator.getByTestId("test-result-step-content").first();
+
+  /**
+   * A locator for the sub-steps of the step. The step's sub-steps are visible if and only if the step exists,
+   * is expanded, and has at least one sub-step.
+   */
+  readonly substepsLocator: Locator = this.locator.getByTestId("test-result-step");
+
+  #allStepDetailsLocator = this.locator.getByTestId("test-result-error");
+  #substepDetailsLocator = this.substepsLocator.getByTestId("test-result-error");
+
+  /**
+   * A locator for the step's details. The step's details are visible if and only if the step exists, is expanded,
+   * and has details.
+   *
+   * WARNING: make sure `hasDetails` returns `true` before using this locator. Otherwise, it may point to a sub-step's
+   * details.
+   */
+  readonly stepDetailsLocator = this.#allStepDetailsLocator.first();
+
+  /**
+   * A locator for the step's message. The step's message is visible if and only if the step exists, is expanded, and
+   * has details.
+   *
+   * WARNING: make sure `hasDetails` returns `true` before using this locator. Otherwise, it may point to a sub-step's
+   * message.
+   */
+  readonly stepMessageLocator = this.stepDetailsLocator.getByTestId("test-result-error-message");
+
+  /**
+   * A locator for the step's trace. The step's trace is visible if and only if the step exists, is expanded, has
+   * details with a trace defined, and the details are expanded.
+   *
+   * WARNING: make sure `hasDetails` returns `true` before using this locator. Otherwise, it may point to a sub-step's
+   * trace.
+   */
+  readonly stepTraceLocator = this.stepDetailsLocator.getByTestId("test-result-error-trace");
+
+  constructor(
+    readonly testResultPage: TestResultPage,
+    readonly stepName: string,
+    readonly parent?: StepResultFixture,
+  ) {
+    super(testResultPage.page);
+  }
+
+  async screenshot() {
+    return await this.locator.screenshot();
+  }
+
+  /**
+   * Expands or collapses the step's sub-steps.
+   */
+  async toggleStep() {
+    await this.locator.getByTestId("test-result-step-arrow-button").click();
+  }
+
+  /**
+   * Expands or collapses the step's trace.
+   */
+  async toggleDetails() {
+    if (await this.hasDetails()) {
+      await this.stepMessageLocator.click();
+    }
+  }
+
+  /**
+   * Checks if the step has details.
+   *
+   * WARNING: make sure the step is expanded before calling this method.
+   *
+   * @returns `true` if the step is visible, has status details and is expanded, `false` otherwise.
+   */
+  async hasDetails() {
+    await this.contentLocator.waitFor();
+    return (await this.#allStepDetailsLocator.count()) === (await this.#substepDetailsLocator.count()) + 1;
+  }
+
+  /**
+   * Returns a fixture for a sub-step of the current step.
+   *
+   * HINT: make sure the step is expanded before accessing the sub-step.
+   *
+   * @param name The name of the sub-step to get.
+   */
+  getSubstepByName(name: string) {
+    return new StepResultFixture(this.testResultPage, name, this);
+  }
+}

--- a/packages/e2e/test/pageObjects/TestResult.ts
+++ b/packages/e2e/test/pageObjects/TestResult.ts
@@ -1,5 +1,6 @@
 import { type Locator, type Page } from "@playwright/test";
 import { CommonPage } from "./Common.js";
+import { StepResultFixture } from "./StepResult.js";
 
 export class TestResultPage extends CommonPage {
   titleLocator: Locator;
@@ -76,6 +77,13 @@ export class TestResultPage extends CommonPage {
 
   tabById(id: string) {
     return this.page.getByTestId(`test-result-tab-${id}`);
+  }
+
+  /**
+   * Returns a fixture for a top-level step of the current test.
+   */
+  getStepByName(stepName: string) {
+    return new StepResultFixture(this, stepName);
   }
 
   get envTabLocator() {

--- a/packages/e2e/test/pageObjects/TestResult.ts
+++ b/packages/e2e/test/pageObjects/TestResult.ts
@@ -1,7 +1,7 @@
 import { type Locator, type Page } from "@playwright/test";
-import { PageObject } from "./pageObject.js";
+import { CommonPage } from "./Common.js";
 
-export class TestResultPage extends PageObject {
+export class TestResultPage extends CommonPage {
   titleLocator: Locator;
   fullnameLocator: Locator;
   fullnameCopyLocator: Locator;
@@ -34,7 +34,7 @@ export class TestResultPage extends PageObject {
   videoAttachmentContentLocator: Locator;
 
   historyItemLocator: Locator;
-  prevStatusLocator: Locator;0
+  prevStatusLocator: Locator;
 
   constructor(readonly page: Page) {
     super(page);

--- a/packages/e2e/test/pageObjects/Tree.ts
+++ b/packages/e2e/test/pageObjects/Tree.ts
@@ -1,8 +1,8 @@
 import { type Locator, type Page } from "@playwright/test";
 import { randomNumber } from "../utils/index.js";
-import { PageObject } from "./pageObject.js";
+import { CommonPage } from "./Common.js";
 
-export class TreePage extends PageObject {
+export class TreePage extends CommonPage {
   leafLocator: Locator;
 
   leafStatusPassedLocator: Locator;

--- a/packages/e2e/test/pageObjects/pageObject.ts
+++ b/packages/e2e/test/pageObjects/pageObject.ts
@@ -4,11 +4,13 @@ import { attachment } from "allure-js-commons";
 export class PageObject {
   constructor(readonly page: Page) {}
 
-  async screenshot(name: string = "screenshot") {
-    const screenshot = await this.page.screenshot({
+  async screenshot() {
+    return await this.page.screenshot({
       fullPage: true,
     });
+  }
 
-    await attachment(name, screenshot, "image/png");
+  async attachScreenshot(name: string = "screenshot") {
+    await attachment(name, await this.screenshot(), "image/png");
   }
 }

--- a/packages/e2e/test/playwright.ts
+++ b/packages/e2e/test/playwright.ts
@@ -1,0 +1,63 @@
+import { expect as baseExpect } from "@playwright/test";
+import type { StepResultFixture } from "./pageObjects/StepResult.js";
+
+export { test } from "@playwright/test";
+
+export const expect = baseExpect.extend({
+  async toHaveDetails(step: StepResultFixture, message: string | RegExp, trace?: string | RegExp) {
+    const assertionName = "toHaveDetails";
+    let pass: boolean;
+    let matcherResult: any;
+
+    let locator = step.stepMessageLocator;
+    let expectedValue = message;
+
+    if (await step.hasDetails()) {
+      try {
+        const expectation = this.isNot ? baseExpect(locator).not : baseExpect(locator);
+        await expectation.toHaveText(message);
+        pass = true;
+      } catch (e: any) {
+        matcherResult = e.matcherResult;
+        pass = false;
+      }
+    }
+
+    if (pass && typeof trace !== "undefined") {
+      locator = step.stepTraceLocator;
+      expectedValue = trace;
+      try {
+        const expectation = this.isNot ? baseExpect(locator).not : baseExpect(locator);
+        await expectation.toHaveText(expectedValue);
+        pass = true;
+      } catch (e: any) {
+        matcherResult = e.matcherResult;
+        pass = false;
+      }
+    }
+
+    if (this.isNot) {
+      pass = !pass;
+    }
+
+    const matcherHint = this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot });
+    const expected = this.utils.printExpected(expectedValue);
+    const received = matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : "";
+
+    /* eslint-disable @typescript-eslint/restrict-template-expressions */
+    /* eslint-disable @typescript-eslint/no-base-to-string */
+    const getErrorMessage = pass
+      ? () => `${matcherHint}\n\nLocator: ${locator}\nExpected: not ${expected}\n${received}`
+      : () => `${matcherHint}\n\nLocator: ${locator}\nExpected: ${expected}\n${received}`;
+    /* eslint-enable @typescript-eslint/no-base-to-string */
+    /* eslint-enable @typescript-eslint/restrict-template-expressions */
+
+    return {
+      message: getErrorMessage,
+      pass,
+      name: assertionName,
+      expected: expectedValue,
+      actual: matcherResult?.actual,
+    };
+  },
+});

--- a/packages/web-awesome/src/components/TestResult/TrSteps/TrStep.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/TrStep.tsx
@@ -26,7 +26,7 @@ export const TrStepsContent = (props: { item: DefaultTestStepResult }) => {
   return (
     <div data-testid={"test-result-step-content"} className={styles["test-result-step-content"]}>
       {Boolean(item?.parameters?.length) && <TrStepParameters parameters={item.parameters} />}
-      {Boolean(item?.message && item?.trace) && <TrError {...item} />}
+      {Boolean(item?.message && item?.trace && !item?.hasSimilarErrorInSubSteps) && <TrError {...item} />}
       {Boolean(item?.steps?.length) && (
         <>
           {item.steps?.map((subItem, key) => {


### PR DESCRIPTION
The PR removed a step's details from all parent steps. That only applies to details with identical messages. If the messages differ, all the details are retained.

The implementation is based on the `hasSimilarErrorInSubSteps` flag introduced in #149, but it makes the flag recursive, which fixes #201.

### E2E page objects refactoring

The idea behind the refactoring is to allow defining fixtures to check parts of pages, specifically, the steps of a test on the test result page. Here is the list of changes:

  - Split `screenshot` into `screenshot` and `attachScreenshot`. The former can be overridden to attach screenshots of specific elements.
  - Make `TreePage` and `TestResultPage` derive from `CommonPage` instead of `PageObject`.
  - Implement `StepResultFixture` to check steps. Currently, it only contains locators and methods to check status details. Other locators and methods can be added to verify parameters, attachments, etc. Use `TestResult.getStepByName` or `StepResultFixture.getSubstepByName` to create a fixture for a step.

    Use `StepResultFixture.attachScreenshot` to attach a screenshot of the step to Allure (the step must be visible in the report).

  - Implement a custom `toHaveDetails` [Playwright matcher](https://playwright.dev/docs/test-assertions#add-custom-matchers-using-expectextend). Example:

    ```js
    import { expect, test } from "../../playwright.js";
    
    /* ... */
    
    test("My step must have message and trace", async () => {
      const step = testResultPage.getStepByName("My step");
      await step.toggleDetails();
      await expect(step).toHaveDetails("Lorem ipsum", "dolor sit amet");
    });
    ```

    If an expected value is provided for the step's trace, make sure the step's details are expanded.

    We may add other matches in the future. If the module becomes too large, we may split it into separate modules and combine them into a single extension point as described [here](https://playwright.dev/docs/test-assertions#combine-custom-matchers-from-multiple-modules).

### Other changes

  - Define an issue template for `@allurereport/e2e`.
  - Remove an unused variable from `environments.test.ts`
  - Implement an e2e test for nested steps with details

Fixes #201
