### PR TITLE
fix(web-awesome): sort by selection not reactive

### DIFF
--- a/packages/web-awesome/src/stores/treeSort.ts
+++ b/packages/web-awesome/src/stores/treeSort.ts
@@ -1,5 +1,5 @@
 import { getParamValue, hasParam, setParams } from "@allurereport/web-commons";
-import { computed, effect } from "@preact/signals";
+import { computed, effect, signal } from "@preact/signals";
 
 export type SortByDirection = "asc" | "desc";
 export type SortByField = "order" | "duration" | "status" | "name";
@@ -16,6 +16,19 @@ const SORT_BY_PARAM = "sortBy";
 
 const hasSortByParam = computed(() => hasParam(SORT_BY_PARAM));
 
+const getInitialSortBy = (): SortBy => {
+  if (typeof window === "undefined") {
+    return DEFAULT_SORT_BY;
+  }
+  const stored = localStorage.getItem(SORT_BY_STORAGE_KEY);
+  if (stored && validateSortBy(stored.toLowerCase())) {
+    return stored.toLowerCase() as SortBy;
+  }
+  return DEFAULT_SORT_BY;
+};
+
+const sortBySignal = signal<SortBy>(getInitialSortBy());
+
 export const setSortBy = (sortByValue: SortBy) => {
   if (hasSortByParam.peek()) {
     setParams({
@@ -24,11 +37,7 @@ export const setSortBy = (sortByValue: SortBy) => {
     });
   }
 
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  localStorage.setItem(SORT_BY_STORAGE_KEY, sortByValue);
+  sortBySignal.value = sortByValue;
 };
 
 const validateSortBy = (sortByValue: string): sortByValue is SortBy => {
@@ -53,13 +62,7 @@ export const sortBy = computed<SortBy>(() => {
     return DEFAULT_SORT_BY;
   }
 
-  const storageSortBy = localStorage.getItem(SORT_BY_STORAGE_KEY);
-
-  if (storageSortBy && validateSortBy(storageSortBy.toLowerCase())) {
-    return storageSortBy.toLowerCase() as SortBy;
-  }
-
-  return DEFAULT_SORT_BY;
+  return sortBySignal.value;
 });
 
 effect(() => {

--- a/packages/web-awesome/src/stores/treeSort.ts
+++ b/packages/web-awesome/src/stores/treeSort.ts
@@ -16,6 +16,16 @@ const SORT_BY_PARAM = "sortBy";
 
 const hasSortByParam = computed(() => hasParam(SORT_BY_PARAM));
 
+const validateSortBy = (sortByValue: string): sortByValue is SortBy => {
+  const parts = sortByValue.split(",");
+  if (parts.length !== 2) {
+    return false;
+  }
+  const [field, direction] = parts;
+
+  return SORT_BY_FIELDS.includes(field as SortByField) && DIRECTIONS.includes(direction as SortByDirection);
+};
+
 const getInitialSortBy = (): SortBy => {
   if (typeof window === "undefined") {
     return DEFAULT_SORT_BY;
@@ -38,16 +48,6 @@ export const setSortBy = (sortByValue: SortBy) => {
   }
 
   sortBySignal.value = sortByValue;
-};
-
-const validateSortBy = (sortByValue: string): sortByValue is SortBy => {
-  const parts = sortByValue.split(",");
-  if (parts.length !== 2) {
-    return false;
-  }
-  const [field, direction] = parts;
-
-  return SORT_BY_FIELDS.includes(field as SortByField) && DIRECTIONS.includes(direction as SortByDirection);
 };
 
 export const sortBy = computed<SortBy>(() => {


### PR DESCRIPTION
## Problem

Clicking any sort option (Duration, Status, Alphabet) in the Sort By dropdown had no effect — the button remained stuck on the previous selection and the test list order never changed.

<img width="351" height="289" alt="截圖 2026-04-09 14 57 29" src="https://github.com/user-attachments/assets/48f1f2c2-07df-4f06-915a-eee829c01ae6" />

ref. https://allure-framework.github.io/allure3/awesome/

## Root Cause

`setSortBy` was writing directly to `localStorage` instead of updating a signal, so the `sortBy` computed never re-evaluated and the UI stayed stuck on the previous sort option.

`localStorage` is not part of Preact Signals' reactive system — writing to it does not trigger any computed re-evaluation, meaning the UI would never reflect the user's selection.

## Fix

Introduce `sortBySignal` to hold the current sort state reactively. `setSortBy` now updates the signal; the existing effect handles localStorage persistence.

**File:** `packages/web-awesome/src/stores/treeSort.ts`

| | Before | After |
|---|---|---|
| `setSortBy()` | Wrote to `localStorage` | Updates `sortBySignal.value` |
| `sortBy` computed | Read from `localStorage` (non-reactive) | Reads from `sortBySignal` (reactive) |
| localStorage sync | Done inside `setSortBy` directly | Handled by existing `effect` |