### PR TITLE
feat: add Arabic translation and RTL support

### DIFF
--- a/packages/web-allure2/src/translations/ar.json
+++ b/packages/web-allure2/src/translations/ar.json
@@ -1,0 +1,222 @@
+{
+  "chart": {
+    "duration": {
+      "empty": "لا يوجد شيء لعرضه",
+      "name": "المدة"
+    },
+    "severity": {
+      "name": "الخطورة"
+    },
+    "status": {
+      "name": "الحالة"
+    },
+    "trend": {
+      "empty": "لا يوجد شيء لعرضه"
+    }
+  },
+  "component": {
+    "markToggle": {
+      "hideCases": "إخفاء نتائج اختبار {{mark}}",
+      "showCases": "عرض نتائج اختبار {{mark}}"
+    },
+    "statusToggle": {
+      "hideCases": "إخفاء نتائج الاختبار بحالة {{status}}",
+      "showCases": "عرض نتائج الاختبار بحالة {{status}}"
+    },
+    "tree": {
+      "download": "تحميل CSV",
+      "empty": "لا توجد عناصر",
+      "filter": "الحالة",
+      "filter-marks": "العلامات",
+      "filtered": {
+        "shown": "{{count}} معروض",
+        "total": "{{count}} نتيجة اختبار",
+        "total_plural": "{{count}} نتائج اختبار"
+      },
+      "groups": "تبديل معلومات المجموعات",
+      "time": {
+        "max": {
+          "name": "الأقصى",
+          "tooltip": "أطول مدة اختبار"
+        },
+        "sum": {
+          "name": "المجموع",
+          "tooltip": "مجموع مدد جميع الاختبارات"
+        },
+        "total": {
+          "name": "الإجمالي",
+          "tooltip": "المدة من بداية أول اختبار إلى نهاية آخر اختبار"
+        }
+      },
+      "unknown": "<فارغ>"
+    },
+    "widgetStatus": {
+      "showAll": "عرض الكل",
+      "total": "{{count}} عنصر إجمالاً",
+      "total_plural": "{{count}} عناصر إجمالاً"
+    }
+  },
+  "controls": {
+    "backto": "العودة إلى",
+    "clipboard": "نسخ إلى الحافظة",
+    "clipboardError": "لا يمكن نسخ القيمة إلى الحافظة. يبدو أن هذه الميزة غير مدعومة في متصفحك",
+    "clipboardSuccess": "تم النسخ بنجاح",
+    "collapse": "طي",
+    "expand": "توسيع",
+    "fullscreen": "ملء الشاشة",
+    "language": "تغيير اللغة"
+  },
+  "errors": {
+    "missedAttachment": "المرفق غير موجود",
+    "notFound": "غير موجود"
+  },
+  "marks": {
+    "flaky": "متقلب",
+    "newBroken": "معطل جديد",
+    "newFailed": "فاشل جديد",
+    "newPassed": "ناجح جديد",
+    "retriesStatusChange": "تغيرت الحالة بعد الإعادة"
+  },
+  "sorter": {
+    "duration": "المدة",
+    "name": "الاسم",
+    "order": "الترتيب",
+    "status": "الحالة"
+  },
+  "status": {
+    "broken": "معطل",
+    "failed": "فاشل",
+    "passed": "ناجح",
+    "skipped": "تم تخطيه",
+    "unknown": "غير معروف"
+  },
+  "tab": {
+    "categories": {
+      "name": "الفئات"
+    },
+    "graph": {
+      "name": "الرسوم البيانية"
+    },
+    "overview": {
+      "name": "نظرة عامة"
+    },
+    "suites": {
+      "name": "مجموعات الاختبار"
+    },
+    "timeline": {
+      "name": "الخط الزمني",
+      "selected": "تم تحديد {{count}} اختبار ({{percent}}%) بمدة أعلى من {{duration}}",
+      "selected_plural": "تم تحديد {{count}} اختبارات ({{percent}}%) بمدة أعلى من {{duration}}"
+    }
+  },
+  "testResult": {
+    "categories": {
+      "name": "الفئات"
+    },
+    "description": {
+      "name": "الوصف"
+    },
+    "duration": {
+      "name": "المدة"
+    },
+    "execution": {
+      "body": "جسم الاختبار",
+      "downloadAttachment": {
+        "tooltip": "فتح المرفق في علامة تبويب جديدة"
+      },
+      "name": "التنفيذ",
+      "setup": "الإعداد",
+      "teardown": "التفكيك"
+    },
+    "history": {
+      "empty": "لا تتوفر معلومات عن السجل.",
+      "name": "السجل",
+      "statistic": "{{passed}} من {{total}}",
+      "successRate": "معدل النجاح",
+      "time": "{{date}} في {{time}}"
+    },
+    "links": {
+      "name": "الروابط"
+    },
+    "overview": {
+      "name": "نظرة عامة"
+    },
+    "owner": {
+      "name": "المالك"
+    },
+    "parameters": {
+      "name": "المعاملات"
+    },
+    "retries": {
+      "empty": "لا تتوفر معلومات عن إعادات الاختبار",
+      "name": "الإعادات",
+      "time": "{{date}} في {{time}}"
+    },
+    "severity": {
+      "name": "الخطورة",
+      "blocker": "حاجب",
+      "critical": "حرج",
+      "normal": "عادي",
+      "minor": "ثانوي",
+      "trivial": "بسيط"
+    },
+    "stats": {
+      "count": {
+        "attachments": "{{count}} مرفق",
+        "attachments_plural": "{{count}} مرفقات",
+        "parameters": "{{count}} معامل",
+        "parameters_plural": "{{count}} معاملات",
+        "steps": "{{count}} خطوة فرعية",
+        "steps_plural": "{{count}} خطوات فرعية"
+      }
+    },
+    "status": {
+      "empty": "تفاصيل الحالة فارغة",
+      "trace": "عرض التتبع"
+    },
+    "tags": {
+      "name": "الوسوم"
+    }
+  },
+  "widget": {
+    "categories": {
+      "name": "الفئات"
+    },
+    "categoriesTrend": {
+      "name": "اتجاه الفئات"
+    },
+    "durationTrend": {
+      "name": "اتجاه المدة"
+    },
+    "environment": {
+      "empty": "لا توجد متغيرات بيئة",
+      "name": "البيئة",
+      "showAll": "عرض الكل"
+    },
+    "executors": {
+      "empty": "لا تتوفر معلومات عن منفذي الاختبارات",
+      "name": "المنفذون",
+      "unknown": "غير معروف"
+    },
+    "launches": {
+      "empty": "لا تتوفر معلومات عن عمليات الإطلاق",
+      "name": "عمليات الإطلاق"
+    },
+    "retryTrend": {
+      "name": "اتجاه الإعادات"
+    },
+    "suites": {
+      "name": "مجموعات الاختبار"
+    },
+    "summary": {
+      "aggregatedName": "تقرير مُجمَّع",
+      "launches": "عملية إطلاق",
+      "launches_plural": "عمليات إطلاق",
+      "testResults": "حالة اختبار",
+      "testResults_plural": "حالات اختبار"
+    },
+    "trend": {
+      "name": "الاتجاه"
+    }
+  }
+}

--- a/packages/web-allure2/src/utils/translation.js
+++ b/packages/web-allure2/src/utils/translation.js
@@ -3,6 +3,7 @@ import gtag from "./gtag.js";
 import settings from "./settings.js";
 
 export const LANGUAGES = [
+  { id: "ar", title: "العربية" },
   { id: "az", title: "Azərbaycanca" },
   { id: "br", title: "Brazil" },
   { id: "de", title: "Deutsch" },

--- a/packages/web-awesome/src/locales/ar.json
+++ b/packages/web-awesome/src/locales/ar.json
@@ -1,0 +1,427 @@
+{
+  "statuses": {
+    "passed": "ناجح",
+    "failed": "فاشل",
+    "broken": "معطل",
+    "skipped": "تم تخطيه",
+    "unknown": "غير معروف",
+    "total": "الإجمالي",
+    "flakyTests": "متقلب",
+    "newTests": "جديد",
+    "retryTests": "إعادة"
+  },
+  "testSummary": {
+    "total": "الإجمالي",
+    "flaky": "اختبارات متقلبة",
+    "retries": "اختبارات مُعادة",
+    "new": "اختبارات جديدة"
+  },
+  "tabs": {
+    "total": "الكل",
+    "results": "النتائج",
+    "globalAttachments": "المرفقات العامة",
+    "globalErrors": "الأخطاء العامة",
+    "qualityGates": "بوابات الجودة",
+    "categories": "الفئات"
+  },
+  "search": {
+    "search": "بحث",
+    "search-placeholder": "الاسم أو المُعرِّف"
+  },
+  "filters": {
+    "flaky": "متقلب",
+    "nonFlaky": "غير متقلب",
+    "retry": "إعادة",
+    "new": "جديد",
+    "fixed": "تم إصلاحه",
+    "regressed": "تراجع",
+    "malfunctioned": "خلل",
+    "transition": "انتقال",
+    "status": "الحالة",
+    "severity": "الخطورة",
+    "owner": "المالك",
+    "layer": "الطبقة",
+    "tags": "الوسوم",
+    "categories": "الفئات",
+    "goto_filter": "انتقل إلى الفلتر",
+    "errors": {
+      "max_values_one": "يتم استخدام أول {{count}} قيمة فقط للتصفية.\nيتم تجاهل القيم الإضافية",
+      "max_values_other": "يتم استخدام أول {{count}} قيم فقط للتصفية.\nيتم تجاهل القيم الإضافية"
+    },
+    "description": {
+      "flaky": "عرض الاختبارات غير المستقرة",
+      "retry": "عرض نتائج الاختبارات التي تمت إعادة تشغيلها",
+      "new": "عرض نتائج الاختبارات التي تظهر لأول مرة في هذا التقرير",
+      "fixed": "عرض الاختبارات الناجحة الآن والتي كانت \"فاشلة\" أو \"معطلة\" في تقرير سابق",
+      "regressed": "عرض نتائج الاختبارات التي تغيرت إلى حالة \"فاشل\" من حالة \"ناجح\" أو \"معطل\"",
+      "malfunctioned": "عرض نتائج الاختبارات التي تغيرت إلى حالة \"معطل\" من حالة \"ناجح\" أو \"فاشل\"",
+      "tags": "عرض نتائج الاختبارات التي تحتوي على الوسوم المحددة",
+      "categories": "عرض نتائج الاختبارات التي تحتوي على الفئات المحددة"
+    }
+  },
+  "sort-by": {
+    "sort-by-text": "ترتيب حسب:",
+    "sort-by-category": "ترتيب حسب",
+    "direction-category": "الاتجاه"
+  },
+  "sort-by.values": {
+    "order": "الترتيب",
+    "alphabet": "الأبجدية",
+    "duration": "المدة",
+    "status": "الحالة"
+  },
+  "sort-by.directions": {
+    "order-desc": "الأحدث – الأقدم",
+    "order-asc": "الأقدم – الأحدث",
+    "order-asc-short": "الأقدم",
+    "order-desc-short": "الأحدث",
+    "alphabet-asc": "أ – ي",
+    "alphabet-desc": "ي – أ",
+    "alphabet-asc-short": "أ – ي",
+    "alphabet-desc-short": "ي – أ",
+    "duration-asc": "1 – 9",
+    "duration-desc": "9 – 1",
+    "duration-asc-short": "1 – 9",
+    "duration-desc-short": "9 – 1",
+    "status-asc": "كما في قائمة الفلتر",
+    "status-desc": "معكوس",
+    "status-asc-short": "عادي",
+    "status-desc-short": "معكوس"
+  },
+  "empty": {
+    "no-results": "لا توجد نتائج",
+    "no-value": "لا توجد قيمة",
+    "no-value-for": "لا توجد قيمة: {{entity}}",
+    "no-transition": "لا يوجد انتقال",
+    "no-layer": "لا توجد طبقة",
+    "no-owner": "لا يوجد مالك",
+    "no-severity": "لا توجد خطورة",
+    "no-status": "لا توجد حالة",
+    "no-environment": "لا توجد بيئة",
+    "no-flaky": "لا يوجد متقلب",
+    "empty-value": "فارغ",
+    "no-tests-found": "لم يتم العثور على نتائج",
+    "no-message-provided": "لم يتم تقديم رسالة",
+    "clear-filters": "مسح الفلاتر",
+    "no-attachments-results": "لا تتوفر معلومات عن المرفقات",
+    "no-global-errors-results": "لا تتوفر معلومات عن الأخطاء العامة",
+    "no-quality-gate-results": "لا تتوفر نتائج بوابات الجودة",
+    "no-history-results": "لا تتوفر معلومات عن السجل",
+    "no-retries-results": "لا تتوفر معلومات عن الإعادات",
+    "no-test-steps-results": "لا تتوفر معلومات عن خطوات الاختبار",
+    "no-test-case-results": "لا توجد نتائج حالات اختبار",
+    "no-environments-results": "لا تتوفر معلومات عن البيئات",
+    "no-categories-results": "لا تتوفر نتائج الفئات"
+  },
+  "severity": {
+    "blocker": "حاجب",
+    "critical": "حرج",
+    "normal": "عادي",
+    "minor": "ثانوي",
+    "trivial": "بسيط"
+  },
+  "execution": {
+    "name": "التنفيذ",
+    "body": "جسم الاختبار",
+    "setup": "الإعداد",
+    "teardown": "التفكيك"
+  },
+  "environments": {
+    "environment_one": "بيئة",
+    "environment_other": "بيئات",
+    "all": "الكل"
+  },
+  "ui": {
+    "labels": "التصنيفات",
+    "metadata": "البيانات الوصفية",
+    "parameters": "المعاملات",
+    "category": "الفئة",
+    "description": "الوصف",
+    "links": "الروابط",
+    "overview": "نظرة عامة",
+    "history": "السجل",
+    "attachments": "المرفقات",
+    "retries": "الإعادات",
+    "environments": "البيئات",
+    "error": "خطأ",
+    "goToStep": "انتقل إلى الخطوة",
+    "showLess": "عرض أقل",
+    "showMore": "عرض المزيد",
+    "copy": "نسخ",
+    "copy-email": "نسخ البريد الإلكتروني",
+    "attempt": "المحاولة {{attempt}} من {{total}}",
+    "at": "في",
+    "variables": "المتغيرات",
+    "openPwTrace": "فتح تتبع Playwright",
+    "finishedAtOriginal": "{{formattedCreatedAt}}، برمز خروج {{original}}",
+    "finishedAtBoth": "{{formattedCreatedAt}}، برمز خروج {{actual}} (الأصلي {{original}})"
+  },
+  "controls": {
+    "newTabAttachment": "فتح المرفق في علامة تبويب جديدة",
+    "nextTR": "نتيجة الاختبار التالية",
+    "prevTR": "نتيجة الاختبار السابقة",
+    "downloadAttachment": "تحميل المرفق",
+    "backto": "العودة إلى",
+    "clipboard": "نسخ إلى الحافظة",
+    "clipboardError": "لا يمكن نسخ القيمة إلى الحافظة. يبدو أن هذه الميزة غير مدعومة في متصفحك",
+    "clipboardSuccess": "تم النسخ بنجاح",
+    "collapse": "طي",
+    "expand": "توسيع",
+    "fullscreen": "ملء الشاشة",
+    "language": "تغيير اللغة",
+    "openInNewTab": "فتح في علامة تبويب جديدة",
+    "openPreview": "فتح المعاينة",
+    "noSelectedTR": "لم يتم تحديد نتيجة اختبار",
+    "comparison": "المقارنة",
+    "showDiff": "عرض الاختلاف",
+    "viewMode": "وضع العرض",
+    "unified": "موحد",
+    "side-by-side": "جنباً إلى جنب",
+    "compareBy": "مقارنة حسب",
+    "chars": "أحرف",
+    "words": "كلمات",
+    "lines": "أسطر",
+    "actual": "الفعلي",
+    "expected": "المتوقع"
+  },
+  "errors": {
+    "missedAttachment": "المرفق غير موجود"
+  },
+  "sections": {
+    "report": "التقرير",
+    "charts": "الرسوم البيانية",
+    "timeline": "الخط الزمني"
+  },
+  "timeline": {
+    "empty": "لا توجد بيانات",
+    "empty_host": "لا توجد بيانات لـ {{ host }}",
+    "selected_one": "تم تحديد {{ count }} اختبار ({{ percentage }}%) بمدة أكثر من {{ minDuration }} وأقل من {{ maxDuration }}",
+    "selected_other": "تم تحديد {{ count }} اختبارات ({{ percentage }}%) بمدة أكثر من {{ minDuration }} وأقل من {{ maxDuration }}",
+    "host": "المضيف: {{ host }}"
+  },
+  "charts": {
+    "trend": {
+      "title": "مخطط الاتجاه: {{type}}",
+      "type": {
+        "status": "الحالة",
+        "severity": "الخطورة"
+      }
+    },
+    "currentStatus": {
+      "title": "الحالة الحالية",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "percentage": "{{percentage}}%",
+      "of": "من {{total}}",
+      "total": "الإجمالي",
+      "tests": {
+        "new_zero": "لا توجد اختبارات جديدة",
+        "new_one": "{{count}} اختبار جديد",
+        "new_other": "{{count}} اختبارات جديدة",
+        "flaky_zero": "لا توجد اختبارات متقلبة",
+        "flaky_one": "{{count}} اختبار متقلب",
+        "flaky_other": "{{count}} اختبارات متقلبة",
+        "retries_zero": "لا توجد اختبارات مُعادة",
+        "retries_one": "{{count}} اختبار مُعاد",
+        "retries_other": "{{count}} اختبارات مُعادة"
+      }
+    },
+    "statusDynamics": {
+      "title": "ديناميكيات الحالة",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusTransitions": {
+      "title": "انتقالات الحالة",
+      "legend": {
+        "trend": "معدل الإصلاح"
+      },
+      "transitions": {
+        "new": "$t(transitions:new, capitalize)",
+        "fixed": "$t(transitions:fixed, capitalize)",
+        "regressed": "$t(transitions:regressed, capitalize)",
+        "malfunctioned": "$t(transitions:malfunctioned, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "durations": {
+      "title": "مدد حسب {{groupBy}} - مخطط بياني",
+      "title_none": "مخطط بياني للمدد",
+      "no-results": "$t(empty:no-results)",
+      "groupBy": {
+        "none": "لا شيء",
+        "layer": "الطبقة"
+      },
+      "ticks": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "tooltips": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "legend": {
+        "value": "{{value}}",
+        "total": "عدد الاختبارات"
+      }
+    },
+    "stabilityDistribution": {
+      "title": "توزيع الاستقرار",
+      "no-results": "$t(empty:no-results)",
+      "legend": {
+        "stabilityRate": "معدل الاستقرار"
+      }
+    },
+    "testBaseGrowthDynamics": {
+      "title": "ديناميكيات نمو قاعدة الاختبارات",
+      "status": {
+        "newpassed": "جديد $t(statuses:passed)",
+        "newfailed": "جديد $t(statuses:failed)",
+        "newbroken": "جديد $t(statuses:broken)",
+        "newskipped": "جديد $t(statuses:skipped)",
+        "newunknown": "جديد $t(statuses:unknown)",
+        "removedpassed": "محذوف $t(statuses:passed)",
+        "removedfailed": "محذوف $t(statuses:failed)",
+        "removedbroken": "محذوف $t(statuses:broken)",
+        "removedskipped": "محذوف $t(statuses:skipped)",
+        "removedunknown": "محذوف $t(statuses:unknown)"
+      },
+      "legend": {
+        "trend": "اتجاه النمو"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusAgePyramid": {
+      "title": "هرم عمر الحالة",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "trSeverities": {
+      "title": "نتائج الاختبارات حسب الخطورة",
+      "no-results": "$t(empty:no-results)",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "severity": {
+        "blocker": "$t(severity:blocker, capitalize)",
+        "critical": "$t(severity:critical, capitalize)",
+        "normal": "$t(severity:normal, capitalize)",
+        "minor": "$t(severity:minor, capitalize)",
+        "trivial": "$t(severity:trivial, capitalize)",
+        "unset": "بدون خطورة"
+      }
+    },
+    "durationDynamics": {
+      "title": "ديناميكيات المدة",
+      "durations": {
+        "sequential": "المدة التسلسلية",
+        "duration": "مدة الاختبار",
+        "speedup": "التسريع"
+      },
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      },
+      "legend": {
+        "duration": "{{duration, format_duration}}",
+        "speedup": "{{speedup}}x"
+      }
+    }
+  },
+  "transitions": {
+    "description": {
+      "new": "أول ظهور لنتيجة الاختبار هذه في التقرير",
+      "fixed": "اختبار كان \"فاشلاً\" أو \"معطلاً\" سابقاً وأصبح الآن \"ناجحاً\"",
+      "regressed": "اختبار كان \"ناجحاً\" أو \"معطلاً\" سابقاً وأصبح الآن \"فاشلاً\"",
+      "malfunctioned": "اختبار كان \"ناجحاً\" أو \"فاشلاً\" سابقاً وأصبح الآن \"معطلاً\"",
+      "retries": "{{count}} إعادات",
+      "flaky": "غير متسق عبر التشغيلات"
+    },
+    "new": "جديد",
+    "fixed": "تم إصلاحه",
+    "regressed": "تراجع",
+    "malfunctioned": "خلل"
+  },
+  "trHistory": {
+    "unknown-date": "تاريخ غير معروف"
+  },
+  "attachments": {
+    "imageDiff": {
+      "mode": {
+        "diff": "الفرق",
+        "actual": "الفعلي",
+        "expected": "المتوقع",
+        "side-by-side": "جنباً إلى جنب",
+        "overlay": "تراكب"
+      },
+      "empty": {
+        "failed-to-load": "فشل تحميل فرق الصورة"
+      },
+      "image": {
+        "diff": "الفرق",
+        "actual": "الفعلي",
+        "expected": "المتوقع"
+      }
+    }
+  }
+}

--- a/packages/web-awesome/src/stores/locale.ts
+++ b/packages/web-awesome/src/stores/locale.ts
@@ -157,4 +157,5 @@ export const setLocale = async (locale: LangLocale) => {
   await i18next.changeLanguage(locale as string);
   localStorage.setItem("currentLocale", locale as string);
   currentLocale.value = locale;
+  document.documentElement.dir = ["ar", "he", "fa"].includes(locale) ? "rtl" : "ltr";
 };

--- a/packages/web-classic/src/stores/locale.ts
+++ b/packages/web-classic/src/stores/locale.ts
@@ -82,4 +82,5 @@ export const setLocale = async (locale: LangLocale) => {
   await i18next.changeLanguage(locale);
   localStorage.setItem("currentLocale", locale);
   currentLocale.value = locale;
+  document.documentElement.dir = ["ar", "he", "fa"].includes(locale) ? "rtl" : "ltr";
 };

--- a/packages/web-classic/src/translations/ar.json
+++ b/packages/web-classic/src/translations/ar.json
@@ -1,0 +1,137 @@
+{
+  "statuses": {
+    "passed": "ناجح",
+    "failed": "فاشل",
+    "broken": "معطل",
+    "skipped": "تم تخطيه",
+    "unknown": "غير معروف",
+    "total": "الإجمالي",
+    "flakyTests": "متقلب",
+    "newTests": "جديد",
+    "retryTests": "إعادة"
+  },
+  "testSummary": {
+    "all": "كل الاختبارات",
+    "flaky": "اختبار متقلب",
+    "retry": "اختبار مُعاد",
+    "new": "اختبار جديد"
+  },
+  "tabs": {
+    "total": "الكل"
+  },
+  "search": {
+    "search": "بحث",
+    "search-placeholder": "الاسم أو المُعرِّف"
+  },
+  "filters": {
+    "more-filters": "فلاتر إضافية",
+    "enable-filter": "تفعيل فلتر \"{{filter}}\"",
+    "flaky": "متقلب",
+    "retry": "إعادة",
+    "new": "جديد"
+  },
+  "sort-by": {
+    "sort-by-text": "ترتيب حسب:",
+    "sort-by-category": "ترتيب حسب",
+    "direction-category": "الاتجاه"
+  },
+  "sort-by.values": {
+    "order": "الترتيب",
+    "alphabet": "الأبجدية",
+    "duration": "المدة",
+    "status": "الحالة"
+  },
+  "sort-by.directions": {
+    "order-desc": "الأحدث – الأقدم",
+    "order-asc": "الأقدم – الأحدث",
+    "order-asc-short": "الأقدم",
+    "order-desc-short": "الأحدث",
+    "alphabet-asc": "أ – ي",
+    "alphabet-desc": "ي – أ",
+    "alphabet-asc-short": "أ – ي",
+    "alphabet-desc-short": "ي – أ",
+    "duration-asc": "1 – 9",
+    "duration-desc": "9 – 1",
+    "duration-asc-short": "1 – 9",
+    "duration-desc-short": "9 – 1",
+    "status-asc": "كما في قائمة الفلتر",
+    "status-desc": "معكوس",
+    "status-asc-short": "عادي",
+    "status-desc-short": "معكوس"
+  },
+  "empty": {
+    "no-results": "لا توجد نتائج",
+    "no-tests-found": "لم يتم العثور على نتائج",
+    "no-message-provided": "لم يتم تقديم رسالة",
+    "clear-filters": "مسح الفلاتر",
+    "no-attachments-results": "لا تتوفر معلومات عن المرفقات",
+    "no-history-results": "لا تتوفر معلومات عن السجل",
+    "no-retries-results": "لا تتوفر معلومات عن الإعادات"
+  },
+  "severity": {
+    "blocker": "حاجب",
+    "critical": "حرج",
+    "normal": "عادي",
+    "minor": "ثانوي",
+    "trivial": "بسيط"
+  },
+  "execution": {
+    "name": "التنفيذ",
+    "body": "جسم الاختبار",
+    "setup": "الإعداد",
+    "teardown": "التفكيك"
+  },
+  "ui": {
+    "labels": "التصنيفات",
+    "metadata": "البيانات الوصفية",
+    "parameters": "المعاملات",
+    "description": "الوصف",
+    "links": "الروابط",
+    "overview": "نظرة عامة",
+    "history": "السجل",
+    "attachments": "المرفقات",
+    "retries": "الإعادات",
+    "error": "خطأ",
+    "goToStep": "انتقل إلى الخطوة",
+    "showLess": "عرض أقل",
+    "showMore": "عرض المزيد",
+    "copy": "نسخ",
+    "attempt": "المحاولة {{attempt}} من {{total}}",
+    "at": "في"
+  },
+  "controls": {
+    "newTabAttachment": "فتح المرفق في علامة تبويب جديدة",
+    "nextTR": "نتيجة الاختبار التالية",
+    "prevTR": "نتيجة الاختبار السابقة",
+    "downloadAttachment": "تحميل المرفق",
+    "backto": "العودة إلى",
+    "clipboard": "نسخ إلى الحافظة",
+    "clipboardError": "لا يمكن نسخ القيمة إلى الحافظة. يبدو أن هذه الميزة غير مدعومة في متصفحك",
+    "clipboardSuccess": "تم النسخ بنجاح",
+    "collapse": "طي",
+    "expand": "توسيع",
+    "fullscreen": "ملء الشاشة",
+    "language": "تغيير اللغة",
+    "openInNewTab": "فتح في علامة تبويب جديدة"
+  },
+  "errors": {
+    "missedAttachment": "المرفق غير موجود"
+  },
+  "nav": {
+    "overview": "نظرة عامة",
+    "behaviors": "السلوكيات",
+    "categories": "الفئات",
+    "graphs": "الرسوم البيانية",
+    "packages": "الحزم",
+    "suites": "مجموعات الاختبار",
+    "timeline": "الخط الزمني"
+  },
+  "charts": {
+    "trend": {
+      "title": "مخطط الاتجاه {{type}}"
+    },
+    "pie": {
+      "title": "معدل نجاح الاختبارات"
+    }
+  }
+}

--- a/packages/web-classic/src/translations/constants.ts
+++ b/packages/web-classic/src/translations/constants.ts
@@ -7,6 +7,7 @@ export const AVAILABLE_LOCALES = [
   "pt",
   "de",
   "am",
+  "ar",
   "az",
   "fr",
   "it",
@@ -71,6 +72,11 @@ export const LANG_LOCALE: Record<
     short: "Am",
     full: "Հայերեն",
     iso: "hy-AM",
+  },
+  "ar": {
+    short: "Ar",
+    full: "العربية",
+    iso: "ar-SA",
   },
   "az": {
     short: "Az",

--- a/packages/web-commons/src/i18n.ts
+++ b/packages/web-commons/src/i18n.ts
@@ -8,6 +8,7 @@ export const AVAILABLE_LOCALES = [
   "pt",
   "de",
   "hy",
+  "ar",
   "az",
   "fr",
   "it",
@@ -131,6 +132,11 @@ export const LANG_LOCALE: Record<
     short: "Hy",
     full: "Հայերեն",
     iso: "hy-AM",
+  },
+  "ar": {
+    short: "Ar",
+    full: "العربية",
+    iso: "ar-SA",
   },
   "az": {
     short: "Az",

--- a/packages/web-dashboard/src/locales/ar.json
+++ b/packages/web-dashboard/src/locales/ar.json
@@ -1,0 +1,227 @@
+{
+  "statuses": {
+    "passed": "ناجح",
+    "failed": "فاشل",
+    "broken": "معطل",
+    "skipped": "تم تخطيه",
+    "unknown": "غير معروف",
+    "total": "الإجمالي"
+  },
+  "empty": {
+    "no-results": "لا توجد نتائج",
+    "no-history-results": "لا تتوفر معلومات عن السجل"
+  },
+  "severity": {
+    "blocker": "حاجب",
+    "critical": "حرج",
+    "normal": "عادي",
+    "minor": "ثانوي",
+    "trivial": "بسيط"
+  },
+  "environments": {
+    "environment_one": "بيئة",
+    "environment_other": "بيئات",
+    "all": "الكل"
+  },
+  "charts": {
+    "trend": {
+      "title": "مخطط الاتجاه: {{type}}",
+      "type": {
+        "status": "الحالة",
+        "severity": "الخطورة"
+      }
+    },
+    "currentStatus": {
+      "title": "الحالة الحالية",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "percentage": "{{percentage}}%",
+      "of": "من {{total}}",
+      "total": "{{total}}",
+      "tests": {
+        "new_zero": "لا توجد اختبارات جديدة",
+        "new_one": "{{count}} اختبار جديد",
+        "new_other": "{{count}} اختبارات جديدة",
+        "flaky_zero": "لا توجد اختبارات متقلبة",
+        "flaky_one": "{{count}} اختبار متقلب",
+        "flaky_other": "{{count}} اختبارات متقلبة",
+        "retries_zero": "لا توجد اختبارات مُعادة",
+        "retries_one": "{{count}} اختبار مُعاد",
+        "retries_other": "{{count}} اختبارات مُعادة"
+      }
+    },
+    "statusDynamics": {
+      "title": "ديناميكيات الحالة",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusTransitions": {
+      "title": "انتقالات الحالة",
+      "legend": {
+        "trend": "معدل الإصلاح"
+      },
+      "transitions": {
+        "new": "$t(transitions:new, capitalize)",
+        "fixed": "$t(transitions:fixed, capitalize)",
+        "regressed": "$t(transitions:regressed, capitalize)",
+        "malfunctioned": "$t(transitions:malfunctioned, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "durations": {
+      "title": "مدد حسب {{groupBy}} - مخطط بياني",
+      "title_none": "مخطط بياني للمدد",
+      "no-results": "$t(empty:no-results)",
+      "groupBy": {
+        "none": "لا شيء",
+        "layer": "الطبقة"
+      },
+      "ticks": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "tooltips": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "legend": {
+        "value": "{{value}}",
+        "total": "عدد الاختبارات"
+      }
+    },
+    "stabilityDistribution": {
+      "title": "توزيع الاستقرار",
+      "no-results": "$t(empty:no-results)",
+      "legend": {
+        "stabilityRate": "معدل الاستقرار"
+      }
+    },
+    "testBaseGrowthDynamics": {
+      "title": "ديناميكيات نمو قاعدة الاختبارات",
+      "status": {
+        "newpassed": "جديد $t(statuses:passed)",
+        "newfailed": "جديد $t(statuses:failed)",
+        "newbroken": "جديد $t(statuses:broken)",
+        "newskipped": "جديد $t(statuses:skipped)",
+        "newunknown": "جديد $t(statuses:unknown)",
+        "removedpassed": "محذوف $t(statuses:passed)",
+        "removedfailed": "محذوف $t(statuses:failed)",
+        "removedbroken": "محذوف $t(statuses:broken)",
+        "removedskipped": "محذوف $t(statuses:skipped)",
+        "removedunknown": "محذوف $t(statuses:unknown)"
+      },
+      "legend": {
+        "trend": "اتجاه النمو"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusAgePyramid": {
+      "title": "هرم عمر الحالة",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "trSeverities": {
+      "title": "نتائج الاختبارات حسب الخطورة",
+      "no-results": "$t(empty:no-results)",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "severity": {
+        "blocker": "$t(severity:blocker, capitalize)",
+        "critical": "$t(severity:critical, capitalize)",
+        "normal": "$t(severity:normal, capitalize)",
+        "minor": "$t(severity:minor, capitalize)",
+        "trivial": "$t(severity:trivial, capitalize)",
+        "unset": "بدون خطورة"
+      }
+    },
+    "durationDynamics": {
+      "title": "ديناميكيات المدة",
+      "durations": {
+        "sequential": "المدة التسلسلية",
+        "duration": "مدة الاختبار",
+        "speedup": "التسريع"
+      },
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "أحدث تقرير ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "تقرير من {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "الأحدث",
+        "history": "{{timestamp, timestamp_date}}"
+      },
+      "legend": {
+        "duration": "{{duration, format_duration}}",
+        "speedup": "{{speedup}}x"
+      }
+    }
+  },
+  "transitions": {
+    "description": {
+      "new": "أول ظهور لنتيجة الاختبار هذه في التقرير",
+      "fixed": "اختبار كان \"فاشلاً\" أو \"معطلاً\" سابقاً وأصبح الآن \"ناجحاً\"",
+      "regressed": "اختبار كان \"ناجحاً\" أو \"معطلاً\" سابقاً وأصبح الآن \"فاشلاً\"",
+      "malfunctioned": "اختبار كان \"ناجحاً\" أو \"فاشلاً\" سابقاً وأصبح الآن \"معطلاً\""
+    },
+    "new": "جديد",
+    "fixed": "تم إصلاحه",
+    "regressed": "تراجع",
+    "malfunctioned": "خلل"
+  }
+}

--- a/packages/web-dashboard/src/stores/locale.ts
+++ b/packages/web-dashboard/src/stores/locale.ts
@@ -147,4 +147,5 @@ export const setLocale = async (locale: LangLocale) => {
   await i18next.changeLanguage(locale as string);
   localStorage.setItem("currentLocale", locale as string);
   currentLocale.value = locale;
+  document.documentElement.dir = ["ar", "he", "fa"].includes(locale) ? "rtl" : "ltr";
 };

--- a/packages/web-summary/src/i18n/constants.ts
+++ b/packages/web-summary/src/i18n/constants.ts
@@ -7,6 +7,7 @@ export const AVAILABLE_LOCALES = [
   "pt",
   "de",
   "hy",
+  "ar",
   "az",
   "fr",
   "it",
@@ -71,6 +72,11 @@ export const LANG_LOCALE: Record<
     short: "Hy",
     full: "Հայերեն",
     iso: "hy-AM",
+  },
+  "ar": {
+    short: "Ar",
+    full: "العربية",
+    iso: "ar-SA",
   },
   "az": {
     short: "Az",

--- a/packages/web-summary/src/i18n/locales/ar.json
+++ b/packages/web-summary/src/i18n/locales/ar.json
@@ -1,0 +1,31 @@
+{
+  "summary": {
+    "status": {
+      "passed": "ناجح",
+      "failed": "فاشل",
+      "broken": "معطل",
+      "skipped": "تم تخطيه",
+      "unknown": "غير معروف"
+    },
+    "createdAt": "{{createdAt, timestamp_long_no_seconds}}",
+    "total": "الإجمالي",
+    "in": "في",
+    "metadata": {
+      "new_zero": "لا توجد اختبارات جديدة",
+      "new_one": "{{count}} اختبار جديد",
+      "new_other": "{{count}} اختبارات جديدة",
+      "flaky_zero": "لا توجد اختبارات متقلبة",
+      "flaky_one": "{{count}} اختبار متقلب",
+      "flaky_other": "{{count}} اختبارات متقلبة",
+      "retry_zero": "لا توجد اختبارات مُعادة",
+      "retry_one": "{{count}} اختبار مُعاد",
+      "retry_other": "{{count}} اختبارات مُعادة"
+    }
+  },
+  "ui": {
+    "at": "في"
+  },
+  "empty": {
+    "no-reports": "لم يتم العثور على تقارير"
+  }
+}

--- a/packages/web-summary/src/stores/locale.ts
+++ b/packages/web-summary/src/stores/locale.ts
@@ -73,4 +73,5 @@ export const setLocale = async (locale: LangLocale) => {
   await i18next.changeLanguage(locale as string);
   localStorage.setItem("currentLocale", locale as string);
   currentLocale.value = locale;
+  document.documentElement.dir = ["ar", "he", "fa"].includes(locale as string) ? "rtl" : "ltr";
 };


### PR DESCRIPTION
 ## Summary  
 - Register Arabic (`ar`) in `AVAILABLE_LOCALES` and `LANG_LOCALE` across web-commons, web-summary, web-classic, and web-allure2
  - Add Arabic translation files (`ar.json`) for all 5 web packages: web-awesome, web-dashboard, web-summary, web-classic, web-allure2
  - Update `setLocale()` in Preact stores to set `document.documentElement.dir` to `"rtl"` for Arabic, Hebrew, and Persian locales

  ## Details
  - All `{{variable}}` interpolation placeholders, `$t()` cross-references, and pluralization suffixes preserved exactly
  - Arabic alphabet sort directions (أ – ي / ي – أ) used instead of A–Z
  - 13 files changed (4 config edits + 5 new JSON files + 4 store edits)
  - web-allure2 already handles RTL via `i18next.dir()` so no store change needed there

<img width="855" height="480" alt="image" src="https://github.com/user-attachments/assets/3706854d-a7a3-4ec1-8f21-65f45cb8ed8a" />

<img width="880" height="473" alt="image" src="https://github.com/user-attachments/assets/944967a1-1768-4473-b2f6-07e94a5862f0" />

<img width="1124" height="944" alt="image" src="https://github.com/user-attachments/assets/5bc3bf68-6429-4b80-bb04-4312947b9955" />

<img width="1818" height="955" alt="image" src="https://github.com/user-attachments/assets/b070c482-d03f-4f13-a5b4-e2a6cc6e3795" />
