### PR TITLE
Awesome: use a link's name as the anchor's text if provided

### DIFF
--- a/packages/e2e/test/allure-awesome/test/testResult.test.ts
+++ b/packages/e2e/test/allure-awesome/test/testResult.test.ts
@@ -33,6 +33,15 @@ test.beforeAll(async () => {
         stage: Stage.FINISHED,
         start: now,
         stop: now + 1000,
+        links: [
+          {
+            url: "https://allurereport.org/",
+            name: "Homepage",
+          },
+          {
+            url: "https://allurereport.org/docs/",
+          },
+        ],
       },
       {
         name: "1 sample failed test",
@@ -155,6 +164,33 @@ test.describe("allure-awesome", () => {
       await expect(testResultPage.errorTraceLocator).not.toBeVisible();
       await testResultPage.errorMessageLocator.click();
       await expect(testResultPage.errorTraceLocator).toHaveText("broken test trace");
+    });
+
+    test("has a collapsable links section with links", async () => {
+      const homepageLink = testResultPage.getLink(0);
+      const docsLink = testResultPage.getLink(1);
+
+      await treePage.clickLeafByTitle("0 sample passed test");
+      await expect(testResultPage.linksLocator).toBeVisible();
+
+      // Collapse
+      await testResultPage.toggleLinkSection();
+
+      await expect(homepageLink.locator).not.toBeVisible();
+      await expect(docsLink.locator).not.toBeVisible();
+
+      // Expand
+      await testResultPage.toggleLinkSection();
+
+      await expect(homepageLink.locator).toBeVisible();
+      await expect(homepageLink.iconLocator).toBeVisible();
+      await expect(homepageLink.anchorLocator).toHaveAttribute("href", "https://allurereport.org/");
+      await expect(homepageLink.anchorLocator).toHaveText("Homepage");
+
+      await expect(docsLink.locator).toBeVisible();
+      await expect(docsLink.iconLocator).toBeVisible();
+      await expect(docsLink.anchorLocator).toHaveAttribute("href", "https://allurereport.org/docs/");
+      await expect(docsLink.anchorLocator).toHaveText("https://allurereport.org/docs/");
     });
   });
 });

--- a/packages/e2e/test/pageObjects/LinkFixture.ts
+++ b/packages/e2e/test/pageObjects/LinkFixture.ts
@@ -1,0 +1,33 @@
+import type { TestResultPage } from "./TestResult.js";
+import { PageObject } from "./pageObject.js";
+
+/**
+ * A test fixture to validate test links.
+ */
+export class LinkFixture extends PageObject {
+  /**
+   * A locator for the link.
+   */
+  readonly locator = this.testResultPage.linksLocator.getByTestId("test-result-meta-link").nth(this.linkIndex);
+
+  /**
+   * A locator for the link's icon.
+   */
+  readonly iconLocator = this.locator.locator("svg");
+
+  /**
+   * A locator for the link's anchor (<a> tag).
+   */
+  readonly anchorLocator = this.locator.getByRole("link");
+
+  constructor(
+    readonly testResultPage: TestResultPage,
+    readonly linkIndex: number,
+  ) {
+    super(testResultPage.page);
+  }
+
+  async screenshot() {
+    return await this.locator.screenshot();
+  }
+}

--- a/packages/e2e/test/pageObjects/TestResult.ts
+++ b/packages/e2e/test/pageObjects/TestResult.ts
@@ -1,5 +1,6 @@
 import { type Locator, type Page } from "@playwright/test";
 import { CommonPage } from "./Common.js";
+import { LinkFixture } from "./LinkFixture.js";
 import { RetryItemFixture } from "./RetryItem.js";
 import { StepResultFixture } from "./StepResult.js";
 
@@ -39,6 +40,8 @@ export class TestResultPage extends CommonPage {
   retriesItemLocator: Locator;
   prevStatusLocator: Locator;
 
+  linksLocator: Locator;
+
   constructor(readonly page: Page) {
     super(page);
 
@@ -76,6 +79,8 @@ export class TestResultPage extends CommonPage {
     this.historyItemLocator = page.getByTestId("test-result-history-item");
     this.retriesItemLocator = page.getByTestId("test-result-retries-item");
     this.prevStatusLocator = page.getByTestId("test-result-prev-status");
+
+    this.linksLocator = page.getByTestId("test-result-meta-links");
   }
 
   tabById(id: string) {
@@ -97,6 +102,13 @@ export class TestResultPage extends CommonPage {
    */
   getRetry(index: number) {
     return new RetryItemFixture(this, index);
+  }
+
+  /**
+   * Returns a fixture for a link by its index.
+   */
+  getLink(index: number) {
+    return new LinkFixture(this, index);
   }
 
   get envTabLocator() {
@@ -137,5 +149,9 @@ export class TestResultPage extends CommonPage {
     });
 
     await locator.click();
+  }
+
+  async toggleLinkSection() {
+    this.linksLocator.getByRole("button").click();
   }
 }

--- a/packages/web-awesome/src/components/TestResult/TrLinks/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrLinks/index.tsx
@@ -22,13 +22,13 @@ const linksIconMap: Record<string, string> = {
 const TrLink: FunctionalComponent<{
   link: TrLinkProps;
 }> = ({ link }) => {
-  const { url, type } = link;
+  const { url, name, type } = link;
 
   return (
-    <div className={styles["test-result-link"]}>
+    <div className={styles["test-result-link"]} data-testid="test-result-meta-link">
       <SvgIcon id={linksIconMap[type] ?? allureIcons.lineGeneralLink1} />
       <Text tag={"a"} href={url} target={"_blank"} size={"m"} className={styles["test-result-link-text"]}>
-        {url}
+        {name || url}
       </Text>
     </div>
   );
@@ -46,7 +46,7 @@ export const TrLinks: FunctionalComponent<TrLinksProps> = ({ links }) => {
   });
 
   return (
-    <div className={styles["test-result-links"]}>
+    <div className={styles["test-result-links"]} data-testid="test-result-meta-links">
       <div className={styles["test-result-links-wrapper"]}>
         <MetadataButton isOpened={isOpened} setIsOpen={setIsOpen} counter={links.length} title={t("links")} />
         {isOpened && <div className={styles["test-result-links-list"]}>{linkMap}</div>}


### PR DESCRIPTION
Fix #452.