### PR TITLE
Fix config parameter priority

### DIFF
--- a/packages/cli/src/commands/allure2.ts
+++ b/packages/cli/src/commands/allure2.ts
@@ -63,8 +63,8 @@ export class Allure2Command extends Command {
       reportLanguage: this.reportLanguage,
     } as Allure2PluginOptions;
     const config = await readConfig(cwd, this.config, {
-      output: this.output ?? "allure-report",
-      name: this.reportName ?? "Allure Report",
+      output: this.output,
+      name: this.reportName,
       knownIssuesPath: this.knownIssues,
       historyPath: this.historyPath,
     });

--- a/packages/cli/src/commands/awesome.ts
+++ b/packages/cli/src/commands/awesome.ts
@@ -78,8 +78,8 @@ export class AwesomeCommand extends Command {
       groupBy: this.groupBy?.split?.(",") ?? ["parentSuite", "suite", "subSuite"],
     } as AwesomePluginOptions;
     const config = await readConfig(cwd, this.config, {
-      output: this.output ?? "allure-report",
-      name: this.reportName ?? "Allure Report",
+      output: this.output,
+      name: this.reportName,
       knownIssuesPath: this.knownIssues,
       historyPath: this.historyPath,
     });

--- a/packages/cli/src/commands/classic.ts
+++ b/packages/cli/src/commands/classic.ts
@@ -63,8 +63,8 @@ export class ClassicCommand extends Command {
       reportLanguage: this.reportLanguage,
     } as ClassicPluginOptions;
     const config = await readConfig(cwd, this.config, {
-      output: this.output ?? "allure-report",
-      name: this.reportName ?? "Allure Report",
+      output: this.output,
+      name: this.reportName,
       knownIssuesPath: this.knownIssues,
       historyPath: this.historyPath,
     });

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -65,8 +65,8 @@ export class DashboardCommand extends Command {
       reportLanguage: this.reportLanguage ?? "en",
     } as DashboardPluginOptions;
     const config = await readConfig(cwd, this.config, {
-      output: this.output ?? "allure-report",
-      name: this.reportName ?? "Allure Report",
+      output: this.output,
+      name: this.reportName,
     });
 
     config.plugins = [

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -60,7 +60,7 @@ export class GenerateCommand extends Command {
     const resultsDir = (this.resultsDir ?? "./**/allure-results").replace(/[\\/]$/, "");
     const config = await readConfig(cwd, this.config, {
       name: this.reportName,
-      output: this.output ?? "allure-report",
+      output: this.output,
     });
     const stageDumpFiles: string[] = [];
     const resultsDirectories: string[] = [];

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -33,7 +33,7 @@ export class OpenCommand extends Command {
   });
 
   async execute() {
-    const config = await readConfig(this.cwd, this.config, { output: this.reportDir ?? "./allure-report" });
+    const config = await readConfig(this.cwd, this.config, { output: this.reportDir });
 
     await serve({
       port: this.port ? parseInt(this.port, 10) : undefined,

--- a/packages/cli/test/commands/allure2.test.ts
+++ b/packages/cli/test/commands/allure2.test.ts
@@ -1,5 +1,6 @@
 import { AllureReport, readConfig } from "@allurereport/core";
 import Allure2Plugin from "@allurereport/plugin-allure2";
+import { run } from "clipanion";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { Allure2Command } from "../../src/commands/allure2.js";
 
@@ -88,5 +89,44 @@ describe("allure2 command", () => {
         ]),
       }),
     );
+  });
+
+  it("should prefer CLI arguments over config and defaults", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(Allure2Command, [
+      "allure2",
+      "--report-name",
+      "foo",
+      "--output",
+      "bar",
+      "--known-issues",
+      "baz",
+      "--history-path",
+      "qux",
+      "./allure-results",
+    ]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      name: "foo",
+      output: "bar",
+      knownIssuesPath: "baz",
+      historyPath: "qux",
+    });
+  });
+
+  it("should not overwrite readConfig values if no CLI arguments provided", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(Allure2Command, ["allure2", "./allure-results"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      name: undefined,
+      output: undefined,
+      knownIssuesPath: undefined,
+      historyPath: undefined,
+    });
   });
 });

--- a/packages/cli/test/commands/classic.test.ts
+++ b/packages/cli/test/commands/classic.test.ts
@@ -1,5 +1,6 @@
 import { AllureReport, readConfig } from "@allurereport/core";
 import ClassicPlugin from "@allurereport/plugin-classic";
+import { run } from "clipanion";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { ClassicCommand } from "../../src/commands/classic.js";
 
@@ -89,5 +90,44 @@ describe("classic command", () => {
         ]),
       }),
     );
+  });
+
+  it("should prefer CLI arguments over config and defaults", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(ClassicCommand, [
+      "classic",
+      "--report-name",
+      "foo",
+      "--output",
+      "bar",
+      "--known-issues",
+      "baz",
+      "--history-path",
+      "qux",
+      "./allure-results",
+    ]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      name: "foo",
+      output: "bar",
+      knownIssuesPath: "baz",
+      historyPath: "qux",
+    });
+  });
+
+  it("should not overwrite readConfig values if no CLI arguments provided", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(ClassicCommand, ["classic", "./allure-results"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      name: undefined,
+      output: undefined,
+      knownIssuesPath: undefined,
+      historyPath: undefined,
+    });
   });
 });

--- a/packages/cli/test/commands/csv.test.ts
+++ b/packages/cli/test/commands/csv.test.ts
@@ -1,5 +1,6 @@
 import { AllureReport, readConfig } from "@allurereport/core";
 import CsvPlugin from "@allurereport/plugin-csv";
+import { run } from "clipanion";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { CsvCommand } from "../../src/commands/csv.js";
 
@@ -88,5 +89,29 @@ describe("csv command", () => {
         ]),
       }),
     );
+  });
+
+  it("should prefer CLI arguments over config and defaults", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(CsvCommand, ["csv", "--output", "foo", "--known-issues", "bar", "./allure-results"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      output: "foo",
+      knownIssuesPath: "bar",
+    });
+  });
+
+  it("should set output to default and take other props from readConfig if no CLI arguments provided", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(CsvCommand, ["csv", "./allure-results"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      output: "allure.csv",
+      knownIssuesPath: undefined,
+    });
   });
 });

--- a/packages/cli/test/commands/dashboard.test.ts
+++ b/packages/cli/test/commands/dashboard.test.ts
@@ -1,5 +1,6 @@
 import { AllureReport, readConfig } from "@allurereport/core";
 import DashboardPlugin from "@allurereport/plugin-dashboard";
+import { run } from "clipanion";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { DashboardCommand } from "../../src/commands/dashboard.js";
 
@@ -89,5 +90,29 @@ describe("dashboard command", () => {
         ]),
       }),
     );
+  });
+
+  it("should prefer CLI arguments over config and defaults", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(DashboardCommand, ["dashboard", "--output", "foo", "--report-name", "bar", "./allure-results"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      output: "foo",
+      name: "bar",
+    });
+  });
+
+  it("should not overwrite readConfig values if no CLI arguments provided", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+
+    await run(DashboardCommand, ["dashboard", "./allure-results"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      output: undefined,
+      name: undefined,
+    });
   });
 });

--- a/packages/cli/test/commands/open.test.ts
+++ b/packages/cli/test/commands/open.test.ts
@@ -1,5 +1,6 @@
 import { readConfig } from "@allurereport/core";
 import { serve } from "@allurereport/static-server";
+import { run } from "clipanion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OpenCommand } from "../../src/commands/open.js";
 
@@ -50,7 +51,7 @@ describe("open command", () => {
     await command.execute();
 
     expect(readConfig).toHaveBeenCalledTimes(1);
-    expect(readConfig).toHaveBeenCalledWith(fixtures.cwd, undefined, { output: "./allure-report" });
+    expect(readConfig).toHaveBeenCalledWith(fixtures.cwd, undefined, { output: undefined });
     expect(serve).toHaveBeenCalledTimes(1);
     expect(serve).toHaveBeenCalledWith({
       port: undefined,
@@ -79,6 +80,24 @@ describe("open command", () => {
       servePath: "allure-report",
       live: true,
       open: true,
+    });
+  });
+
+  it("should prefer CLI arguments over config and defaults", async () => {
+    await run(OpenCommand, ["open", "foo"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(undefined, undefined, {
+      output: "foo",
+    });
+  });
+
+  it("should not overwrite readConfig values if no CLI arguments provided", async () => {
+    await run(OpenCommand, ["open"]);
+
+    expect(readConfig).toHaveBeenCalledTimes(1);
+    expect(readConfig).toHaveBeenCalledWith(undefined, undefined, {
+      output: undefined,
     });
   });
 });


### PR DESCRIPTION
Many Allure 3 commands take CLI arguments that have configuration counterparts. Currently, there are many cases when, if such an argument is not provided, its config counterpart is ignored, and a default value is used instead.

The PR fixes the commands to properly use values from the configuration file.

Extra changes:

  - fix consistency issue with quality-gate tests
  - fix eslint issues in quality-gate tests

Fixes #388