### PR TITLE
fix: show empty state when chart data is considered empty

### DIFF
--- a/packages/web-components/src/components/Charts/TestingPyramidWidget/index.tsx
+++ b/packages/web-components/src/components/Charts/TestingPyramidWidget/index.tsx
@@ -138,7 +138,11 @@ export const TestingPyramidWidget = (props: Props) => {
   );
 
   if (!data || data.length === 0) {
-    return <EmptyDataStub label={emptyLabel} width={width} height={height} ariaLabel={emptyLabel} />;
+    return (
+      <Widget title={title}>
+        <EmptyDataStub label={emptyLabel} width={width} height={height} ariaLabel={emptyLabel} />
+      </Widget>
+    );
   }
 
   return (


### PR DESCRIPTION
For some charts, simply checking the `data` array length (or its presence) is not sufficient, because the array may contain data, but the data itself is not meaningful for end user.

This change ensures that specific conditions for data emptiness are handled for all chart types.