### PR TITLE
fix: resolve #568 — Collapse all sections

### DIFF
--- a/packages/web-classic/src/components/CollapseAllButton.test.ts
+++ b/packages/web-classic/src/components/CollapseAllButton.test.ts
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CollapseAllButton } from './CollapseAllButton';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import treeReducer from '../redux/treeSlice';
+import { ALLURE_PLUGIN_KEY } from '../utils/constants';
+
+const renderWithStore = (initialState = {}) => {
+  const store = configureStore({
+    reducer: {
+      [ALLURE_PLUGIN_KEY]: treeReducer,
+    },
+    preloadedState: {
+      [ALLURE_PLUGIN_KEY]: initialState,
+    },
+  });
+
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <CollapseAllButton />
+      </Provider>,
+    ),
+  };
+};
+
+describe('CollapseAllButton', () => {
+  it('renders the collapse all button', () => {
+    renderWithStore();
+    expect(screen.getByText(/collapse all/i)).toBeInTheDocument();
+  });
+
+  it('dispatches toggleTreeCollapsed action when clicked', () => {
+    const { store } = renderWithStore();
+    const button = screen.getByText(/collapse all/i);
+    fireEvent.click(button);
+    expect(store.getState()[ALLURE_PLUGIN_KEY].treeCollapsed).toBe(true);
+  });
+
+  it('toggles collapsed state from false to true', () => {
+    const { store } = renderWithStore({ treeCollapsed: false });
+    const button = screen.getByText(/collapse all/i);
+    fireEvent.click(button);
+    expect(store.getState()[ALLURE_PLUGIN_KEY].treeCollapsed).toBe(true);
+  });
+
+  it('toggles collapsed state from true to false', () => {
+    const { store } = renderWithStore({ treeCollapsed: true });
+    const button = screen.getByText(/collapse all/i);
+    fireEvent.click(button);
+    expect(store.getState()[ALLURE_PLUGIN_KEY].treeCollapsed).toBe(false);
+  });
+
+  it('is a button element', () => {
+    renderWithStore();
+    expect(screen.getByText(/collapse all/i)).toBeInstanceOf(HTMLButtonElement);
+  });
+});

--- a/packages/web-classic/src/stores/sections.ts
+++ b/packages/web-classic/src/stores/sections.ts
@@ -1,0 +1,68 @@
+import { writable, derived, type Writable, type Readable } from 'svelte/store';
+
+type CollapseState = Map<string, boolean>;
+
+interface SectionsState {
+  collapsedIds: Set<string>;
+}
+
+function createSectionsStore() {
+  const { subscribe, update, set }: Writable<SectionsState> = writable({
+    collapsedIds: new Set<string>()
+  });
+
+  return {
+    subscribe,
+    collapse: (id: string) => {
+      update(state => {
+        const newCollapsedIds = new Set(state.collapsedIds);
+        newCollapsedIds.add(id);
+        return { ...state, collapsedIds: newCollapsedIds };
+      });
+    },
+    expand: (id: string) => {
+      update(state => {
+        const newCollapsedIds = new Set(state.collapsedIds);
+        newCollapsedIds.delete(id);
+        return { ...state, collapsedIds: newCollapsedIds };
+      });
+    },
+    toggle: (id: string) => {
+      update(state => {
+        const newCollapsedIds = new Set(state.collapsedIds);
+        if (newCollapsedIds.has(id)) {
+          newCollapsedIds.delete(id);
+        } else {
+          newCollapsedIds.add(id);
+        }
+        return { ...state, collapsedIds: newCollapsedIds };
+      });
+    },
+    collapseAll: (ids: string[]) => {
+      update(state => ({
+        ...state,
+        collapsedIds: new Set(ids)
+      }));
+    },
+    expandAll: () => {
+      update(state => ({
+        ...state,
+        collapsedIds: new Set<string>()
+      }));
+    },
+    isCollapsed: (state: SectionsState, id: string): boolean => {
+      return state.collapsedIds.has(id);
+    }
+  };
+}
+
+export const sectionsStore = createSectionsStore();
+
+export const collapsedIds: Readable<Set<string>> = derived(
+  sectionsStore,
+  $store => $store.collapsedIds
+);
+
+export function isSectionCollapsed(id: string): Readable<boolean> {
+  return derived(sectionsStore, $store => $store.collapsedIds.has(id));
+}


### PR DESCRIPTION
## Summary

fix: resolve #568 — Collapse all sections

## Problem

**Severity**: `High` | **File**: `packages/web-classic/src/stores/sections.ts`

Create a Svelte store (or extend an existing one) that tracks the global "collapse all" state and provides methods to collapse/expand all sections at once. This store will be the single source of truth for the collapse state across all section components.

## Solution



## Changes

- `packages/web-classic/src/stores/sections.ts` (new)
- `packages/web-classic/src/components/CollapseAllButton.test.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*