### PR TITLE
types: add type for namespace arg for useI18n

### DIFF
--- a/packages/web-awesome/src/stores/locale.ts
+++ b/packages/web-awesome/src/stores/locale.ts
@@ -26,7 +26,7 @@ const namespaces = [
   "charts",
   "sections",
   "transitions.description",
-];
+] as const;
 
 export const currentLocale = signal<LangLocale>("en" as LangLocale);
 export const currentLocaleIso = computed(() => LANG_LOCALE[currentLocale.value]?.iso ?? LANG_LOCALE.en.iso);
@@ -63,8 +63,12 @@ export const waitForI18next = i18next
     interpolation: { escapeValue: false },
   });
 
-export const useI18n = (namespace?: string) => {
-  const t = computed(() => (key: string, options?: TOptions) => i18next.t(key, { ns: namespace, ...options }));
+export const useI18n = (namespace: (typeof namespaces)[number]) => {
+  const t = computed(
+    () =>
+      (key: string, options: TOptions = {}) =>
+        i18next.t(key, { ns: namespace, ...options }),
+  );
 
   return {
     t: t.value,


### PR DESCRIPTION
When you add a new key to a locale JSON file and try to access it via `useI18n`, the `t` function simply returns the key itself (e.g. `t("selected")` → `"selected"`) because that key isn’t included in the namespaces array.

With this change, TS will throw a type error if a key isn’t listed in `namespaces`, preventing silent failures. This helps avoid debugging sessions where the translation doesn’t work and no one realizes it’s missing from the `namespaces`.