### PR TITLE
chore: fix type aware linting in the build workflow

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,7 +11,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:@typescript-eslint/recommended-type-checked",
     "prettier",
   ],
   parser: "@typescript-eslint/parser",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -66,10 +66,13 @@ module.exports = {
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/consistent-type-definitions": "off",
     "@typescript-eslint/consistent-type-exports": "error",
-    "@typescript-eslint/consistent-type-imports": ["error", {
-      fixStyle: 'separate-type-imports',
-      prefer: 'type-imports',
-    }],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        fixStyle: "separate-type-imports",
+        prefer: "type-imports",
+      },
+    ],
     "@typescript-eslint/dot-notation": "error",
     "@typescript-eslint/explicit-member-accessibility": [
       "off",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache --check-cache
+      - name: Build the project
+        run: yarn build
       - name: Lint Project
         run: yarn eslint
 

--- a/packages/core-api/test/utils/time.test.ts
+++ b/packages/core-api/test/utils/time.test.ts
@@ -22,12 +22,11 @@ describe("formatDuration", () => {
     const duration = randomInt(999);
     const formatted = formatDuration(duration / 2000);
 
-    console.log(formatted);
     expect(formatted).toEqual("0s");
   });
 
   it("should format ms only if less then a second", () => {
-    const duration = randomInt(999);
+    const duration = randomInt(999, 1);
     const formatted = formatDuration(duration);
 
     expect(formatted).toEqual(`${duration}ms`);


### PR DESCRIPTION
ESLint type-aware rules don't work if a dependency package is not built (unless [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) and [`projectService: true`](https://typescript-eslint.io/troubleshooting/typed-linting#are-typescript-project-references-supported) are used, which is not our case).

This manifests in false positives like [this one](https://github.com/allure-framework/allure3/actions/runs/17400416378/job/49396377474#step:5:19): 

```
[@allurereport/plugin-api]:   46:29  error  This assertion is unnecessary since the receiver accepts the original type of the expression  @typescript-eslint/no-unnecessary-type-assertion
[@allurereport/plugin-api]:   61:32  error  This assertion is unnecessary since the receiver accepts the original type of the expression  @typescript-eslint/no-unnecessary-type-assertion
```

The PR adds the build step.

**Extra changes**

  - use `plugin:@typescript-eslint/recommended-type-checked` instead of its alias
  - fix styling in .eslintrc.cjs
  - fix flaky formatDuration test