### PR TITLE
Attach combined stdout/stderr to failure trace and use `close` for process termination

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -505,13 +505,17 @@ export class RunCommand extends Command {
       stderrResultFile.contentType = "text/plain";
 
       allureReport.realtimeDispatcher.sendGlobalAttachment(stderrResultFile, "stderr.txt");
+    }
 
-      if (processFailed) {
-        allureReport.realtimeDispatcher.sendGlobalError({
-          message: "Test process has failed",
-          trace: testProcessResult.stderr,
-        });
-      }
+    if (processFailed) {
+      const processFailureTrace = [testProcessResult?.stderr, testProcessResult?.stdout]
+        .filter((output): output is string => !!output)
+        .join("\n");
+
+      allureReport.realtimeDispatcher.sendGlobalError({
+        message: "Test process has failed",
+        ...(processFailureTrace ? { trace: processFailureTrace } : {}),
+      });
     }
 
     allureReport.realtimeDispatcher.sendGlobalExitCode(globalExitCode);

--- a/packages/cli/src/utils/process.ts
+++ b/packages/cli/src/utils/process.ts
@@ -53,7 +53,7 @@ export const runProcess = (params: {
 
 export const terminationOf = (testProcess: ChildProcess): Promise<number | null> =>
   new Promise((resolve) => {
-    testProcess.on("exit", (code) => resolve(code));
+    testProcess.on("close", (code) => resolve(code));
   });
 
 /**


### PR DESCRIPTION
### Motivation
- Ensure richer failure diagnostics by including both stdout and stderr when reporting a test process failure.
- Make `terminationOf` resolve at the correct time by using the `close` event so child stream cleanup is observed.

### Description
- When a test process fails, build a combined trace from `testProcessResult.stderr` and `testProcessResult.stdout` and include it in the global error only if non-empty, instead of always sending only `stderr`.
- Fixed the surrounding block structure to properly attach `stdout`/`stderr` result files when not ignored.
- Changed `terminationOf` to listen for the `close` event instead of `exit` so the returned promise resolves after stdio streams are closed.

### Testing
- Ran the repository test suite with `yarn test`, and the tests completed successfully.
- Ran linting with `yarn lint`, and no lint errors were reported.
- Verified the CLI manually in a smoke test that a failing child process now includes combined output in the reported trace.