### PR TITLE
fix(store): overwrite existing entries instead of merging when restoring the state

### DIFF
--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -100,34 +100,12 @@ export const mapToObject = <K extends string | number | symbol, T = any>(map: Ma
   return result;
 };
 
-export const mergeMapWithRecord = <K extends string | number | symbol, T = any>(
+export const updateMapWithRecord = <K extends string | number | symbol, T = any>(
   map: Map<K, T>,
   record: Record<K, T>,
 ): Map<K, T> => {
   Object.entries(record).forEach(([key, value]) => {
-    const existingValue = map.get(key as K);
-
-    if (existingValue !== undefined) {
-      if (Array.isArray(existingValue) && Array.isArray(value)) {
-        // Merge arrays
-        map.set(key as K, [...existingValue, ...value] as unknown as T);
-      } else if (
-        typeof existingValue === "object" &&
-        existingValue !== null &&
-        typeof value === "object" &&
-        value !== null &&
-        !Array.isArray(existingValue) &&
-        !Array.isArray(value)
-      ) {
-        // Merge objects
-        map.set(key as K, { ...existingValue, ...value } as unknown as T);
-      } else {
-        // For primitives or incompatible types, just overwrite
-        map.set(key as K, value as T);
-      }
-    } else {
-      map.set(key as K, value as T);
-    }
+    map.set(key as K, value as T);
   });
 
   return map;
@@ -820,11 +798,11 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
       indexKnownByHistoryId = {},
     } = stateDump;
 
-    mergeMapWithRecord(this.#testResults, testResults);
-    mergeMapWithRecord(this.#attachments, attachments);
-    mergeMapWithRecord(this.#testCases, testCases);
-    mergeMapWithRecord(this.#fixtures, fixtures);
-    mergeMapWithRecord(this.#attachmentContents, attachmentsContents);
+    updateMapWithRecord(this.#testResults, testResults);
+    updateMapWithRecord(this.#attachments, attachments);
+    updateMapWithRecord(this.#testCases, testCases);
+    updateMapWithRecord(this.#fixtures, fixtures);
+    updateMapWithRecord(this.#attachmentContents, attachmentsContents);
 
     this.#addEnvironments(environments);
     this.#globalAttachments.push(...globalAttachments);

--- a/packages/core/test/store/store.test.ts
+++ b/packages/core/test/store/store.test.ts
@@ -4,7 +4,7 @@ import { type AllureStoreDump, md5 } from "@allurereport/plugin-api";
 import type { RawTestResult } from "@allurereport/reader-api";
 import { BufferResultFile } from "@allurereport/reader-api";
 import { describe, expect, it, vi } from "vitest";
-import { DefaultAllureStore, mapToObject, mergeMapWithRecord } from "../../src/store/store.js";
+import { DefaultAllureStore, mapToObject, updateMapWithRecord } from "../../src/store/store.js";
 
 class AllureTestHistory implements AllureHistory {
   constructor(readonly history: HistoryDataPoint[]) {}
@@ -2325,91 +2325,24 @@ describe("dump state", () => {
   });
 });
 
-describe("mergeMapWithRecord", () => {
-  it("should merge a record into a map with string keys", () => {
-    const map = new Map<string, number>([["a", 1]]);
-    const record = { b: 2, c: 3 };
-    const result = mergeMapWithRecord(map, record);
+describe("updateMapWithRecord", () => {
+  it("should update a map with a record", () => {
+    const map = new Map<string, number>([["a", 1], ["b", 2]]);
+    const record = { b: 3, c: 4 };
+    const result = updateMapWithRecord(map, record);
 
     expect(result).toBe(map);
     expect(Array.from(result.entries())).toEqual([
       ["a", 1],
-      ["b", 2],
-      ["c", 3],
+      ["b", 3],
+      ["c", 4],
     ]);
-  });
-
-  it("should overwrite existing keys with primitive values", () => {
-    const map = new Map<string, number>([
-      ["a", 1],
-      ["b", 2],
-    ]);
-    const record = { b: 42, c: 3 };
-
-    mergeMapWithRecord(map, record);
-
-    expect(map.get("b")).toBe(42);
-    expect(map.get("c")).toBe(3);
-  });
-
-  it("should merge arrays when both existing and new values are arrays", () => {
-    const map = new Map<string, any>([
-      ["a", [1, 2]],
-      ["b", "string"],
-      ["c", [5, 6]],
-    ]);
-    const record = { a: [3, 4], b: [7, 8], d: [9, 10] };
-
-    mergeMapWithRecord(map, record);
-
-    expect(Array.from(map.entries())).toEqual([
-      ["a", [1, 2, 3, 4]],
-      ["b", [7, 8]],
-      ["c", [5, 6]],
-      ["d", [9, 10]],
-    ]);
-  });
-
-  it("should merge objects when both existing and new values are objects", () => {
-    const map = new Map<string, any>([
-      ["a", { x: 1, y: 2 }],
-      ["b", "string"],
-      ["c", { z: 3 }],
-    ]);
-    const record = {
-      a: { y: 3, z: 4 },
-      b: { new: "object" },
-      d: { foo: "bar" },
-    };
-
-    mergeMapWithRecord(map, record);
-
-    expect(map.get("a")).toEqual({ x: 1, y: 3, z: 4 });
-    expect(map.get("b")).toEqual({ new: "object" });
-    expect(map.get("c")).toEqual({ z: 3 });
-    expect(map.get("d")).toEqual({ foo: "bar" });
-  });
-
-  it("should not merge when types are incompatible", () => {
-    const map = new Map<string, any>([
-      ["a", { x: 1 }],
-      ["b", [1, 2]],
-    ]);
-    const record = {
-      a: [3, 4], // object vs array
-      b: { y: 3 }, // array vs object
-    };
-
-    mergeMapWithRecord(map, record);
-
-    expect(map.get("a")).toEqual([3, 4]);
-    expect(map.get("b")).toEqual({ y: 3 });
   });
 
   it("should handle empty record and map", () => {
     const map = new Map();
     const record = {};
-    const result = mergeMapWithRecord(map, record);
+    const result = updateMapWithRecord(map, record);
 
     expect(result.size).toBe(0);
   });


### PR DESCRIPTION
During state restoration (`allure generate --stage ...`), if Allure encounters an entry that is already in the store (e.g., because it's been restored from another dump), it attempts to merge the two entries with `{ ...old, ...new }`. This breaks `PathResultFile` instances in `attachmentContents` by turning them into plain objects, which eventually throws `file.asBuffer is not a function`.

A situation where two entries have the same ID should not occur in the first place. These IDs are randomly generated and are not meant to be reused across runs. But if it does, it's better to play safe and overwrite an entry without modifying it.

The PR removes the merging logic from `mergeMapWithRecord` and renames it to `updateMapWithRecord`. 