### PR TITLE
Fix the invalid use of results directory input by watch

### DIFF
--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -37,7 +37,7 @@ export class WatchCommand extends Command {
   });
 
   output = Option.String("--output,-o", {
-    description: "The output file name, allure.csv by default. Accepts absolute paths (default: ./allure-report)",
+    description: "The output directory name. Absolute paths are accepted as well (default: allure-report)",
   });
 
   reportName = Option.String("--report-name,--name", {
@@ -112,7 +112,7 @@ export class WatchCommand extends Command {
 
     await allureReport.start();
 
-    const input = resolve(this.resultsDir[0]);
+    const input = resolve(this.resultsDir);
     const { abort } = newFilesInDirectoryWatcher(input, async (path) => {
       await allureReport.readResult(new PathResultFile(path));
     });


### PR DESCRIPTION
`allure watch` takes the first character from `resutlsDir` and uses it as the input directory:

https://github.com/allure-framework/allure3/blob/7e6eaefaeaf174a547010ca5e8e44e7144577a93/packages/cli/src/commands/watch.ts#L115

The PR fixes this issue.

Additionally, the PR fixes the incorrect description of the `--output` CLI argument of `watch`.