### PR TITLE
feat: add support for non mainline development tests by displaying a version label in awesome report

### DIFF
--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -436,6 +436,7 @@ export const generateStaticFiles = async (
     charts = [],
     defaultSection = "",
     ci,
+    versionLabel,
   } = payload;
   const compile = Handlebars.compile(template);
   const manifest = await readTemplateManifest(payload.singleFile);
@@ -499,6 +500,7 @@ export const generateStaticFiles = async (
     allureVersion,
     sections,
     defaultSection,
+    versionLabel,
   };
 
   try {

--- a/packages/plugin-awesome/src/model.ts
+++ b/packages/plugin-awesome/src/model.ts
@@ -16,6 +16,7 @@ export type AwesomeOptions = {
   sections?: string[];
   defaultSection?: string;
   publish?: boolean;
+  versionLabel?: string;
 };
 
 export type TemplateManifest = Record<string, string>;

--- a/packages/web-awesome/src/components/TestResult/TrHistory/TrHistoryItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrHistory/TrHistoryItem.tsx
@@ -1,4 +1,4 @@
-import { type HistoryTestResult, formatDuration } from "@allurereport/core-api";
+import { type HistoryTestResult, type TestLabel, formatDuration } from "@allurereport/core-api";
 import { getReportOptions } from "@allurereport/web-commons";
 import { ArrowButton, IconButton, Text, TooltipWrapper, TreeItemIcon, allureIcons } from "@allurereport/web-components";
 import { type FunctionalComponent } from "preact";
@@ -13,11 +13,13 @@ export const TrHistoryItem: FunctionalComponent<{
   testResultItem: HistoryTestResult;
 }> = ({ testResultItem }: { testResultItem: HistoryTestResult }) => {
   const reportOptions = getReportOptions<AwesomeReportOptions & { id: string }>();
-  const { status, error, stop, duration, id, url } = testResultItem;
+  const { status, error, stop, duration, id, url, labels } = testResultItem;
   const [isOpened, setIsOpen] = useState(false);
   const convertedStop = stop ? timestampToDate(stop) : undefined;
   const formattedDuration = duration ? formatDuration(duration) : undefined;
   const { t } = useI18n("controls");
+  const versionLabel = reportOptions?.versionLabel;
+  const labelValue = versionLabel ? labels?.find((label: TestLabel) => label.name === versionLabel)?.value : undefined;
   const navigateUrl = useMemo(() => {
     if (!url) {
       return undefined;
@@ -52,10 +54,17 @@ export const TrHistoryItem: FunctionalComponent<{
     );
   };
   const renderItemContent = () => {
+    let displayText = convertedStop;
+    if (labelValue && convertedStop) {
+      displayText = `${labelValue}: ${convertedStop}`;
+    } else if (labelValue) {
+      displayText = labelValue;
+    }
+    
     return (
       <>
         <TreeItemIcon status={status} className={styles["test-result-history-item-status"]} />
-        {convertedStop && <Text className={styles["test-result-history-item-text"]}>{convertedStop}</Text>}
+        {displayText && <Text className={styles["test-result-history-item-text"]}>{displayText}</Text>}
         <div className={styles["test-result-history-item-info"]}>
           {formattedDuration && (
             <Text type="ui" size={"s"} className={styles["item-time"]}>

--- a/packages/web-awesome/src/components/TestResult/TrPrevStatuses/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrPrevStatuses/index.tsx
@@ -1,4 +1,4 @@
-import { type HistoryTestResult } from "@allurereport/core-api";
+import { type HistoryTestResult, type TestLabel } from "@allurereport/core-api";
 import { capitalize, getReportOptions } from "@allurereport/web-commons";
 import { SvgIcon, Text, TooltipWrapper, allureIcons } from "@allurereport/web-components";
 import type { FunctionalComponent } from "preact";
@@ -30,16 +30,20 @@ const TrPrevStatus: FunctionalComponent<{ item: HistoryTestResult }> = ({ item }
   );
 };
 const TrPrevStatusTooltip: FunctionalComponent<{ item: HistoryTestResult }> = ({ item }) => {
+  const reportOptions = getReportOptions<AwesomeReportOptions & { id: string }>();
   const convertedStop = item.stop && timestampToDate(item.stop);
   const { t } = useI18n("statuses");
   const status = t(item.status);
+  const versionLabel = reportOptions?.versionLabel;
+  const labelValue = versionLabel ? item.labels?.find((label: TestLabel) => label.name === versionLabel)?.value : undefined;
 
   return (
     <div className={styles["test-result-prev-status-tooltip"]}>
       <Text tag={"div"} size={"m"} bold>
         {capitalize(status)}
       </Text>
-      <Text size={"m"}>{convertedStop}</Text>
+      <Text tag={"div"} size={"m"}>{convertedStop}</Text>
+      {Boolean(labelValue) && <Text size={"m"}>{labelValue}</Text>}
     </div>
   );
 };

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
@@ -1,8 +1,9 @@
 import { formatDuration } from "@allurereport/core-api";
 import { ArrowButton, IconButton, Text, TreeItemIcon, allureIcons } from "@allurereport/web-components";
+import { getReportOptions } from "@allurereport/web-commons";
 import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
-import type { AwesomeTestResult } from "types";
+import type { AwesomeReportOptions, AwesomeTestResult } from "types";
 import { TrError } from "@/components/TestResult/TrError";
 import * as styles from "@/components/TestResult/TrRetriesView/styles.scss";
 import { useI18n } from "@/stores/locale";
@@ -16,14 +17,25 @@ export type TrRetriesItemProps = {
 };
 
 export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testResultItem, attempt, totalAttempts }) => {
-  const { id, status, error, stop, duration } = testResultItem;
+  const { id, status, error, stop, duration, labels } = testResultItem;
   const [isOpened, setIsOpen] = useState(false);
 
   const { t } = useI18n("ui");
+  const reportOptions = getReportOptions<AwesomeReportOptions>();
+  const versionLabel = reportOptions?.versionLabel;
 
   const retryTitlePrefix = t("attempt", { attempt, total: totalAttempts });
   const convertedStop = stop ? timestampToDate(stop) : undefined;
-  const retryTitle = convertedStop ? `${retryTitlePrefix} – ${convertedStop}` : retryTitlePrefix;
+  const labelValue = versionLabel ? labels?.find((label) => label.name === versionLabel)?.value : undefined;
+  
+  let displayValue = convertedStop;
+  if (labelValue && convertedStop) {
+    displayValue = `${labelValue}: ${convertedStop}`;
+  } else if (labelValue) {
+    displayValue = labelValue;
+  }
+  
+  const retryTitle = displayValue ? `${retryTitlePrefix} – ${displayValue}` : retryTitlePrefix;
 
   const formattedDuration = typeof duration === "number" ? formatDuration(duration) : undefined;
   const navigateUrl = id;

--- a/packages/web-awesome/types.d.ts
+++ b/packages/web-awesome/types.d.ts
@@ -27,6 +27,7 @@ export type AwesomeReportOptions = {
   sections?: string[];
   cacheKey: string;
   ci?: CiDescriptor;
+  versionLabel?: string;
 };
 
 export type AwesomeFixtureResult = Omit<


### PR DESCRIPTION
Allure3 seems to be mainly development to test systems in mainline development. We want to use allure3 for our test reports, however it's important for us to display the version of the system under test for each run.

I've implemented a feature that enables the selection of a label that indicates the version number for each run.
The implementation was done with the help of Copilot Business, public code matching turned of.   
The version will be displayed in the history and retries like this:
<img width="602" height="236" alt="image" src="https://github.com/user-attachments/assets/0cf348c7-9253-40d1-8654-ce9d36069ed5" />
At the previous result tooltip:
<img width="273" height="121" alt="image" src="https://github.com/user-attachments/assets/b421c351-3af1-4d8f-99de-d425868907d5" />
And in trend charts:
<img width="1306" height="408" alt="image" src="https://github.com/user-attachments/assets/38f1a8f7-ba23-4ac2-8f84-d183983b5111" />

Please let me know if I should change something or this feature is not something you would consider for allure3.
