### PR TITLE
feat: add Traditional Chinese (zh-TW) locale support

### DIFF
--- a/packages/web-awesome/src/locales/zh-TW.json
+++ b/packages/web-awesome/src/locales/zh-TW.json
@@ -1,0 +1,432 @@
+{
+  "statuses": {
+    "passed": "通過",
+    "failed": "失敗",
+    "broken": "損壞",
+    "skipped": "跳過",
+    "unknown": "未知",
+    "total": "總計",
+    "flakyTests": "不穩定",
+    "newTests": "新的",
+    "retryTests": "重試"
+  },
+  "testSummary": {
+    "total": "總計",
+    "flaky": "不穩定的測試",
+    "retries": "重跑測試",
+    "new": "新的測試"
+  },
+  "tabs": {
+    "total": "全部",
+    "results": "結果",
+    "globalAttachments": "全域附件",
+    "globalErrors": "全域錯誤",
+    "qualityGates": "品質卡點",
+    "categories": "分類"
+  },
+  "search": {
+    "search": "搜尋",
+    "search-placeholder": "名稱或 ID"
+  },
+  "filters": {
+    "flaky": "不穩定",
+    "nonFlaky": "穩定",
+    "retry": "重試",
+    "new": "新的",
+    "fixed": "已修復",
+    "regressed": "已回歸",
+    "malfunctioned": "已損壞",
+    "transition": "狀態變化",
+    "status": "狀態",
+    "severity": "嚴重程度",
+    "owner": "負責人",
+    "layer": "層",
+    "tags": "標籤",
+    "categories": "分類",
+    "goto_filter": "前往篩選器",
+    "errors": {
+      "max_values_one": "僅使用前 {{count}} 個值進行篩選。\n其他值將被忽略",
+      "max_values_other": "僅使用前 {{count}} 個值進行篩選。\n其他值將被忽略"
+    },
+    "description": {
+      "flaky": "顯示不穩定的測試",
+      "retry": "顯示重新執行的測試結果",
+      "new": "顯示在此報告中首次出現的測試結果",
+      "fixed": "顯示現在通過但之前「失敗」或「損壞」的測試",
+      "regressed": "顯示從「通過」或「損壞」狀態變為「失敗」狀態的測試結果",
+      "malfunctioned": "顯示從「通過」或「失敗」狀態變為「損壞」狀態的測試結果",
+      "tags": "顯示具有指定標籤的測試結果",
+      "categories": "顯示具有指定分類的測試結果"
+    }
+  },
+  "sort-by": {
+    "sort-by-text": "排序依據:",
+    "sort-by-category": "排序類別",
+    "direction-category": "方向"
+  },
+  "sort-by.values": {
+    "order": "順序",
+    "alphabet": "字母",
+    "duration": "持續時間",
+    "status": "狀態"
+  },
+  "sort-by.directions": {
+    "order-desc": "最新 – 最舊",
+    "order-asc": "最舊 – 最新",
+    "order-asc-short": "最舊",
+    "order-desc-short": "最新",
+    "alphabet-asc": "A – Z",
+    "alphabet-desc": "Z – A",
+    "alphabet-asc-short": "A – Z",
+    "alphabet-desc-short": "Z – A",
+    "duration-asc": "1 – 9",
+    "duration-desc": "9 – 1",
+    "duration-asc-short": "1 – 9",
+    "duration-desc-short": "9 – 1",
+    "status-asc": "按照篩選清單",
+    "status-desc": "反轉",
+    "status-asc-short": "正常",
+    "status-desc-short": "反轉"
+  },
+  "empty": {
+    "no-results": "沒有結果",
+    "no-value": "無值",
+    "no-value-for": "無值：{{entity}}",
+    "no-transition": "無狀態變化",
+    "no-layer": "無分層",
+    "no-owner": "無負責人",
+    "no-severity": "無嚴重程度",
+    "no-status": "無狀態",
+    "no-environment": "無環境",
+    "no-flaky": "無不穩定",
+    "empty-value": "空",
+    "no-tests-found": "未找到結果",
+    "no-message-provided": "未提供訊息",
+    "clear-filters": "清除篩選器",
+    "no-attachments-results": "沒有附件資訊",
+    "no-global-errors-results": "沒有全域錯誤資訊",
+    "no-quality-gate-results": "沒有品質卡點結果",
+    "no-history-results": "沒有歷史資訊",
+    "no-retries-results": "沒有重試資訊",
+    "no-test-steps-results": "沒有可用的測試步驟資訊",
+    "no-test-case-results": "沒有測試案例結果",
+    "no-environments-results": "沒有環境資訊",
+    "no-categories-results": "暫無可用的分類結果"
+  },
+  "severity": {
+    "blocker": "阻礙",
+    "critical": "嚴重",
+    "normal": "正常",
+    "minor": "次要",
+    "trivial": "輕微"
+  },
+  "execution": {
+    "name": "執行",
+    "body": "測試內容",
+    "setup": "前置作業",
+    "teardown": "後置作業"
+  },
+  "environments": {
+    "environment_one": "環境",
+    "environment_other": "環境",
+    "all": "全部"
+  },
+  "ui": {
+    "labels": "標籤",
+    "metadata": "中繼資料",
+    "parameters": "參數",
+    "category": "分類",
+    "description": "描述",
+    "links": "連結",
+    "overview": "概覽",
+    "history": "歷史",
+    "attachments": "附件",
+    "retries": "重試",
+    "environments": "環境",
+    "error": "錯誤",
+    "goToStep": "跳轉到步驟",
+    "showLess": "顯示更少",
+    "showMore": "顯示更多",
+    "copy": "複製",
+    "copy-email": "複製電子郵件",
+    "attempt": "第 {{attempt}} 次嘗試，共 {{total}} 次",
+    "at": "於",
+    "variables": "變數",
+    "openPwTrace": "開啟 Playwright Trace",
+    "pwTracePopupBlocked": "瀏覽器封鎖了開啟 Playwright Trace Viewer。",
+    "pwTracePopupBlockedHint": "請允許彈出視窗後重試。",
+    "finishedAtOriginal": "{{formattedCreatedAt}}，結束代碼 {{original}}",
+    "finishedAtBoth": "{{formattedCreatedAt}}，結束代號 {{actual}}（原始 {{original}}）"
+  },
+  "controls": {
+    "newTabAttachment": "在新分頁中開啟附件",
+    "nextTR": "下一個測試結果",
+    "prevTR": "上一個測試結果",
+    "downloadAttachment": "下載附件",
+    "previewAttachment": "預覽",
+    "viewCode": "查看程式碼",
+    "syntaxHighlight": "語法醒目提示",
+    "backto": "返回",
+    "clipboard": "複製到剪貼簿",
+    "clipboardError": "無法複製到剪貼簿。可能是瀏覽器不支援此功能",
+    "clipboardSuccess": "複製成功",
+    "collapse": "折疊",
+    "expand": "展開",
+    "fullscreen": "全螢幕",
+    "language": "更改語言",
+    "openInNewTab": "在新分頁中開啟",
+    "openPreview": "開啟預覽",
+    "noSelectedTR": "沒有選取的測試結果",
+    "comparison": "對比",
+    "showDiff": "顯示差異",
+    "viewMode": "查看模式",
+    "unified": "統一",
+    "side-by-side": "並排",
+    "compareBy": "比較方式",
+    "chars": "字元",
+    "words": "單詞",
+    "lines": "行",
+    "actual": "實際",
+    "expected": "預期"
+  },
+  "errors": {
+    "missedAttachment": "未找到附件"
+  },
+  "sections": {
+    "report": "報告",
+    "charts": "統計圖表",
+    "timeline": "時間軸"
+  },
+  "timeline": {
+    "empty": "無資料",
+    "empty_host": "{{ host }} 無資料",
+    "selected_one": "已選擇 {{ count }} 個測試（{{ percentage }}%），持續時間大於 {{ minDuration }} 且小於 {{ maxDuration }}",
+    "selected_other": "已選擇 {{ count }} 個測試（{{ percentage }}%），持續時間大於 {{ minDuration }} 且小於 {{ maxDuration }}",
+    "host": "主機: {{ host }}"
+  },
+  "charts": {
+    "trend": {
+      "title": "趨勢圖表: {{type}}",
+      "type": {
+        "status": "狀態",
+        "severity": "嚴重程度"
+      }
+    },
+    "currentStatus": {
+      "title": "當前狀態",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "percentage": "{{percentage}}%",
+      "of": "共 {{total}}",
+      "total": "總計",
+      "tests": {
+        "new_zero": "沒有新的測試",
+        "new_one": "{{count}} 個新的測試",
+        "new_other": "{{count}} 個新的測試",
+        "flaky_zero": "沒有不穩定的測試",
+        "flaky_one": "{{count}} 個不穩定的測試",
+        "flaky_other": "{{count}} 個不穩定的測試",
+        "retries_zero": "沒有重跑的測試",
+        "retries_one": "{{count}} 個重跑的測試",
+        "retries_other": "{{count}} 個重跑的測試"
+      }
+    },
+    "statusDynamics": {
+      "title": "狀態趨勢",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "{{timestamp, timestamp_long_no_seconds}} 的報告"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusTransitions": {
+      "title": "狀態轉變",
+      "legend": {
+        "trend": "修復率"
+      },
+      "transitions": {
+        "new": "$t(transitions:new, capitalize)",
+        "fixed": "$t(transitions:fixed, capitalize)",
+        "regressed": "$t(transitions:regressed, capitalize)",
+        "malfunctioned": "$t(transitions:malfunctioned, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "{{timestamp, timestamp_long_no_seconds}} 的報告"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "durations": {
+      "title": "按{{groupBy}}的持續時間直方圖",
+      "title_none": "持續時間直方圖",
+      "no-results": "$t(empty:no-results)",
+      "groupBy": {
+        "none": "無",
+        "layer": "層"
+      },
+      "ticks": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "tooltips": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "legend": {
+        "value": "{{value}}",
+        "total": "測試數量"
+      }
+    },
+    "stabilityDistribution": {
+      "title": "穩定性分佈",
+      "no-results": "$t(empty:no-results)",
+      "legend": {
+        "stabilityRate": "穩定率"
+      }
+    },
+    "testBaseGrowthDynamics": {
+      "title": "測試增長趨勢",
+      "status": {
+        "newpassed": "新增 $t(statuses:passed)",
+        "newfailed": "新增 $t(statuses:failed)",
+        "newbroken": "新增 $t(statuses:broken)",
+        "newskipped": "新增 $t(statuses:skipped)",
+        "newunknown": "新增 $t(statuses:unknown)",
+        "removedpassed": "移除 $t(statuses:passed)",
+        "removedfailed": "移除 $t(statuses:failed)",
+        "removedbroken": "移除 $t(statuses:broken)",
+        "removedskipped": "移除 $t(statuses:skipped)",
+        "removedunknown": "移除 $t(statuses:unknown)"
+      },
+      "legend": {
+        "trend": "增長趨勢"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "報告來自 {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusAgePyramid": {
+      "title": "狀態分布金字塔",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "報告來自 {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "trSeverities": {
+      "title": "按嚴重程度的測試結果",
+      "no-results": "$t(empty:no-results)",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "severity": {
+        "blocker": "$t(severity:blocker, capitalize)",
+        "critical": "$t(severity:critical, capitalize)",
+        "normal": "$t(severity:normal, capitalize)",
+        "minor": "$t(severity:minor, capitalize)",
+        "trivial": "$t(severity:trivial, capitalize)",
+        "unset": "無嚴重程度"
+      }
+    },
+    "durationDynamics": {
+      "title": "執行時間趨勢",
+      "durations": {
+        "sequential": "順序持續時間",
+        "duration": "測試持續時間",
+        "speedup": "加速"
+      },
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "{{timestamp, timestamp_long_no_seconds}} 的報告"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      },
+      "legend": {
+        "duration": "{{duration, format_duration}}",
+        "speedup": "{{speedup}}x"
+      }
+    }
+  },
+  "transitions": {
+    "description": {
+      "new": "此測試結果在報告中的首次出現",
+      "fixed": "之前「失敗」或「損壞」的測試現在「通過」了",
+      "regressed": "之前「通過」或「損壞」的測試現在「失敗」了",
+      "malfunctioned": "之前「通過」或「失敗」的測試現在「損壞」了",
+      "retries": "{{count}} 次重試",
+      "flaky": "多次執行結果不一致"
+    },
+    "new": "新的",
+    "fixed": "已修復",
+    "regressed": "已回歸",
+    "malfunctioned": "已損壞"
+  },
+  "trHistory": {
+    "unknown-date": "未知日期"
+  },
+  "attachments": {
+    "imageDiff": {
+      "mode": {
+        "diff": "差異",
+        "actual": "實際",
+        "expected": "預期",
+        "side-by-side": "並排",
+        "overlay": "疊加"
+      },
+      "empty": {
+        "failed-to-load": "無法載入圖像對比"
+      },
+      "image": {
+        "diff": "差異",
+        "actual": "實際",
+        "expected": "預期"
+      }
+    }
+  }
+}

--- a/packages/web-commons/src/i18n.ts
+++ b/packages/web-commons/src/i18n.ts
@@ -20,6 +20,7 @@ export const AVAILABLE_LOCALES = [
   "sv",
   "tr",
   "zh",
+  "zh-TW",
 ] as const;
 
 export const DEFAULT_LOCALE = "en";
@@ -192,5 +193,10 @@ export const LANG_LOCALE: Record<
     short: "Zh",
     full: "中文",
     iso: "zh-CN",
+  },
+  "zh-TW": {
+    short: "Zh-TW",
+    full: "繁體中文",
+    iso: "zh-TW",
   },
 };

--- a/packages/web-dashboard/src/locales/zh-TW.json
+++ b/packages/web-dashboard/src/locales/zh-TW.json
@@ -1,0 +1,227 @@
+{
+  "statuses": {
+    "passed": "通過",
+    "failed": "失敗",
+    "broken": "損壞",
+    "skipped": "跳過",
+    "unknown": "未知",
+    "total": "總計"
+  },
+  "empty": {
+    "no-results": "無結果",
+    "no-history-results": "無歷史資訊"
+  },
+  "severity": {
+    "blocker": "阻礙",
+    "critical": "嚴重",
+    "normal": "正常",
+    "minor": "次要",
+    "trivial": "輕微"
+  },
+  "environments": {
+    "environment_one": "環境",
+    "environment_other": "環境",
+    "all": "全部"
+  },
+  "charts": {
+    "trend": {
+      "title": "趨勢圖表: {{type}}",
+      "type": {
+        "status": "狀態",
+        "severity": "嚴重程度"
+      }
+    },
+    "currentStatus": {
+      "title": "當前狀態",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "percentage": "{{percentage}}%",
+      "of": "共 {{total}}",
+      "total": "{{total}}",
+      "tests": {
+        "new_zero": "沒有新的測試",
+        "new_one": "{{count}} 個新的測試",
+        "new_other": "{{count}} 個新的測試",
+        "flaky_zero": "沒有不穩定的測試",
+        "flaky_one": "{{count}} 個不穩定的測試",
+        "flaky_other": "{{count}} 個不穩定的測試",
+        "retries_zero": "沒有重跑的測試",
+        "retries_one": "{{count}} 個重跑的測試",
+        "retries_other": "{{count}} 個重跑的測試"
+      }
+    },
+    "statusDynamics": {
+      "title": "狀態趨勢",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "{{timestamp, timestamp_long_no_seconds}} 的報告"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusTransitions": {
+      "title": "狀態轉變",
+      "legend": {
+        "trend": "修復率"
+      },
+      "transitions": {
+        "new": "$t(transitions:new, capitalize)",
+        "fixed": "$t(transitions:fixed, capitalize)",
+        "regressed": "$t(transitions:regressed, capitalize)",
+        "malfunctioned": "$t(transitions:malfunctioned, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "{{timestamp, timestamp_long_no_seconds}} 的報告"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "durations": {
+      "title": "按{{groupBy}}的持續時間直方圖",
+      "title_none": "持續時間直方圖",
+      "no-results": "$t(empty:no-results)",
+      "groupBy": {
+        "none": "無",
+        "layer": "層"
+      },
+      "ticks": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "tooltips": {
+        "durationRange": "{{from, format_duration}} - {{to, format_duration}}"
+      },
+      "legend": {
+        "value": "{{value}}",
+        "total": "測試數量"
+      }
+    },
+    "stabilityDistribution": {
+      "title": "穩定性分佈",
+      "no-results": "$t(empty:no-results)",
+      "legend": {
+        "stabilityRate": "穩定率"
+      }
+    },
+    "testBaseGrowthDynamics": {
+      "title": "測試增長趨勢",
+      "status": {
+        "newpassed": "新增 $t(statuses:passed)",
+        "newfailed": "新增 $t(statuses:failed)",
+        "newbroken": "新增 $t(statuses:broken)",
+        "newskipped": "新增 $t(statuses:skipped)",
+        "newunknown": "新增 $t(statuses:unknown)",
+        "removedpassed": "移除 $t(statuses:passed)",
+        "removedfailed": "移除 $t(statuses:failed)",
+        "removedbroken": "移除 $t(statuses:broken)",
+        "removedskipped": "移除 $t(statuses:skipped)",
+        "removedunknown": "移除 $t(statuses:unknown)"
+      },
+      "legend": {
+        "trend": "增長趨勢"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "報告來自 {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "statusAgePyramid": {
+      "title": "狀態分布金字塔",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "no-history": "$t(empty:no-history-results)",
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "報告來自 {{timestamp, timestamp_long_no_seconds}}"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      }
+    },
+    "trSeverities": {
+      "title": "按嚴重程度的測試結果",
+      "no-results": "$t(empty:no-results)",
+      "status": {
+        "passed": "$t(statuses:passed, capitalize)",
+        "failed": "$t(statuses:failed, capitalize)",
+        "broken": "$t(statuses:broken, capitalize)",
+        "skipped": "$t(statuses:skipped, capitalize)",
+        "unknown": "$t(statuses:unknown, capitalize)"
+      },
+      "severity": {
+        "blocker": "$t(severity:blocker, capitalize)",
+        "critical": "$t(severity:critical, capitalize)",
+        "normal": "$t(severity:normal, capitalize)",
+        "minor": "$t(severity:minor, capitalize)",
+        "trivial": "$t(severity:trivial, capitalize)",
+        "unset": "無嚴重程度"
+      }
+    },
+    "durationDynamics": {
+      "title": "執行時間趨勢",
+      "durations": {
+        "sequential": "順序持續時間",
+        "duration": "測試持續時間",
+        "speedup": "加速"
+      },
+      "no-results": "$t(empty:no-results)",
+      "tooltips": {
+        "current": "最新報告 ({{timestamp, timestamp_long_no_seconds}})",
+        "history": "{{timestamp, timestamp_long_no_seconds}} 的報告"
+      },
+      "ticks": {
+        "current": "最新",
+        "history": "{{timestamp, timestamp_date}}"
+      },
+      "legend": {
+        "duration": "{{duration, format_duration}}",
+        "speedup": "{{speedup}}x"
+      }
+    }
+  },
+  "transitions": {
+    "description": {
+      "new": "此測試結果在報告中的首次出現",
+      "fixed": "之前「失敗」或「損壞」的測試現在「通過」了",
+      "regressed": "之前「通過」或「損壞」的測試現在「失敗」了",
+      "malfunctioned": "之前「通過」或「失敗」的測試現在「損壞」了"
+    },
+    "new": "新的",
+    "fixed": "已修復",
+    "regressed": "已回歸",
+    "malfunctioned": "已損壞"
+  }
+}

--- a/packages/web-summary/src/i18n/locales/zh-TW.json
+++ b/packages/web-summary/src/i18n/locales/zh-TW.json
@@ -1,0 +1,31 @@
+{
+  "summary": {
+    "status": {
+      "passed": "通過",
+      "failed": "失敗",
+      "broken": "損壞",
+      "skipped": "跳過",
+      "unknown": "未知"
+    },
+    "createdAt": "{{createdAt, timestamp_long_no_seconds}}",
+    "total": "總計",
+    "in": "在",
+    "metadata": {
+      "new_zero": "沒有新的測試",
+      "new_one": "{{count}} 個新的測試",
+      "new_other": "{{count}} 個新的測試",
+      "flaky_zero": "沒有不穩定的測試",
+      "flaky_one": "{{count}} 個不穩定的測試",
+      "flaky_other": "{{count}} 個不穩定的測試",
+      "retry_zero": "沒有重跑的測試",
+      "retry_one": "{{count}} 個重跑的測試",
+      "retry_other": "{{count}} 個重跑的測試"
+    }
+  },
+  "ui": {
+    "at": "於"
+  },
+  "empty": {
+    "no-reports": "未找到報告"
+  }
+}


### PR DESCRIPTION
- Add zh-TW translation files for web-awesome, web-dashboard, and web-summary. 
- Register zh-TW in AVAILABLE_LOCALES and LANG_LOCALE in web-commons.