### PR TITLE
fix(static-server): decode path before accessing FS

### DIFF
--- a/packages/static-server/src/index.ts
+++ b/packages/static-server/src/index.ts
@@ -108,7 +108,7 @@ export const serve = async (options?: {
       return;
     }
 
-    let fsPath = join(pathToServe, pathname.replace(/\?.*$/, ""));
+    let fsPath = join(pathToServe, decodeURI(pathname));
     let stats: Stats;
 
     try {

--- a/packages/static-server/test/unit/static.test.ts
+++ b/packages/static-server/test/unit/static.test.ts
@@ -29,6 +29,16 @@ it("serves files without extension as binary ones", async () => {
   expect(res.data).not.toBeUndefined();
 });
 
+it("decode path before accessing the file system", async () => {
+  server = await serve({ port, servePath });
+  const res = await axios.get(`http://localhost:${port}/with%20space`, {
+    timeout: 500,
+  });
+
+  expect(res.headers["content-type"]).toBe("application/octet-stream");
+  expect(res.status).toBe(200);
+});
+
 it("serves .bin files", async () => {
   server = await serve({ port, servePath });
   const res = await axios.get(`http://localhost:${port}/sample.bin`, {


### PR DESCRIPTION
The static server doesn't decode the path before reading files/folders from the file system. That may lead to HTTP 404 errors.

Example: an environment with spaces in its ID:

```js
export default defineConfig({
  // ...
  environments: {
    ["Linux, Chrome"]: { /* ... */ },
  },
});
```

This creates the `widgets/Linux, Chrome` directory with some `.json` files in it. The report then throws the `Failed to fetch http://localhost:51593/widgets/Linux,%20Chrome/tree.json?v=1756327153126, response status: 404` error.

<img width="1826" height="138" alt="image" src="https://github.com/user-attachments/assets/e6628d2b-9d98-4125-9ad2-b3aae3fca716" />

We use `new URL(...).toString()` to get the URL for requests, which applies `encodeURI` to the result string.

The PR adds the missing `decodeURI` call.

> [!NOTE]
> It might be a better idea to apply `md5` to such user-provided names that are translated to directory/file names to avoid such hassle with special characters.

**Extra changes**

  - remove query string stripping from `pathname`; it's already stripped by the `URL` into the `search` property:
    ```js
    > new URL("foo/bar?baz=qux", "https://localhost")
    URL {
      // ...
      pathname: '/foo/bar',
      search: '?baz=qux',
    }
    ```