### PR TITLE
fix(awesome): the "Retries" tab of a test result without start/stop timestamps breaks the report

### DIFF
--- a/packages/e2e/test/allure-awesome/features/retries.test.ts
+++ b/packages/e2e/test/allure-awesome/features/retries.test.ts
@@ -1,11 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { Stage, Status, label } from "allure-js-commons";
-import { TreePage } from "../../pageObjects/index.js";
+import { TestResultPage, TreePage } from "../../pageObjects/index.js";
 import { type ReportBootstrap, bootstrapReport } from "../utils/index.js";
 import { makeHistoryId, makeReportConfig, makeTestResultNames, makeTestResults } from "../utils/mocks.js";
-
-let bootstrap: ReportBootstrap;
-let treePage: TreePage;
 
 const reportName = "Sample allure report";
 
@@ -22,83 +19,184 @@ const { name: testWithoutRetriesName, fullName: testWithoutRetriesFullname } =
 const testWithoutRetriesHistoryId = makeHistoryId(testWithoutRetriesFullname);
 
 test.describe("retries", () => {
-  test.beforeAll(async () => {
-    const testResults = makeTestResults(6, (index) => {
-      if ([0, 1, 2].includes(index)) {
+  test.describe("tree", () => {
+    let bootstrap: ReportBootstrap;
+    let treePage: TreePage;
+    test.beforeAll(async () => {
+      const testResults = makeTestResults(6, (index) => {
+        if ([0, 1, 2].includes(index)) {
+          return {
+            name: firstTestWithRetries,
+            fullName: firstTestWithRetriesFullname,
+            historyId: firstTestWithRetriesHistoryId,
+            status: index % 2 === 0 ? Status.FAILED : Status.PASSED,
+            stage: Stage.FINISHED,
+          };
+        } else if ([3, 4].includes(index)) {
+          return {
+            name: secondTestWithRetriesName,
+            fullName: secondTestWithRetriesFullname,
+            historyId: secondTestWithRetriesHistoryId,
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          };
+        }
+
         return {
-          name: firstTestWithRetries,
-          fullName: firstTestWithRetriesFullname,
-          historyId: firstTestWithRetriesHistoryId,
-          status: index % 2 === 0 ? Status.FAILED : Status.PASSED,
-          stage: Stage.FINISHED,
-        };
-      } else if ([3, 4].includes(index)) {
-        return {
-          name: secondTestWithRetriesName,
-          fullName: secondTestWithRetriesFullname,
-          historyId: secondTestWithRetriesHistoryId,
+          name: testWithoutRetriesName,
+          fullName: testWithoutRetriesFullname,
+          historyId: testWithoutRetriesHistoryId,
           status: Status.PASSED,
           stage: Stage.FINISHED,
         };
-      }
+      });
 
-      return {
-        name: testWithoutRetriesName,
-        fullName: testWithoutRetriesFullname,
-        historyId: testWithoutRetriesHistoryId,
-        status: Status.PASSED,
-        stage: Stage.FINISHED,
-      };
+      bootstrap = await bootstrapReport({
+        reportConfig: makeReportConfig({
+          name: reportName,
+          appendHistory: false,
+        }),
+        testResults,
+      });
     });
 
-    bootstrap = await bootstrapReport({
-      reportConfig: makeReportConfig({
-        name: reportName,
-        appendHistory: false,
-      }),
-      testResults,
+    test.beforeEach(async ({ browserName, page }) => {
+      await label("env", browserName);
+
+      treePage = new TreePage(page);
+
+      await page.goto(bootstrap.url);
+    });
+
+    test.afterAll(async () => {
+      await bootstrap?.shutdown?.();
+    });
+
+    test("shows only tests with retries", async () => {
+      await expect(treePage.leafLocator).toHaveCount(3);
+      await treePage.toggleRetryFilter();
+      await expect(treePage.leafLocator).toHaveCount(2);
+      await treePage.toggleRetryFilter();
+      await expect(treePage.leafLocator).toHaveCount(3);
+    });
+
+    test("should show retry icon in the tree for tests with retries", async ({ page }) => {
+      const retryIcons = page.getByTestId("tree-leaf-retries");
+
+      await expect(retryIcons).toHaveCount(2);
+
+      const firstTestWithRetriesIcon = treePage.getLeafByTitle(firstTestWithRetries).getByTestId("tree-leaf-retries");
+      const anotherTestWithRetriesIcon = treePage
+        .getLeafByTitle(secondTestWithRetriesName)
+        .getByTestId("tree-leaf-retries");
+
+      await expect(firstTestWithRetriesIcon).toContainText("2");
+      await expect(anotherTestWithRetriesIcon).toContainText("1");
+    });
+
+    test("metadata shows correct count of retries", async () => {
+      const total = await treePage.getMetadataValue("total");
+      const retries = await treePage.getMetadataValue("retries");
+
+      expect(total).toBe("3");
+      expect(retries).toBe("2");
     });
   });
 
-  test.beforeEach(async ({ browserName, page }) => {
-    await label("env", browserName);
+  test.describe("test results", () => {
+    let bootstrap: ReportBootstrap;
+    let treePage: TreePage;
+    let testResultPage: TestResultPage;
+    test.beforeAll(async () => {
+      const now = Date.now();
 
-    treePage = new TreePage(page);
+      bootstrap = await bootstrapReport({
+        reportConfig: makeReportConfig({
+          name: reportName,
+          appendHistory: false,
+        }),
+        rawTestResults: [
+          {
+            name: "With timestamps",
+            fullName: "With timestamps",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+            start: now,
+            stop: now + 1000,
+          },
+          {
+            name: "With timestamps",
+            fullName: "With timestamps",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+            start: now + 1010,
+            stop: now + 2000,
+          },
+          {
+            name: "With timestamps",
+            fullName: "With timestamps",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+            start: now + 2010,
+            stop: now + 3000,
+          },
+          {
+            name: "Without timestamps",
+            fullName: "Without timestamps",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          },
+          {
+            name: "Without timestamps",
+            fullName: "Without timestamps",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          },
+          {
+            name: "Without timestamps",
+            fullName: "Without timestamps",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          },
+        ],
+      });
+    });
 
-    await page.goto(bootstrap.url);
-  });
+    test.beforeEach(async ({ page, browserName }) => {
+      await label("env", browserName);
 
-  test.afterAll(async () => {
-    await bootstrap?.shutdown?.();
-  });
+      treePage = new TreePage(page);
+      testResultPage = new TestResultPage(page);
 
-  test("shows only tests with retries", async () => {
-    await expect(treePage.leafLocator).toHaveCount(3);
-    await treePage.toggleRetryFilter();
-    await expect(treePage.leafLocator).toHaveCount(2);
-    await treePage.toggleRetryFilter();
-    await expect(treePage.leafLocator).toHaveCount(3);
-  });
+      await page.goto(bootstrap.url);
+    });
 
-  test("should show retry icon in the tree for tests with retries", async ({ page }) => {
-    const retryIcons = page.getByTestId("tree-leaf-retries");
+    test.afterAll(async () => {
+      await bootstrap.shutdown();
+    });
 
-    await expect(retryIcons).toHaveCount(2);
+    test.describe("titles", () => {
+      test("retry titles of tests with timestampts have prefixes and timestamps", async () => {
+        await treePage.clickLeafByTitle("With timestamps");
+        await testResultPage.tabById("retries").click();
 
-    const firstTestWithRetriesIcon = treePage.getLeafByTitle(firstTestWithRetries).getByTestId("tree-leaf-retries");
-    const anotherTestWithRetriesIcon = treePage
-      .getLeafByTitle(secondTestWithRetriesName)
-      .getByTestId("tree-leaf-retries");
+        const retryAt0 = testResultPage.getRetry(0);
+        const retryAt1 = testResultPage.getRetry(1);
 
-    await expect(firstTestWithRetriesIcon).toContainText("2");
-    await expect(anotherTestWithRetriesIcon).toContainText("1");
-  });
+        await expect(retryAt0.textLocator).toHaveText(/^Attempt 2 of 3 -- \d+\/\d+\/\d+ at \d+:\d+:\d+$/);
+        await expect(retryAt1.textLocator).toHaveText(/^Attempt 1 of 3 -- \d+\/\d+\/\d+ at \d+:\d+:\d+$/);
+      });
 
-  test("metadata shows correct count of retries", async () => {
-    const total = await treePage.getMetadataValue("total");
-    const retries = await treePage.getMetadataValue("retries");
+      test("retry titles of tests with no timestampts have prefixes", async () => {
+        await treePage.clickLeafByTitle("Without timestamps");
+        await testResultPage.tabById("retries").click();
 
-    expect(total).toBe("3");
-    expect(retries).toBe("2");
+        const retryAt0 = testResultPage.getRetry(0);
+        const retryAt1 = testResultPage.getRetry(1);
+
+        await expect(retryAt0.textLocator).toHaveText("Attempt 2 of 3");
+        await expect(retryAt1.textLocator).toHaveText("Attempt 1 of 3");
+      });
+    });
   });
 });

--- a/packages/e2e/test/pageObjects/RetryItem.ts
+++ b/packages/e2e/test/pageObjects/RetryItem.ts
@@ -1,0 +1,64 @@
+import type { TestResultPage } from "./TestResult.js";
+import { PageObject } from "./pageObject.js";
+
+/**
+ * A test fixture to validate retries.
+ */
+export class RetryItemFixture extends PageObject {
+  /**
+   * A locator for the retry item.
+   */
+  readonly locator = this.testResultPage.retriesItemLocator.nth(this.index);
+
+  /**
+   * A locator for the text of the retry item.
+   */
+  readonly textLocator = this.locator.getByTestId("test-result-retries-item-text");
+
+  /**
+   * A locator for the retry item's details.
+   */
+  readonly detailsLocator = this.locator.getByTestId("test-result-error");
+
+  /**
+   * A locator for the retry item's details message.
+   */
+  readonly messageLocator = this.detailsLocator.getByTestId("test-result-error-message");
+
+  /**
+   * A locator for the retry item's details trace.
+   */
+  readonly traceLocator = this.detailsLocator.getByTestId("test-result-error-trace");
+
+  constructor(
+    readonly testResultPage: TestResultPage,
+    readonly index: number,
+  ) {
+    super(testResultPage.page);
+  }
+
+  async screenshot() {
+    return await this.locator.screenshot();
+  }
+
+  /**
+   * Expands or collapses the retry item's details.
+   */
+  async toggleDetails() {
+    await this.locator.getByTestId("test-result-retries-item-arrow-button").click();
+  }
+
+  /**
+   * Expands or collapses the retry item's trace.
+   */
+  async toggleTrace() {
+    await this.messageLocator.click();
+  }
+
+  /**
+   * Opens a retry details page.
+   */
+  async openRetry() {
+    await this.locator.getByTestId("test-result-retries-item-open-button").click();
+  }
+}

--- a/packages/e2e/test/pageObjects/TestResult.ts
+++ b/packages/e2e/test/pageObjects/TestResult.ts
@@ -1,5 +1,6 @@
 import { type Locator, type Page } from "@playwright/test";
 import { CommonPage } from "./Common.js";
+import { RetryItemFixture } from "./RetryItem.js";
 import { StepResultFixture } from "./StepResult.js";
 
 export class TestResultPage extends CommonPage {
@@ -35,6 +36,7 @@ export class TestResultPage extends CommonPage {
   videoAttachmentContentLocator: Locator;
 
   historyItemLocator: Locator;
+  retriesItemLocator: Locator;
   prevStatusLocator: Locator;
 
   constructor(readonly page: Page) {
@@ -72,6 +74,7 @@ export class TestResultPage extends CommonPage {
     this.videoAttachmentContentLocator = page.getByTestId("video-attachment-content");
 
     this.historyItemLocator = page.getByTestId("test-result-history-item");
+    this.retriesItemLocator = page.getByTestId("test-result-retries-item");
     this.prevStatusLocator = page.getByTestId("test-result-prev-status");
   }
 
@@ -84,6 +87,16 @@ export class TestResultPage extends CommonPage {
    */
   getStepByName(stepName: string) {
     return new StepResultFixture(this, stepName);
+  }
+
+  /**
+   * Returns a fixture for a retry item at a specific index.
+   *
+   * NOTE: the retries are in the most recent first order, which means index 0 corresponds to the most recent retry in
+   * the list.
+   */
+  getRetry(index: number) {
+    return new RetryItemFixture(this, index);
   }
 
   get envTabLocator() {

--- a/packages/e2e/test/utils/index.ts
+++ b/packages/e2e/test/utils/index.ts
@@ -15,7 +15,8 @@ export type GeneratorParams = {
   rootDir: string;
   reportDir: string;
   resultsDir: string;
-  testResults: Partial<TestResult>[];
+  testResults?: Partial<TestResult>[];
+  rawTestResults?: Partial<TestResult>[];
   attachments?: { source: string; content: Buffer }[];
   reportConfig?: Omit<FullConfig, "output" | "reportFiles" | "historyPath">;
 };
@@ -36,7 +37,16 @@ export const randomNumber = (min: number, max: number): number => {
 };
 
 export const generateReport = async (payload: GeneratorParams) => {
-  const { reportConfig, rootDir, reportDir, resultsDir, testResults, attachments = [], history = [] } = payload;
+  const {
+    reportConfig,
+    rootDir,
+    reportDir,
+    resultsDir,
+    testResults = [],
+    rawTestResults = [],
+    attachments = [],
+    history = [],
+  } = payload;
 
   const hasHistory = history.length > 0;
   const historyPath = resolve(rootDir, `history-${randomUUID()}.jsonl`);
@@ -65,6 +75,10 @@ export const generateReport = async (payload: GeneratorParams) => {
   testResults.forEach((tr) => {
     runtime.writeTest(runtime.startTest(tr, [scopeUuid]));
   });
+
+  for (const tr of rawTestResults) {
+    await writeFile(resolve(resultsDir, `${randomUUID()}-result.json`), JSON.stringify(tr));
+  }
 
   for (const attachment of attachments) {
     await writeFile(resolve(resultsDir, attachment.source), attachment.content);

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
@@ -29,14 +29,20 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
   const navigateUrl = id;
 
   return (
-    <div>
+    <div data-testid="test-result-retries-item">
       <div className={styles["test-result-retries-item-header"]} onClick={() => setIsOpen(!isOpened)}>
         {Boolean(error.trace || error.message) && (
-          <ArrowButton isOpened={isOpened} icon={allureIcons.lineArrowsChevronDown} />
+          <ArrowButton
+            data-testid="test-result-retries-item-arrow-button"
+            isOpened={isOpened}
+            icon={allureIcons.lineArrowsChevronDown}
+          />
         )}
         <div className={styles["test-result-retries-item-wrap"]}>
           <TreeItemIcon status={status} className={styles["test-result-retries-item-status"]} />
-          <Text className={styles["test-result-retries-item-text"]}>{retryTitle}</Text>
+          <Text data-testid="test-result-retries-item-text" className={styles["test-result-retries-item-text"]}>
+            {retryTitle}
+          </Text>
           <div className={styles["test-result-retries-item-info"]}>
             {Boolean(formattedDuration) && (
               <Text type="ui" size={"s"} className={styles["item-time"]}>
@@ -48,6 +54,7 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
               style={"ghost"}
               size={"s"}
               className={styles["test-result-retries-item-link"]}
+              data-testid="test-result-retries-item-open-button"
               onClick={() => navigateTo(navigateUrl)}
             />
           </div>

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
@@ -5,15 +5,26 @@ import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 import { TrError } from "@/components/TestResult/TrError";
 import * as styles from "@/components/TestResult/TrRetriesView/styles.scss";
+import { useI18n } from "@/stores/locale";
 import { navigateTo } from "@/stores/router";
 import { timestampToDate } from "@/utils/time";
 
-export const TrRetriesItem: FunctionalComponent<{
+export type TrRetriesItemProps = {
   testResultItem: AwesomeTestResult;
-}> = ({ testResultItem }) => {
+  attempt: number;
+  totalAttempts: number;
+};
+
+export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testResultItem, attempt, totalAttempts }) => {
   const { id, status, error, stop, duration } = testResultItem;
   const [isOpened, setIsOpen] = useState(false);
-  const convertedStop = timestampToDate(stop);
+
+  const { t } = useI18n("ui");
+
+  const retryTitlePrefix = t("attempt", { attempt, total: totalAttempts });
+  const convertedStop = stop ? timestampToDate(stop) : undefined;
+  const retryTitle = convertedStop ? `${retryTitlePrefix} -- ${convertedStop}` : retryTitlePrefix;
+
   const formattedDuration = typeof duration === "number" ? formatDuration(duration) : undefined;
   const navigateUrl = id;
 
@@ -25,7 +36,7 @@ export const TrRetriesItem: FunctionalComponent<{
         )}
         <div className={styles["test-result-retries-item-wrap"]}>
           <TreeItemIcon status={status} className={styles["test-result-retries-item-status"]} />
-          <Text className={styles["test-result-retries-item-text"]}>{convertedStop}</Text>
+          <Text className={styles["test-result-retries-item-text"]}>{retryTitle}</Text>
           <div className={styles["test-result-retries-item-info"]}>
             {Boolean(formattedDuration) && (
               <Text type="ui" size={"s"} className={styles["item-time"]}>

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/index.tsx
@@ -13,7 +13,14 @@ export const TrRetriesView: FunctionalComponent<{
   return (
     <div className={styles["test-result-history"]}>
       {retries.length ? (
-        retries?.map((item, key) => <TrRetriesItem testResultItem={item as unknown as AwesomeTestResult} key={key} />)
+        retries?.map((item, key) => (
+          <TrRetriesItem
+            testResultItem={item as unknown as AwesomeTestResult}
+            key={key}
+            attempt={retries.length - key}
+            totalAttempts={retries.length + 1}
+          />
+        ))
       ) : (
         <div className={styles["test-result-empty"]}>{t("no-retries-results")}</div>
       )}

--- a/packages/web-awesome/src/locales/az.json
+++ b/packages/web-awesome/src/locales/az.json
@@ -116,6 +116,7 @@
     "showLess": "Daha az göstər",
     "showMore": "Daha çox göstər",
     "copy": "Kopyala",
+    "attempt": "Cəhd {{attempt}} / {{total}}",
     "at": "üçün",
     "variables": "Dəyişənlər",
     "openPwTrace": "Playwright Trace aç"

--- a/packages/web-awesome/src/locales/de.json
+++ b/packages/web-awesome/src/locales/de.json
@@ -116,6 +116,7 @@
     "showLess": "Weniger anzeigen",
     "showMore": "Mehr anzeigen",
     "copy": "Kopieren",
+    "attempt": "Versuch {{attempt}} von {{total}}",
     "at": "bei",
     "variables": "Variablen",
     "openPwTrace": "Playwright Trace öffnen"

--- a/packages/web-awesome/src/locales/en.json
+++ b/packages/web-awesome/src/locales/en.json
@@ -116,6 +116,7 @@
     "showLess": "Show less",
     "showMore": "Show more",
     "copy": "Copy",
+    "attempt": "Attempt {{attempt}} of {{total}}",
     "at": "at",
     "variables": "Variables",
     "openPwTrace": "Open Playwright Trace"

--- a/packages/web-awesome/src/locales/es.json
+++ b/packages/web-awesome/src/locales/es.json
@@ -116,6 +116,7 @@
     "showLess": "Mostrar menos",
     "showMore": "Mostrar más",
     "copy": "Copiar",
+    "attempt": "Intento {{attempt}} de {{total}}",
     "at": "a las",
     "variables": "Variables",
     "openPwTrace": "Abrir Playwright Trace"

--- a/packages/web-awesome/src/locales/fr.json
+++ b/packages/web-awesome/src/locales/fr.json
@@ -116,6 +116,7 @@
     "showLess": "Montrer moins",
     "showMore": "Montrer plus",
     "copy": "Copier",
+    "attempt": "Tentative {{attempt}} sur {{total}}",
     "at": "à",
     "variables": "Variables",
     "openPwTrace": "Ouvrir Playwright Trace"

--- a/packages/web-awesome/src/locales/he.json
+++ b/packages/web-awesome/src/locales/he.json
@@ -116,6 +116,7 @@
     "showLess": "הצג פחות",
     "showMore": "הצג עוד",
     "copy": "העתק",
+    "attempt": "ניסיון {{attempt}} מתוך {{total}}",
     "at": "ב-",
     "variables": "משתנים",
     "openPwTrace": "פתח Playwright Trace"

--- a/packages/web-awesome/src/locales/hy.json
+++ b/packages/web-awesome/src/locales/hy.json
@@ -116,6 +116,7 @@
     "showLess": "Ցուցադրել պակաս",
     "showMore": "Ցուցադրել ավելին",
     "copy": "Պատճենել",
+    "attempt": "Փորձ {{attempt}}-ից {{total}}-ը",
     "at": "է",
     "variables": "Փոփոխականներ",
     "openPwTrace": "Բացել Playwright Trace"

--- a/packages/web-awesome/src/locales/it.json
+++ b/packages/web-awesome/src/locales/it.json
@@ -116,6 +116,7 @@
     "showLess": "Mostra meno",
     "showMore": "Mostra di più",
     "copy": "Copia",
+    "attempt": "Tentativo {{attempt}} di {{total}}",
     "at": "a",
     "variables": "Variabili",
     "openPwTrace": "Apri Playwright Trace"

--- a/packages/web-awesome/src/locales/ja.json
+++ b/packages/web-awesome/src/locales/ja.json
@@ -116,6 +116,7 @@
     "showLess": "表示を減らす",
     "showMore": "もっと見る",
     "copy": "コピー",
+    "attempt": "試行 {{attempt}} 回目（全 {{total}} 回）",
     "at": "時",
     "variables": "変数",
     "openPwTrace": "Playwright Trace を開く"

--- a/packages/web-awesome/src/locales/ka.json
+++ b/packages/web-awesome/src/locales/ka.json
@@ -116,6 +116,7 @@
     "showLess": "ნაკლების ჩვენება",
     "showMore": "მეტის ჩვენება",
     "copy": "კოპირება",
+    "attempt": "მცდელობა {{attempt}} {{total}}-დან",
     "at": "ზე",
     "variables": "ცვლადები",
     "openPwTrace": "გახსენი Playwright Trace"

--- a/packages/web-awesome/src/locales/kr.json
+++ b/packages/web-awesome/src/locales/kr.json
@@ -116,6 +116,7 @@
     "showLess": "덜 보기",
     "showMore": "더 보기",
     "copy": "복사",
+    "attempt": "시도 {{attempt}}/{{total}}",
     "at": "에서",
     "variables": "변수",
     "openPwTrace": "Playwright Trace 열기"

--- a/packages/web-awesome/src/locales/nl.json
+++ b/packages/web-awesome/src/locales/nl.json
@@ -116,6 +116,7 @@
     "showLess": "Minder weergeven",
     "showMore": "Meer weergeven",
     "copy": "Kopiëren",
+    "attempt": "Poging {{attempt}} van {{total}}",
     "at": "om",
     "variables": "Variabelen",
     "openPwTrace": "Playwright Trace openen"

--- a/packages/web-awesome/src/locales/pl.json
+++ b/packages/web-awesome/src/locales/pl.json
@@ -116,6 +116,7 @@
     "showLess": "Pokaż mniej",
     "showMore": "Pokaż więcej",
     "copy": "Skopuj",
+    "attempt": "Próba {{attempt}} z {{total}}",
     "at": "w",
     "variables": "Zmienne",
     "openPwTrace": "Otwórz Playwright Trace"

--- a/packages/web-awesome/src/locales/pt.json
+++ b/packages/web-awesome/src/locales/pt.json
@@ -116,6 +116,7 @@
     "showLess": "Mostrar menos",
     "showMore": "Mostrar mais",
     "copy": "Copiar",
+    "attempt": "Tentativa {{attempt}} de {{total}}",
     "at": "em",
     "variables": "Variáveis",
     "openPwTrace": "Abrir Playwright Trace"

--- a/packages/web-awesome/src/locales/ru.json
+++ b/packages/web-awesome/src/locales/ru.json
@@ -116,6 +116,7 @@
     "showLess": "Показать меньше",
     "showMore": "Показать больше",
     "copy": "Скопировать",
+    "attempt": "Попытка {{attempt}} из {{total}}",
     "at": "в",
     "variables": "Переменные",
     "openPwTrace": "Открыть Playwright Trace"

--- a/packages/web-awesome/src/locales/sv.json
+++ b/packages/web-awesome/src/locales/sv.json
@@ -116,6 +116,7 @@
     "showLess": "Visa mindre",
     "showMore": "Visa mer",
     "copy": "Kopiera",
+    "attempt": "Försök {{attempt}} av {{total}}",
     "at": "vid",
     "variables": "Variabler",
     "openPwTrace": "Öppna Playwright Trace"

--- a/packages/web-awesome/src/locales/tr.json
+++ b/packages/web-awesome/src/locales/tr.json
@@ -116,6 +116,7 @@
     "showLess": "Daha az göster",
     "showMore": "Daha fazla göster",
     "copy": "Kopyala",
+    "attempt": "Deneme {{attempt}} / {{total}}",
     "at": "tarihinde",
     "variables": "Değişkenler",
     "openPwTrace": "Playwright Trace'i aç"

--- a/packages/web-awesome/src/locales/zh.json
+++ b/packages/web-awesome/src/locales/zh.json
@@ -116,6 +116,7 @@
     "showLess": "显示更少",
     "showMore": "显示更多",
     "copy": "复制",
+    "attempt": "第 {{attempt}} 次尝试，共 {{total}} 次",
     "at": "在",
     "variables": "变量",
     "openPwTrace": "打开 Playwright Trace"

--- a/packages/web-classic/src/components/TestResult/TestResultRetriesView/TestResultRetriesItem.tsx
+++ b/packages/web-classic/src/components/TestResult/TestResultRetriesView/TestResultRetriesItem.tsx
@@ -6,16 +6,30 @@ import { ArrowButton } from "@/components/ArrowButton";
 import { TestResultError } from "@/components/TestResult/TestResultError";
 import * as styles from "@/components/TestResult/TestResultRetriesView/styles.scss";
 import TreeItemIcon from "@/components/Tree/TreeItemIcon";
+import { useI18n } from "@/stores";
 import { navigateTo } from "@/utils/navigate";
 import { timestampToDate } from "@/utils/time";
 
-export const TestResultRetriesItem: FunctionalComponent<{
+export type TrRetriesItemProps = {
   testResultItem: TestResult;
-}> = ({ testResultItem }) => {
+  attempt: number;
+  totalAttempts: number;
+};
+
+export const TestResultRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({
+  testResultItem,
+  attempt,
+  totalAttempts,
+}) => {
   const { id, status, message, trace, stop, duration } = testResultItem;
   const [isOpened, setIsOpen] = useState(false);
-  const convertedStop = timestampToDate(stop);
-  const formattedDuration = formatDuration(duration as number);
+  const { t } = useI18n("ui");
+
+  const retryTitlePrefix = t("attempt", { attempt, total: totalAttempts });
+  const convertedStop = stop ? timestampToDate(stop) : undefined;
+  const retryTitle = convertedStop ? `${retryTitlePrefix} -- ${convertedStop}` : retryTitlePrefix;
+
+  const formattedDuration = typeof duration === "number" ? formatDuration(duration) : undefined;
   const navigateUrl = `testresult/${id}`;
 
   return (
@@ -24,11 +38,13 @@ export const TestResultRetriesItem: FunctionalComponent<{
         {Boolean(message) && <ArrowButton isOpened={isOpened} icon={allureIcons.lineArrowsChevronDown} />}
         <div className={styles["test-result-retries-item-wrap"]}>
           <TreeItemIcon status={status} className={styles["test-result-retries-item-status"]} />
-          <Text className={styles["test-result-retries-item-text"]}>{convertedStop}</Text>
+          <Text className={styles["test-result-retries-item-text"]}>{retryTitle}</Text>
           <div className={styles["test-result-retries-item-info"]}>
-            <Text type="ui" size={"s"} className={styles["item-time"]}>
-              {formattedDuration}
-            </Text>
+            {Boolean(formattedDuration) && (
+              <Text type="ui" size={"s"} className={styles["item-time"]}>
+                {formattedDuration}
+              </Text>
+            )}
             <IconButton
               icon={allureIcons.lineGeneralLinkExternal}
               style={"ghost"}

--- a/packages/web-classic/src/components/TestResult/TestResultRetriesView/index.tsx
+++ b/packages/web-classic/src/components/TestResult/TestResultRetriesView/index.tsx
@@ -11,7 +11,14 @@ export const TestResultRetriesView: FunctionalComponent<{ testResult: AwesomeTes
   return (
     <div className={styles["test-result-history"]}>
       {retries.length ? (
-        retries?.map((item, key) => <TestResultRetriesItem testResultItem={item} key={key} />)
+        retries?.map((item, key) => (
+          <TestResultRetriesItem
+            testResultItem={item}
+            key={key}
+            attempt={retries.length - key}
+            totalAttempts={retries.length + 1}
+          />
+        ))
       ) : (
         <div className={styles["test-result-empty"]}>{t("no-retries-results")}</div>
       )}

--- a/packages/web-classic/src/translations/am.json
+++ b/packages/web-classic/src/translations/am.json
@@ -95,6 +95,7 @@
     "showLess": "Ցուցադրել պակաս",
     "showMore": "Ցուցադրել ավելին",
     "copy": "Պատճենել",
+    "attempt": "Փորձ {{attempt}}-ից {{total}}-ը",
     "at": "է"
   },
   "controls": {

--- a/packages/web-classic/src/translations/az.json
+++ b/packages/web-classic/src/translations/az.json
@@ -95,6 +95,7 @@
     "showLess": "Daha az göstər",
     "showMore": "Daha çox göstər",
     "copy": "Kopyala",
+    "attempt": "Cəhd {{attempt}} / {{total}}",
     "at": "üçün"
   },
   "controls": {

--- a/packages/web-classic/src/translations/de.json
+++ b/packages/web-classic/src/translations/de.json
@@ -95,6 +95,7 @@
     "showLess": "Weniger anzeigen",
     "showMore": "Mehr anzeigen",
     "copy": "Kopieren",
+    "attempt": "Versuch {{attempt}} von {{total}}",
     "at": "bei"
   },
   "controls": {

--- a/packages/web-classic/src/translations/en.json
+++ b/packages/web-classic/src/translations/en.json
@@ -96,6 +96,7 @@
     "showLess": "Show less",
     "showMore": "Show more",
     "copy": "Copy",
+    "attempt": "Attempt {{attempt}} of {{total}}",
     "at": "at"
   },
   "controls": {

--- a/packages/web-classic/src/translations/es.json
+++ b/packages/web-classic/src/translations/es.json
@@ -95,6 +95,7 @@
     "showLess": "Mostrar menos",
     "showMore": "Mostrar más",
     "copy": "Copiar",
+    "attempt": "Intento {{attempt}} de {{total}}",
     "at": "a las"
   },
   "controls": {

--- a/packages/web-classic/src/translations/fr.json
+++ b/packages/web-classic/src/translations/fr.json
@@ -95,6 +95,7 @@
     "showLess": "Montrer moins",
     "showMore": "Montrer plus",
     "copy": "Copier",
+    "attempt": "Tentative {{attempt}} sur {{total}}",
     "at": "à"
   },
   "controls": {

--- a/packages/web-classic/src/translations/he.json
+++ b/packages/web-classic/src/translations/he.json
@@ -95,6 +95,7 @@
     "showLess": "הצג פחות",
     "showMore": "הצג עוד",
     "copy": "העתק",
+    "attempt": "ניסיון {{attempt}} מתוך {{total}}",
     "at": "ב-"
   },
   "controls": {

--- a/packages/web-classic/src/translations/it.json
+++ b/packages/web-classic/src/translations/it.json
@@ -95,6 +95,7 @@
     "showLess": "Mostra meno",
     "showMore": "Mostra di più",
     "copy": "Copia",
+    "attempt": "Tentativo {{attempt}} di {{total}}",
     "at": "a"
   },
   "controls": {

--- a/packages/web-classic/src/translations/ja.json
+++ b/packages/web-classic/src/translations/ja.json
@@ -95,6 +95,7 @@
     "showLess": "表示を減らす",
     "showMore": "もっと見る",
     "copy": "コピー",
+    "attempt": "試行 {{attempt}} 回目（全 {{total}} 回）",
     "at": "時"
   },
   "controls": {

--- a/packages/web-classic/src/translations/ka.json
+++ b/packages/web-classic/src/translations/ka.json
@@ -95,6 +95,7 @@
     "showLess": "ნაკლების ჩვენება",
     "showMore": "მეტის ჩვენება",
     "copy": "კოპირება",
+    "attempt": "მცდელობა {{attempt}} {{total}}-დან",
     "at": "ზე"
   },
   "controls": {

--- a/packages/web-classic/src/translations/kr.json
+++ b/packages/web-classic/src/translations/kr.json
@@ -95,6 +95,7 @@
     "showLess": "덜 보기",
     "showMore": "더 보기",
     "copy": "복사",
+    "attempt": "시도 {{attempt}}/{{total}}",
     "at": "에서"
   },
   "controls": {

--- a/packages/web-classic/src/translations/nl.json
+++ b/packages/web-classic/src/translations/nl.json
@@ -95,6 +95,7 @@
     "showLess": "Minder weergeven",
     "showMore": "Meer weergeven",
     "copy": "Kopiëren",
+    "attempt": "Poging {{attempt}} van {{total}}",
     "at": "om"
   },
   "controls": {

--- a/packages/web-classic/src/translations/pl.json
+++ b/packages/web-classic/src/translations/pl.json
@@ -93,6 +93,7 @@
     "showLess": "Pokaż mniej",
     "showMore": "Pokaż więcej",
     "copy": "Skopuj",
+    "attempt": "Próba {{attempt}} z {{total}}",
     "at": "w"
   },
   "controls": {

--- a/packages/web-classic/src/translations/pt.json
+++ b/packages/web-classic/src/translations/pt.json
@@ -95,6 +95,7 @@
     "showLess": "Mostrar menos",
     "showMore": "Mostrar mais",
     "copy": "Copiar",
+    "attempt": "Tentativa {{attempt}} de {{total}}",
     "at": "em"
   },
   "controls": {

--- a/packages/web-classic/src/translations/ru.json
+++ b/packages/web-classic/src/translations/ru.json
@@ -93,6 +93,7 @@
     "showLess": "Показать меньше",
     "showMore": "Показать больше",
     "copy": "Скопировать",
+    "attempt": "Попытка {{attempt}} из {{total}}",
     "at": "в"
   },
   "controls": {

--- a/packages/web-classic/src/translations/sv.json
+++ b/packages/web-classic/src/translations/sv.json
@@ -95,6 +95,7 @@
     "showLess": "Visa mindre",
     "showMore": "Visa mer",
     "copy": "Kopiera",
+    "attempt": "Försök {{attempt}} av {{total}}",
     "at": "vid"
   },
   "controls": {

--- a/packages/web-classic/src/translations/tr.json
+++ b/packages/web-classic/src/translations/tr.json
@@ -95,6 +95,7 @@
     "showLess": "Daha az göster",
     "showMore": "Daha fazla göster",
     "copy": "Kopyala",
+    "attempt": "Deneme {{attempt}} / {{total}}",
     "at": "tarihinde"
   },
   "controls": {

--- a/packages/web-classic/src/translations/zh.json
+++ b/packages/web-classic/src/translations/zh.json
@@ -95,6 +95,7 @@
     "showLess": "显示更少",
     "showMore": "显示更多",
     "copy": "复制",
+    "attempt": "第 {{attempt}} 次尝试，共 {{total}} 次",
     "at": "在"
   },
   "controls": {


### PR DESCRIPTION
An entry on the Retries tab has a title that includes the formatted stop timestamp of the corresponding test result. However, some readers produce test results that lack timestamps. For example, the XCResult format doesn't include timestamps at the test result level.

In such cases, opening the "Retries" tab causes the report to become broken: it becomes impossible to navigate, and the content pane becomes empty and collapsed. Here is an example (see the report [here](https://delatrie.github.io/allure-xcresult-samples/repetitions/v3/)).

<img width="934" height="223" alt="image" src="https://github.com/user-attachments/assets/831784ae-452e-455d-9059-73718058e9cc" />

The PR fixes that by omitting the timestamp text in case `stop` is zero.

### Extra changes

#### Improved retry titles

Additionally, it prefixes the timestamp with the following text: `Attempt {{number}} of {{total}}`. The text serves multiple purposes:

1. It prevents entries from being empty in case the timestamps are missing.
2. It makes it easier to figure out how retries are sorted, especially in case the provided resolution (which is 1 second) isn't sufficient to tell apart the retries.

#### Retry fixture and tests

The PR introduces the `RetryItemFixture` class to help with validating the behavior of the Retries tab entries. Use `TestResultPage.getRetry` to access it.

Also, the PR adds a couple of tests that cover retry titles. Ideally, more tests are required to cover buttons, details, and other aspects.

#### Port to classic

The PR also ports those changes to `web-classic`, although it's not possible to verify them since the classic report currently doesn't work.