### PR TITLE
Add allure agent for cleaner test runs and focused reruns

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -12230,6 +12230,7 @@ const RAW_RUNTIME_STATE =
           ["@allurereport/core", "workspace:packages/core"],\
           ["@allurereport/core-api", "workspace:packages/core-api"],\
           ["@allurereport/directory-watcher", "workspace:packages/directory-watcher"],\
+          ["@allurereport/plugin-agent", "workspace:packages/plugin-agent"],\
           ["@allurereport/plugin-allure2", "workspace:packages/plugin-allure2"],\
           ["@allurereport/plugin-api", "workspace:packages/plugin-api"],\
           ["@allurereport/plugin-awesome", "workspace:packages/plugin-awesome"],\

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@
 Use [Allure Agent Mode](docs/allure-agent-mode.md) for all test-related work in this repository.
 
 - Read `docs/allure-agent-mode.md` before designing, writing, reviewing, validating, debugging, or enriching tests.
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 - If agent-mode output is missing or incomplete, debug that first rather than silently falling back to console-only review.
 - Use Allure agent-mode when adding tests for features or fixes so expectations, evidence quality, and scope review are part of the loop.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ To successfully generate a report, ensure that your test setup outputs results i
 
 After the tests complete, the report is generated automatically. Existing results from previous runs are ignored, as Allure 3 focuses solely on new data to ensure accurate and up-to-date reporting.
 
+### Running Tests In Agent Mode
+
+When you need agent-friendly markdown output for review, debugging, or scope validation, use the `agent` command:
+
+```bash
+npx allure agent -- <test_command>
+```
+
+For example:
+
+```bash
+npx allure agent -- npm test
+```
+
+`allure agent` runs with an agent-only profile by default. It creates a fresh output directory automatically, can load an expectations file with `--expectations`, and ignores configured presentation or export plugins such as Awesome or TestOps unless you explicitly fall back to the lower-level `ALLURE_AGENT_*` plus `allure run` flow.
+
 ### Generating Reports Manually
 
 If you already have test results and wish to generate a report manually, use the `generate` command:
@@ -106,6 +122,7 @@ The Allure CLI includes several helpful global options. Use `--help` to explore 
 
 ```bash
 npx allure run --help
+npx allure agent --help
 npx allure watch --help
 ```
 

--- a/docs/agent_enrichment_loop.md
+++ b/docs/agent_enrichment_loop.md
@@ -17,7 +17,7 @@ test run, but it does not mutate tests or invent evidence.
 The enrichment loop sits above that output:
 
 1. Generate `ALLURE_AGENT_EXPECTATIONS` as a fresh per-run YAML or JSON file.
-2. Run tests with `ALLURE_AGENT_OUTPUT`.
+2. Run tests with `allure agent`, or use the lower-level `ALLURE_AGENT_*` plus `allure run` fallback when you need direct environment control.
 3. Review `manifest/run.json`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 4. Enrich only the targeted tests with real runtime metadata.
 5. Rerun the same scope and accept the change only when scope matches and the

--- a/docs/allure-agent-mode.md
+++ b/docs/allure-agent-mode.md
@@ -10,19 +10,21 @@ Use it when:
 - reviewing existing test suites, auditing coverage, or triaging failing suites
 - validating that intended tests ran and unrelated scope did not drift in
 - improving weak or low-signal runtime evidence
-- preparing richer Allure reports, quality gates, and future loop adoption
+- preparing richer agent-mode reviews, quality gates, and future loop adoption
 
 ## Review Principle
 
 Runtime first, source second.
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `ALLURE_AGENT_*` with `allure run` only as the lower-level fallback when you need direct environment control.
 - If the agent-mode output is missing or incomplete, debug that first and treat any console-only conclusion as provisional.
 
 ## Verification Standard
 
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
+- After each agent-mode test run, print the `index.md` path from that run's output directory so users can open the run overview quickly.
 
 ## Repository Status
 
@@ -30,8 +32,22 @@ This repository already has a working Allure 3 setup.
 
 - Root report configuration lives in `allurerc.mjs`.
 - Most package test suites emit results with `allure-vitest/reporter` into `./out/allure-results`.
-- The normal feature-delivery path here is to run a targeted workspace test command under `yarn allure run -- ...`.
+- The normal feature-delivery path here is to run a targeted workspace test command under `yarn allure agent -- ...`.
 - You usually do not need to bootstrap Allure from scratch in this repo; focus on expectations, evidence quality, and scope control.
+
+## Helpful Commands
+
+- `allure agent latest` prints the latest agent output directory for the current project cwd. Use it when a prior run omitted `--output` and you want to reopen the most recent agent-mode artifacts.
+- `allure agent state-dir` prints the state directory for the current project cwd. Use it when you need to inspect where `latest` pointers are stored or debug sandbox behavior.
+- `allure agent select --latest` or `allure agent select --from <output-dir>` prints the review-targeted test plan from a prior agent run. Add `--preset failed` or exact `--label name=value` / `--environment <id>` filters when you need a narrower rerun plan.
+- `allure agent --rerun-latest -- <command>` or `allure agent --rerun-from <output-dir> -- <command>` reruns only the selected tests through the framework-agnostic Allure testplan flow. The default rerun preset is `review`.
+
+## Advanced Reruns
+
+- `--rerun-preset review|failed|unsuccessful|all` changes how the rerun seed set is chosen. Use `review` for the default agent-targeted loop, `failed` for classic failure reruns, `unsuccessful` for any non-passed tests, and `all` when you want the whole previously observed set.
+- `--rerun-environment <id>` narrows the rerun selection to one or more environment ids from the previous agent output. Repeat the flag for multiple environments.
+- `--rerun-label name=value` narrows the rerun selection to tests whose prior results carried exact matching labels. Repeat the flag for multiple label filters.
+- `ALLURE_AGENT_STATE_DIR` overrides the default project-scoped state directory used by `allure agent latest`, `allure agent state-dir`, and `--rerun-latest`. Use it when you need a deterministic shared location in CI or a constrained sandbox.
 
 ## Core Loops
 
@@ -39,18 +55,19 @@ This repository already has a working Allure 3 setup.
 
 1. Identify the exact review scope.
 2. Create a fresh expectations file for this run in a temp directory.
-3. Run only that scope with `allure run`.
+3. Run only that scope with `allure agent`.
 4. Read `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 5. Read per-test markdown only for tests that failed, drifted, or have findings.
 6. Only after runtime review, inspect source code for root cause or coverage gaps.
 7. If evidence is weak or partial, enrich the tests and rerun.
+8. When iterating on the same scope, prefer `allure agent --rerun-latest -- <command>` or `allure agent --rerun-from <output-dir> -- <command>` so the rerun stays focused on the review-targeted tests.
 
 ### Feature Delivery Loop
 
 1. Understand the feature or issue and the intended test scope.
 2. Create a fresh expectations file for this run in a temp directory.
 3. Write or update the tests.
-4. Run the target scope with `allure run`.
+4. Run the target scope with `allure agent`.
 5. Review `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, `manifest/findings.jsonl`, and the relevant per-test markdown files.
 6. Fix scope drift, weak evidence, or bad test design.
 7. Rerun with a new temp output directory and a new expectations file until the run is acceptable.
@@ -69,7 +86,7 @@ Use this when the run is functionally correct but too weak to review:
 Use this when the code change is mostly mechanical, such as typing cleanup, mock refactors, or helper extraction:
 
 1. Create a fresh expectations file and temp output directory for the touched scope.
-2. Run the touched scope with `allure run`, even if the goal is only a smoke check after a small or mechanical change.
+2. Run the touched scope with `allure agent`, even if the goal is only a smoke check after a small or mechanical change.
 3. Review `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 4. Only then make a final statement about regression safety or test correctness.
 
@@ -79,13 +96,13 @@ Use this for command matrices, package audits, or business-logic coverage review
 
 1. Split the audit into scoped groups.
 2. Give each group its own expectations file and temp output directory.
-3. Run each group with `allure run`.
+3. Run each group with `allure agent`.
 4. Review runtime artifacts first, then inspect source code only after the run explains what actually executed.
 5. Mark the review incomplete until each scoped group either matched expectations or was explicitly documented as a broad package-health audit.
 
 ## Per-Run Artifacts
 
-Each run must use fresh temp paths so parallel runs stay isolated.
+Each run must use fresh temp paths so parallel runs stay isolated. `allure agent` creates a fresh temp output directory automatically when you omit `--output`, but this guide still uses explicit temp paths when you need deterministic file locations.
 
 - `ALLURE_AGENT_OUTPUT` should point to a unique temp directory per run.
 - `ALLURE_AGENT_EXPECTATIONS` should point to a unique expectations file per run.
@@ -94,6 +111,8 @@ Each run must use fresh temp paths so parallel runs stay isolated.
 YAML is the preferred format for expectations files in v1, though JSON also works.
 
 Example:
+
+Primary pattern:
 
 ```bash
 TMP_DIR="$(mktemp -d)"
@@ -112,6 +131,15 @@ notes:
   - Only feature A tests should run.
 YAML
 
+npx allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- npm test
+```
+
+Lower-level fallback:
+
+```bash
 ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
 ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
 npx allure run -- npm test
@@ -134,9 +162,10 @@ notes:
   - Review runtime evidence before source inspection.
 YAML
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-yarn allure run -- yarn workspace allure test
+yarn allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- yarn workspace allure test
 ```
 
 Compact coverage-review pattern:
@@ -145,9 +174,10 @@ Compact coverage-review pattern:
 TMP_DIR="$(mktemp -d)"
 EXPECTATIONS="$TMP_DIR/expectations.yaml"
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-yarn allure run -- yarn workspace <workspace> test <scope>
+yarn allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- yarn workspace <workspace> test <scope>
 ```
 
 Package review expectations example:
@@ -177,9 +207,10 @@ notes:
   - Review runtime evidence before source inspection.
 YAML
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-yarn allure run -- yarn workspace allure test test/commands/run.integration.test.ts
+yarn allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- yarn workspace allure test test/commands/run.integration.test.ts
 ```
 
 Single-spec expectations example:
@@ -207,9 +238,10 @@ notes:
   - Only plugin-agent tests should run.
 YAML
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-yarn allure run -- yarn workspace @allurereport/plugin-agent test
+yarn allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- yarn workspace @allurereport/plugin-agent test
 ```
 
 ```bash
@@ -223,9 +255,10 @@ expected:
     package: test.commands.run.integration.test.ts
 YAML
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-yarn allure run -- yarn workspace allure test test/commands/run.integration.test.ts
+yarn allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- yarn workspace allure test test/commands/run.integration.test.ts
 ```
 
 ## Reviewing Agent Output

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,6 +60,22 @@ To successfully generate a report, ensure that your test setup outputs results i
 
 After the tests complete, the report is generated automatically. Existing results from previous runs are ignored, as Allure 3 focuses solely on new data to ensure accurate and up-to-date reporting.
 
+### Running Tests In Agent Mode
+
+When you need agent-friendly markdown output for review, debugging, or scope validation, use the `agent` command:
+
+```bash
+npx allure agent -- <test_command>
+```
+
+For example:
+
+```bash
+npx allure agent -- npm test
+```
+
+`allure agent` runs with an agent-only profile by default. It creates a fresh output directory automatically, can load an expectations file with `--expectations`, and ignores configured presentation or export plugins such as Awesome or TestOps unless you explicitly fall back to the lower-level `ALLURE_AGENT_*` plus `allure run` flow.
+
 ### Generating Reports Manually
 
 If you already have test results and wish to generate a report manually, use the `generate` command:
@@ -102,6 +118,7 @@ The Allure CLI includes several helpful global options. Use `--help` to explore 
 
 ```bash
 npx allure run --help
+npx allure agent --help
 npx allure watch --help
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "@allurereport/core": "workspace:*",
     "@allurereport/core-api": "workspace:*",
     "@allurereport/directory-watcher": "workspace:*",
+    "@allurereport/plugin-agent": "workspace:*",
     "@allurereport/plugin-allure2": "workspace:*",
     "@allurereport/plugin-api": "workspace:*",
     "@allurereport/plugin-awesome": "workspace:*",

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -7,14 +7,6 @@ import process, { exit } from "node:process";
 import { AllureReport, isFileNotFoundError, readConfig } from "@allurereport/core";
 import { Command, Option, UsageError } from "clipanion";
 
-import { executeAllureRun, executeNestedAllureCommand } from "./commons/run.js";
-import {
-  environmentNameOption,
-  environmentOption,
-  normalizeCommandEnvironmentOptions,
-  resolveCommandEnvironment,
-} from "../utils/environment.js";
-import { readLatestAgentState, resolveAgentStateDir, writeLatestAgentState } from "../utils/agent-state.js";
 import {
   createAgentTestPlanContext,
   normalizeAgentRerunPreset,
@@ -22,7 +14,15 @@ import {
   resolveAgentSelectionOutputDir,
   selectAgentTestPlan,
 } from "../utils/agent-select.js";
+import { readLatestAgentState, resolveAgentStateDir, writeLatestAgentState } from "../utils/agent-state.js";
+import {
+  environmentNameOption,
+  environmentOption,
+  normalizeCommandEnvironmentOptions,
+  resolveCommandEnvironment,
+} from "../utils/environment.js";
 import { createChildAllureCliEnvironment, getActiveAllureCliCommand } from "../utils/execution-context.js";
+import { executeAllureRun, executeNestedAllureCommand } from "./commons/run.js";
 
 const withProcessEnv = async <T>(overrides: Record<string, string | undefined>, fn: () => Promise<T>): Promise<T> => {
   const previousValues = new Map<string, string | undefined>();
@@ -199,7 +199,8 @@ export class AgentStateDirCommand extends Command {
 
   static usage = Command.Usage({
     description: "Print the Allure agent state directory for the current project",
-    details: "This command prints the resolved state directory used to persist latest-agent pointers for the current project cwd.",
+    details:
+      "This command prints the resolved state directory used to persist latest-agent pointers for the current project cwd.",
     examples: [
       ["agent state-dir", "Print the resolved state directory for the current project"],
       ["agent state-dir --cwd ./packages/cli", "Print the resolved state directory for a specific project cwd"],
@@ -222,7 +223,8 @@ export class AgentSelectCommand extends Command {
 
   static usage = Command.Usage({
     description: "Select tests from an existing agent output and emit a test plan",
-    details: "This command resolves a set of tests from a prior agent run and prints or writes a testplan.json payload.",
+    details:
+      "This command resolves a set of tests from a prior agent run and prints or writes a testplan.json payload.",
     examples: [
       ["agent select --from ./out/agent-output", "Print a test plan for the default review-targeted tests"],
       ["agent select --latest --preset failed", "Print a test plan for failed tests from the latest project run"],
@@ -231,7 +233,8 @@ export class AgentSelectCommand extends Command {
   });
 
   cwd = Option.String("--cwd", {
-    description: "The project directory used to resolve --latest and relative paths (default: current working directory)",
+    description:
+      "The project directory used to resolve --latest and relative paths (default: current working directory)",
   });
 
   from = Option.String("--from", {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,0 +1,483 @@
+import * as console from "node:console";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import process, { exit } from "node:process";
+
+import { AllureReport, isFileNotFoundError, readConfig } from "@allurereport/core";
+import { Command, Option, UsageError } from "clipanion";
+
+import { executeAllureRun, executeNestedAllureCommand } from "./commons/run.js";
+import {
+  environmentNameOption,
+  environmentOption,
+  normalizeCommandEnvironmentOptions,
+  resolveCommandEnvironment,
+} from "../utils/environment.js";
+import { readLatestAgentState, resolveAgentStateDir, writeLatestAgentState } from "../utils/agent-state.js";
+import {
+  createAgentTestPlanContext,
+  normalizeAgentRerunPreset,
+  parseAgentLabelFilters,
+  resolveAgentSelectionOutputDir,
+  selectAgentTestPlan,
+} from "../utils/agent-select.js";
+import { createChildAllureCliEnvironment, getActiveAllureCliCommand } from "../utils/execution-context.js";
+
+const withProcessEnv = async <T>(overrides: Record<string, string | undefined>, fn: () => Promise<T>): Promise<T> => {
+  const previousValues = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previousValues.set(key, process.env[key]);
+
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+
+    process.env[key] = value;
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previousValues) {
+      if (value === undefined) {
+        delete process.env[key];
+        continue;
+      }
+
+      process.env[key] = value;
+    }
+  }
+};
+
+const isPathInside = (parentPath: string, candidatePath: string) => {
+  const rel = relative(parentPath, candidatePath);
+
+  return rel === "" || (!rel.startsWith("..") && rel !== "." && !rel.startsWith("../"));
+};
+
+const persistLatestAgentState = async (value: Parameters<typeof writeLatestAgentState>[0]) => {
+  try {
+    await writeLatestAgentState(value);
+  } catch (error) {
+    console.error(
+      `Could not update latest agent output in ${resolveAgentStateDir(value.cwd)}: ${(error as Error).message}`,
+    );
+  }
+};
+
+const readOptionalString = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined);
+
+const readOptionalBoolean = (value: unknown): boolean => value === true;
+
+const readOptionalStringArray = (value: unknown): string[] | undefined => (Array.isArray(value) ? value : undefined);
+
+export class AgentCommand extends Command {
+  static paths = [["agent"]];
+
+  static usage = Command.Usage({
+    description: "Run specified command in Allure agent mode",
+    details: "This command runs the specified command with an agent-only Allure profile.",
+    examples: [
+      ["agent -- npm test", "Run npm test and capture only the agent-mode output"],
+      [
+        "agent --expectations ./expected.yaml -- npm test",
+        "Run npm test with agent-mode expectations loaded from ./expected.yaml",
+      ],
+    ],
+  });
+
+  config = Option.String("--config,-c", {
+    description: "The path Allure config file",
+  });
+
+  cwd = Option.String("--cwd", {
+    description: "The working directory for the command to run (default: current working directory)",
+  });
+
+  output = Option.String("--output,-o", {
+    description: "The output directory for agent artifacts. Absolute paths are accepted as well",
+  });
+
+  expectations = Option.String("--expectations", {
+    description: "The path to a YAML or JSON expectations file",
+  });
+
+  environment = environmentOption();
+
+  environmentName = environmentNameOption();
+
+  silent = Option.Boolean("--silent", {
+    description: "Don't pipe the process output logs to console (default: false)",
+  });
+
+  rerunFrom = Option.String("--rerun-from", {
+    description: "Select tests for rerun from an existing agent output directory",
+  });
+
+  rerunLatest = Option.Boolean("--rerun-latest", {
+    description: "Select tests for rerun from the latest recorded agent output for the current project",
+  });
+
+  rerunPreset = Option.String("--rerun-preset", {
+    description: "The rerun selection preset: review, failed, unsuccessful, or all (default: review)",
+  });
+
+  rerunEnvironments = Option.Array("--rerun-environment", {
+    description: "Filter rerun selection by environment id. Repeat the option for multiple environments",
+  });
+
+  rerunLabels = Option.Array("--rerun-label", {
+    description: "Filter rerun selection by exact label name=value. Repeat the option for multiple filters",
+  });
+
+  commandToRun = Option.Rest();
+
+  async execute() {
+    const args = this.commandToRun.filter((arg) => arg !== "--") as string[] | undefined;
+
+    await executeAgentMode({
+      configPath: readOptionalString(this.config),
+      cwd: readOptionalString(this.cwd),
+      output: readOptionalString(this.output),
+      expectations: readOptionalString(this.expectations),
+      environment: readOptionalString(this.environment),
+      environmentName: readOptionalString(this.environmentName),
+      silent: readOptionalBoolean(this.silent),
+      rerunFrom: readOptionalString(this.rerunFrom),
+      rerunLatest: readOptionalBoolean(this.rerunLatest),
+      rerunPreset: readOptionalString(this.rerunPreset),
+      rerunEnvironments: readOptionalStringArray(this.rerunEnvironments),
+      rerunLabels: readOptionalStringArray(this.rerunLabels),
+      args,
+    });
+  }
+}
+
+export class AgentLatestCommand extends Command {
+  static paths = [["agent", "latest"]];
+
+  static usage = Command.Usage({
+    description: "Print the latest Allure agent output directory for the current project",
+    details: "This command prints the latest agent output directory recorded for the resolved project cwd.",
+    examples: [
+      ["agent latest", "Print the latest agent output directory for the current project"],
+      ["agent latest --cwd ./packages/cli", "Print the latest agent output directory for a specific project cwd"],
+    ],
+  });
+
+  cwd = Option.String("--cwd", {
+    description: "The project directory used to resolve the latest agent output (default: current working directory)",
+  });
+
+  async execute() {
+    const cwd = await realpath(this.cwd ?? process.cwd());
+    let latestState;
+
+    try {
+      latestState = await readLatestAgentState(cwd);
+    } catch (error) {
+      console.error(`Could not read the latest agent output for ${cwd}: ${(error as Error).message}`);
+      exit(1);
+      return;
+    }
+
+    if (!latestState) {
+      console.error(`No latest agent output found for ${cwd}`);
+      exit(1);
+      return;
+    }
+
+    console.log(latestState.outputDir);
+  }
+}
+
+export class AgentStateDirCommand extends Command {
+  static paths = [["agent", "state-dir"]];
+
+  static usage = Command.Usage({
+    description: "Print the Allure agent state directory for the current project",
+    details: "This command prints the resolved state directory used to persist latest-agent pointers for the current project cwd.",
+    examples: [
+      ["agent state-dir", "Print the resolved state directory for the current project"],
+      ["agent state-dir --cwd ./packages/cli", "Print the resolved state directory for a specific project cwd"],
+    ],
+  });
+
+  cwd = Option.String("--cwd", {
+    description: "The project directory used to resolve the agent state directory (default: current working directory)",
+  });
+
+  async execute() {
+    const cwd = await realpath(readOptionalString(this.cwd) ?? process.cwd());
+
+    console.log(resolveAgentStateDir(cwd));
+  }
+}
+
+export class AgentSelectCommand extends Command {
+  static paths = [["agent", "select"]];
+
+  static usage = Command.Usage({
+    description: "Select tests from an existing agent output and emit a test plan",
+    details: "This command resolves a set of tests from a prior agent run and prints or writes a testplan.json payload.",
+    examples: [
+      ["agent select --from ./out/agent-output", "Print a test plan for the default review-targeted tests"],
+      ["agent select --latest --preset failed", "Print a test plan for failed tests from the latest project run"],
+      ["agent select --from ./out/agent-output --output ./testplan.json", "Write the selected test plan to a file"],
+    ],
+  });
+
+  cwd = Option.String("--cwd", {
+    description: "The project directory used to resolve --latest and relative paths (default: current working directory)",
+  });
+
+  from = Option.String("--from", {
+    description: "The prior agent output directory to select tests from",
+  });
+
+  latest = Option.Boolean("--latest", {
+    description: "Use the latest recorded agent output for the current project cwd",
+  });
+
+  preset = Option.String("--preset", {
+    description: "The selection preset: review, failed, unsuccessful, or all (default: review)",
+  });
+
+  environments = Option.Array("--environment", {
+    description: "Filter selected tests by environment id. Repeat the option for multiple environments",
+  });
+
+  labels = Option.Array("--label", {
+    description: "Filter selected tests by exact label name=value. Repeat the option for multiple filters",
+  });
+
+  output = Option.String("--output,-o", {
+    description: "Write the resulting test plan to this file instead of printing it to stdout",
+  });
+
+  async execute() {
+    const cwd = await realpath(readOptionalString(this.cwd) ?? process.cwd());
+    const environments = readOptionalStringArray(this.environments);
+    const labels = readOptionalStringArray(this.labels);
+    const outputDir = await resolveAgentSelectionOutputDir({
+      cwd,
+      from: readOptionalString(this.from),
+      latest: readOptionalBoolean(this.latest),
+    });
+    const selection = await selectAgentTestPlan({
+      outputDir,
+      preset: normalizeAgentRerunPreset(readOptionalString(this.preset)),
+      environments: environments?.length ? environments : undefined,
+      labelFilters: parseAgentLabelFilters(labels),
+    });
+
+    if (!selection.testPlan.tests.length) {
+      console.error(`No tests matched selection in ${selection.outputDir}`);
+      exit(1);
+      return;
+    }
+
+    const serialized = `${JSON.stringify(selection.testPlan, null, 2)}\n`;
+
+    const output = readOptionalString(this.output);
+
+    if (!output) {
+      console.log(serialized.trimEnd());
+      return;
+    }
+
+    const outputPath = resolve(cwd, output);
+
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, serialized, "utf-8");
+    console.log(outputPath);
+  }
+}
+
+export const executeAgentMode = async (params: {
+  configPath?: string;
+  cwd?: string;
+  output?: string;
+  expectations?: string;
+  environment?: string;
+  environmentName?: string;
+  silent?: boolean;
+  rerunFrom?: string;
+  rerunLatest?: boolean;
+  rerunPreset?: string;
+  rerunEnvironments?: string[];
+  rerunLabels?: string[];
+  args?: string[];
+}) => {
+  const {
+    configPath,
+    cwd: configuredCwd,
+    output,
+    expectations,
+    environment,
+    environmentName,
+    silent,
+    rerunFrom,
+    rerunLatest,
+    rerunPreset,
+    rerunEnvironments,
+    rerunLabels,
+    args,
+  } = params;
+
+  if (!args || !args.length) {
+    throw new UsageError("expecting command to be specified after --, e.g. allure agent -- npm run test");
+  }
+
+  const command = args[0];
+  const commandArgs = args.slice(1);
+  const cwd = await realpath(configuredCwd ?? process.cwd());
+  const commandString = `${command} ${commandArgs.join(" ")}`;
+  const hasRerunSource = !!rerunFrom || !!rerunLatest;
+  const hasRerunFilters = !!rerunPreset || !!rerunEnvironments?.length || !!rerunLabels?.length;
+
+  if (!hasRerunSource && hasRerunFilters) {
+    throw new UsageError("Use rerun filters only together with --rerun-from <path> or --rerun-latest");
+  }
+
+  const rerunContext = await createAgentTestPlanContext({
+    cwd,
+    from: rerunFrom,
+    latest: rerunLatest,
+    preset: normalizeAgentRerunPreset(rerunPreset),
+    environments: rerunEnvironments?.length ? rerunEnvironments : undefined,
+    labelFilters: parseAgentLabelFilters(rerunLabels),
+  });
+  const childEnvironmentVariables = {
+    ...createChildAllureCliEnvironment("agent"),
+    ...(rerunContext ? { ALLURE_TESTPLAN_PATH: rerunContext.testPlanPath } : {}),
+  };
+
+  try {
+    if (getActiveAllureCliCommand()) {
+      console.log(commandString);
+
+      const exitCode = await executeNestedAllureCommand({
+        command,
+        commandArgs,
+        cwd,
+        ...(rerunContext ? { environmentVariables: { ALLURE_TESTPLAN_PATH: rerunContext.testPlanPath } } : {}),
+        silent,
+      });
+
+      exit(exitCode ?? -1);
+      return;
+    }
+
+    const outputDir = output ? resolve(cwd, output) : await mkdtemp(join(tmpdir(), "allure-agent-"));
+    const expectationsPath = expectations ? resolve(cwd, expectations) : undefined;
+    const environmentOptions = {
+      environment,
+      environmentName,
+    };
+
+    normalizeCommandEnvironmentOptions(environmentOptions);
+
+    if (expectationsPath && isPathInside(outputDir, expectationsPath)) {
+      throw new UsageError(
+        `--expectations path ${JSON.stringify(expectationsPath)} must not be inside the agent output directory ${JSON.stringify(outputDir)}`,
+      );
+    }
+
+    const config = await readConfig(cwd, configPath, {
+      output: outputDir,
+      plugins: {
+        agent: {
+          options: {
+            outputDir,
+          },
+        },
+      },
+    });
+    const resolvedEnvironment = resolveCommandEnvironment(config, environmentOptions);
+
+    try {
+      await rm(outputDir, { recursive: true });
+    } catch (error) {
+      if (!isFileNotFoundError(error)) {
+        console.error("could not clean output directory", error);
+      }
+    }
+
+    const startedAt = new Date().toISOString();
+
+    await persistLatestAgentState({
+      cwd,
+      outputDir,
+      expectationsPath,
+      command: commandString,
+      startedAt,
+      status: "running",
+    });
+
+    console.log(`agent output: ${outputDir}`);
+    if (expectationsPath) {
+      console.log(`agent expectations: ${expectationsPath}`);
+    }
+    console.log(commandString);
+
+    const allureReport = new AllureReport({
+      ...config,
+      output: outputDir,
+      environment: resolvedEnvironment?.id,
+      open: false,
+      port: undefined,
+      qualityGate: undefined,
+      allureService: undefined,
+      realTime: false,
+      plugins: config.plugins,
+    });
+    const knownIssues = await allureReport.store.allKnownIssues();
+
+    const { globalExitCode } = await withProcessEnv(
+      {
+        ALLURE_AGENT_OUTPUT: outputDir,
+        ALLURE_AGENT_EXPECTATIONS: expectationsPath,
+        ALLURE_AGENT_COMMAND: commandString,
+        ALLURE_AGENT_PROJECT_ROOT: cwd,
+        ALLURE_AGENT_NAME: undefined,
+        ALLURE_AGENT_LOOP_ID: undefined,
+        ALLURE_AGENT_TASK_ID: undefined,
+        ALLURE_AGENT_CONVERSATION_ID: undefined,
+      },
+      async () =>
+        await executeAllureRun({
+          allureReport,
+          knownIssues,
+          cwd,
+          command,
+          commandArgs,
+          environmentVariables: childEnvironmentVariables,
+          environment: resolvedEnvironment?.id,
+          withQualityGate: false,
+          logs: "pipe",
+          silent,
+          ignoreLogs: false,
+          logProcessExit: false,
+        }),
+    );
+
+    await persistLatestAgentState({
+      cwd,
+      outputDir,
+      expectationsPath,
+      command: commandString,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      status: "finished",
+      exitCode: globalExitCode.actual ?? globalExitCode.original,
+    });
+
+    exit(globalExitCode.actual ?? globalExitCode.original);
+  } finally {
+    await rerunContext?.cleanup();
+  }
+};

--- a/packages/cli/src/commands/commons/run.ts
+++ b/packages/cli/src/commands/commons/run.ts
@@ -1,0 +1,414 @@
+import * as console from "node:console";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import process from "node:process";
+
+import { AllureReport, QualityGateState, stringifyQualityGateResults } from "@allurereport/core";
+import { type KnownTestFailure, createTestPlan } from "@allurereport/core-api";
+import type { Watcher } from "@allurereport/directory-watcher";
+import {
+  allureResultsDirectoriesWatcher,
+  delayedFileProcessingWatcher,
+  newFilesInDirectoryWatcher,
+} from "@allurereport/directory-watcher";
+import type { ExitCode, QualityGateValidationResult } from "@allurereport/plugin-api";
+import { BufferResultFile, PathResultFile } from "@allurereport/reader-api";
+import { KnownError } from "@allurereport/service";
+import { red } from "yoctocolors";
+
+import { logTests, runProcess, terminationOf } from "../../utils/index.js";
+import { logError } from "../../utils/logs.js";
+import { stopProcessTree } from "../../utils/process.js";
+
+export type TestProcessResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  qualityGateResults: QualityGateValidationResult[];
+};
+
+export type RunLogsMode = "pipe" | "inherit" | "ignore";
+
+export const executeNestedAllureCommand = async (params: {
+  command: string;
+  commandArgs: string[];
+  cwd: string;
+  environmentVariables?: Record<string, string>;
+  silent?: boolean;
+}): Promise<number | null> => {
+  const nestedProcess = runProcess({
+    command: params.command,
+    commandArgs: params.commandArgs,
+    cwd: params.cwd,
+    environmentVariables: params.environmentVariables,
+    logs: params.silent ? "ignore" : "inherit",
+  });
+
+  return await terminationOf(nestedProcess);
+};
+
+export const runTests = async (params: {
+  allureReport: AllureReport;
+  knownIssues: KnownTestFailure[];
+  cwd: string;
+  command: string;
+  commandArgs: string[];
+  environmentVariables: Record<string, string>;
+  environment?: string;
+  withQualityGate: boolean;
+  silent?: boolean;
+  logs?: RunLogsMode;
+  logProcessExit?: boolean;
+}): Promise<TestProcessResult | null> => {
+  const {
+    allureReport,
+    knownIssues,
+    cwd,
+    command,
+    commandArgs,
+    logs,
+    environmentVariables,
+    environment,
+    withQualityGate,
+    silent,
+    logProcessExit = true,
+  } = params;
+  let testProcessStarted = false;
+  const allureResultsWatchers: Map<string, Watcher> = new Map();
+  const processWatcher = delayedFileProcessingWatcher(
+    async (path) => {
+      await allureReport.readResult(new PathResultFile(path));
+    },
+    {
+      indexDelay: 200,
+      minProcessingDelay: 1_000,
+    },
+  );
+  const allureResultsWatch = allureResultsDirectoriesWatcher(
+    cwd,
+    async (newAllureResults, deletedAllureResults) => {
+      for (const delAr of deletedAllureResults) {
+        const watcher = allureResultsWatchers.get(delAr);
+
+        if (watcher) {
+          await watcher.abort();
+        }
+
+        allureResultsWatchers.delete(delAr);
+      }
+
+      for (const newAr of newAllureResults) {
+        if (allureResultsWatchers.has(newAr)) {
+          continue;
+        }
+
+        const watcher = newFilesInDirectoryWatcher(
+          newAr,
+          async (path) => {
+            await processWatcher.addFile(path);
+          },
+          {
+            // the initial scan is preformed before we start the test process.
+            // all the watchers created before the test process
+            // should ignore initial results.
+            ignoreInitial: !testProcessStarted,
+            indexDelay: 300,
+          },
+        );
+
+        allureResultsWatchers.set(newAr, watcher);
+
+        await watcher.initialScan();
+      }
+    },
+    { indexDelay: 600 },
+  );
+
+  await allureResultsWatch.initialScan();
+
+  testProcessStarted = true;
+
+  const beforeProcess = Date.now();
+  const testProcess = runProcess({
+    command,
+    commandArgs,
+    cwd,
+    environmentVariables,
+    logs,
+  });
+  const qualityGateState = new QualityGateState();
+  let qualityGateUnsub: ReturnType<typeof allureReport.realtimeSubscriber.onTestResults> | undefined;
+  let qualityGateResults: QualityGateValidationResult[] = [];
+  let testProcessStdout = "";
+  let testProcessStderr = "";
+
+  if (withQualityGate) {
+    qualityGateUnsub = allureReport.realtimeSubscriber.onTestResults(async (testResults) => {
+      const trs = await Promise.all(testResults.map((tr) => allureReport.store.testResultById(tr)));
+      const filteredTrs = trs.filter((tr) => tr !== undefined);
+
+      if (!filteredTrs.length) {
+        return;
+      }
+
+      const { results, fastFailed } = await allureReport.validate({
+        trs: filteredTrs,
+        state: qualityGateState,
+        environment,
+        knownIssues,
+      });
+
+      // process only fast-failed checks here
+      if (!fastFailed) {
+        return;
+      }
+
+      allureReport.realtimeDispatcher.sendQualityGateResults(results);
+      qualityGateResults = results;
+
+      try {
+        await stopProcessTree(testProcess.pid!);
+      } catch (err) {
+        if ((err as Error).message.includes("kill ESRCH")) {
+          return;
+        }
+
+        throw err;
+      }
+    });
+  }
+
+  if (logs === "pipe") {
+    testProcess.stdout?.setEncoding("utf8").on?.("data", (data: string) => {
+      testProcessStdout += data;
+
+      if (silent) {
+        return;
+      }
+
+      process.stdout.write(data);
+    });
+    testProcess.stderr?.setEncoding("utf8").on?.("data", async (data: string) => {
+      testProcessStderr += data;
+
+      if (silent) {
+        return;
+      }
+
+      process.stderr.write(data);
+    });
+  }
+
+  const code = await terminationOf(testProcess);
+  const afterProcess = Date.now();
+
+  if (logProcessExit) {
+    if (code !== null) {
+      console.log(`process finished with code ${code} (${afterProcess - beforeProcess}ms)`);
+    } else {
+      console.log(`process terminated (${afterProcess - beforeProcess}ms)`);
+    }
+  }
+
+  await allureResultsWatch.abort();
+
+  for (const [ar, watcher] of allureResultsWatchers) {
+    await watcher.abort();
+
+    allureResultsWatchers.delete(ar);
+  }
+
+  await processWatcher.abort();
+
+  qualityGateUnsub?.();
+
+  return {
+    code,
+    stdout: testProcessStdout,
+    stderr: testProcessStderr,
+    qualityGateResults,
+  };
+};
+
+export const executeAllureRun = async (params: {
+  allureReport: AllureReport;
+  knownIssues: KnownTestFailure[];
+  cwd: string;
+  command: string;
+  commandArgs: string[];
+  environmentVariables?: Record<string, string>;
+  environment?: string;
+  withQualityGate: boolean;
+  silent?: boolean;
+  logs?: RunLogsMode;
+  ignoreLogs?: boolean;
+  maxRerun?: number;
+  logProcessExit?: boolean;
+}): Promise<{
+  globalExitCode: ExitCode;
+  testProcessResult: TestProcessResult | null;
+}> => {
+  const {
+    allureReport,
+    knownIssues,
+    cwd,
+    command,
+    commandArgs,
+    environmentVariables = {},
+    environment,
+    withQualityGate,
+    silent,
+    logs,
+    ignoreLogs,
+    maxRerun = 0,
+    logProcessExit = true,
+  } = params;
+  await allureReport.start();
+
+  const globalExitCode: ExitCode = {
+    original: 0,
+    actual: undefined,
+  };
+  let qualityGateResults: QualityGateValidationResult[] = [];
+  let testProcessResult: TestProcessResult | null = null;
+
+  try {
+    testProcessResult = await runTests({
+      logs,
+      silent,
+      allureReport,
+      knownIssues,
+      cwd,
+      command,
+      commandArgs,
+      environment,
+      environmentVariables,
+      withQualityGate,
+      logProcessExit,
+    });
+
+    for (let rerun = 0; rerun < maxRerun; rerun++) {
+      const failed = await allureReport.store.failedTestResults();
+
+      if (failed.length === 0) {
+        console.log("no failed tests is detected.");
+        break;
+      }
+
+      const testPlan = createTestPlan(failed);
+
+      console.log(`rerun number ${rerun} of ${testPlan.tests.length} tests:`);
+      logTests(failed);
+
+      const tmpDir = await mkdtemp(join(tmpdir(), "allure-run-"));
+      const testPlanPath = resolve(tmpDir, `${rerun}-testplan.json`);
+
+      await writeFile(testPlanPath, JSON.stringify(testPlan));
+
+      testProcessResult = await runTests({
+        silent,
+        logs,
+        allureReport,
+        knownIssues,
+        cwd,
+        command,
+        commandArgs,
+        environment,
+        environmentVariables: {
+          ...environmentVariables,
+          ALLURE_TESTPLAN_PATH: testPlanPath,
+          ALLURE_RERUN: `${rerun}`,
+        },
+        withQualityGate,
+        logProcessExit,
+      });
+
+      await rm(tmpDir, { recursive: true });
+
+      logTests(await allureReport.store.allTestResults());
+    }
+
+    const trs = await allureReport.store.allTestResults({ includeHidden: false });
+    qualityGateResults = testProcessResult?.qualityGateResults ?? [];
+
+    if (withQualityGate && !qualityGateResults.length) {
+      const { results } = await allureReport.validate({
+        trs,
+        knownIssues,
+        environment,
+      });
+
+      qualityGateResults = results;
+    }
+
+    if (qualityGateResults.length) {
+      const qualityGateMessage = stringifyQualityGateResults(qualityGateResults);
+
+      console.error(qualityGateMessage);
+
+      allureReport.realtimeDispatcher.sendQualityGateResults(qualityGateResults);
+    }
+
+    globalExitCode.original = testProcessResult?.code ?? -1;
+
+    if (withQualityGate) {
+      globalExitCode.actual = qualityGateResults.length > 0 ? 1 : 0;
+    }
+  } catch (error) {
+    globalExitCode.actual = 1;
+
+    if (error instanceof KnownError) {
+      // eslint-disable-next-line no-console
+      console.error(red(error.message));
+
+      allureReport.realtimeDispatcher.sendGlobalError({
+        message: error.message,
+      });
+    } else {
+      await logError("Failed to run tests using Allure due to unexpected error", error as Error);
+
+      allureReport.realtimeDispatcher.sendGlobalError({
+        message: (error as Error).message,
+        trace: (error as Error).stack,
+      });
+    }
+  }
+
+  const processFailed = Math.abs(globalExitCode.actual ?? globalExitCode.original) !== 0;
+
+  if (!ignoreLogs && testProcessResult?.stdout) {
+    const fileName = randomUUID();
+    const stdoutResultFile = new BufferResultFile(Buffer.from(testProcessResult.stdout, "utf8"), `${fileName}`);
+
+    stdoutResultFile.contentType = "text/plain";
+
+    allureReport.realtimeDispatcher.sendGlobalAttachment(stdoutResultFile, "stdout.txt");
+  }
+
+  if (!ignoreLogs && testProcessResult?.stderr) {
+    const fileName = randomUUID();
+    const stderrResultFile = new BufferResultFile(Buffer.from(testProcessResult.stderr, "utf8"), fileName);
+
+    stderrResultFile.contentType = "text/plain";
+
+    allureReport.realtimeDispatcher.sendGlobalAttachment(stderrResultFile, "stderr.txt");
+
+    if (processFailed) {
+      allureReport.realtimeDispatcher.sendGlobalError({
+        message: "Test process has failed",
+        trace: testProcessResult.stderr,
+      });
+    }
+  }
+
+  allureReport.realtimeDispatcher.sendGlobalExitCode(globalExitCode);
+
+  await allureReport.done();
+
+  return {
+    globalExitCode,
+    testProcessResult,
+  };
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,6 +2,7 @@ export * from "./history.js";
 export * from "./testplan.js";
 export * from "./classic.js";
 export * from "./allure2.js";
+export * from "./agent.js";
 export * from "./awesome.js";
 export * from "./csv.js";
 export * from "./history.js";

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -9,8 +9,6 @@ import { serve } from "@allurereport/static-server";
 import { Command, Option, UsageError } from "clipanion";
 import { red } from "yoctocolors";
 
-import { executeAllureRun, executeNestedAllureCommand } from "./commons/run.js";
-import { executeAgentMode } from "./agent.js";
 import {
   environmentNameOption,
   environmentOption,
@@ -18,6 +16,8 @@ import {
   resolveCommandEnvironment,
 } from "../utils/environment.js";
 import { createChildAllureCliEnvironment, getActiveAllureCliCommand } from "../utils/execution-context.js";
+import { executeAgentMode } from "./agent.js";
+import { executeAllureRun, executeNestedAllureCommand } from "./commons/run.js";
 
 export class RunCommand extends Command {
   static paths = [["run"]];

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,227 +1,23 @@
 import * as console from "node:console";
-import { randomUUID } from "node:crypto";
-import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { realpath, rm } from "node:fs/promises";
+import { resolve } from "node:path";
 import process, { exit } from "node:process";
 
-import {
-  AllureReport,
-  QualityGateState,
-  isFileNotFoundError,
-  readConfig,
-  stringifyQualityGateResults,
-} from "@allurereport/core";
-import { type KnownTestFailure, createTestPlan } from "@allurereport/core-api";
-import type { Watcher } from "@allurereport/directory-watcher";
-import {
-  allureResultsDirectoriesWatcher,
-  delayedFileProcessingWatcher,
-  newFilesInDirectoryWatcher,
-} from "@allurereport/directory-watcher";
-import type { ExitCode, QualityGateValidationResult } from "@allurereport/plugin-api";
+import { AllureReport, isFileNotFoundError, readConfig } from "@allurereport/core";
 import Awesome from "@allurereport/plugin-awesome";
-import { BufferResultFile, PathResultFile } from "@allurereport/reader-api";
-import { KnownError } from "@allurereport/service";
 import { serve } from "@allurereport/static-server";
 import { Command, Option, UsageError } from "clipanion";
 import { red } from "yoctocolors";
 
+import { executeAllureRun, executeNestedAllureCommand } from "./commons/run.js";
+import { executeAgentMode } from "./agent.js";
 import {
   environmentNameOption,
   environmentOption,
   normalizeCommandEnvironmentOptions,
   resolveCommandEnvironment,
 } from "../utils/environment.js";
-import { logTests, runProcess, terminationOf } from "../utils/index.js";
-import { logError } from "../utils/logs.js";
-import { stopProcessTree } from "../utils/process.js";
-
-export type TestProcessResult = {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-  qualityGateResults: QualityGateValidationResult[];
-};
-
-const runTests = async (params: {
-  allureReport: AllureReport;
-  knownIssues: KnownTestFailure[];
-  cwd: string;
-  command: string;
-  commandArgs: string[];
-  environmentVariables: Record<string, string>;
-  environment?: string;
-  withQualityGate: boolean;
-  silent?: boolean;
-  logs?: "pipe" | "inherit" | "ignore";
-}): Promise<TestProcessResult | null> => {
-  const {
-    allureReport,
-    knownIssues,
-    cwd,
-    command,
-    commandArgs,
-    logs,
-    environmentVariables,
-    environment,
-    withQualityGate,
-    silent,
-  } = params;
-  let testProcessStarted = false;
-  const allureResultsWatchers: Map<string, Watcher> = new Map();
-  const processWatcher = delayedFileProcessingWatcher(
-    async (path) => {
-      await allureReport.readResult(new PathResultFile(path));
-    },
-    {
-      indexDelay: 200,
-      minProcessingDelay: 1_000,
-    },
-  );
-  const allureResultsWatch = allureResultsDirectoriesWatcher(
-    cwd,
-    async (newAllureResults, deletedAllureResults) => {
-      for (const delAr of deletedAllureResults) {
-        const watcher = allureResultsWatchers.get(delAr);
-
-        if (watcher) {
-          await watcher.abort();
-        }
-
-        allureResultsWatchers.delete(delAr);
-      }
-
-      for (const newAr of newAllureResults) {
-        if (allureResultsWatchers.has(newAr)) {
-          continue;
-        }
-
-        const watcher = newFilesInDirectoryWatcher(
-          newAr,
-          async (path) => {
-            await processWatcher.addFile(path);
-          },
-          {
-            // the initial scan is preformed before we start the test process.
-            // all the watchers created before the test process
-            // should ignore initial results.
-            ignoreInitial: !testProcessStarted,
-            indexDelay: 300,
-          },
-        );
-
-        allureResultsWatchers.set(newAr, watcher);
-
-        await watcher.initialScan();
-      }
-    },
-    { indexDelay: 600 },
-  );
-
-  await allureResultsWatch.initialScan();
-
-  testProcessStarted = true;
-
-  const beforeProcess = Date.now();
-  const testProcess = runProcess({
-    command,
-    commandArgs,
-    cwd,
-    environmentVariables,
-    logs,
-  });
-  const qualityGateState = new QualityGateState();
-  let qualityGateUnsub: ReturnType<typeof allureReport.realtimeSubscriber.onTestResults> | undefined;
-  let qualityGateResults: QualityGateValidationResult[] = [];
-  let testProcessStdout = "";
-  let testProcessStderr = "";
-
-  if (withQualityGate) {
-    qualityGateUnsub = allureReport.realtimeSubscriber.onTestResults(async (testResults) => {
-      const trs = await Promise.all(testResults.map((tr) => allureReport.store.testResultById(tr)));
-      const filteredTrs = trs.filter((tr) => tr !== undefined);
-
-      if (!filteredTrs.length) {
-        return;
-      }
-
-      const { results, fastFailed } = await allureReport.validate({
-        trs: filteredTrs,
-        state: qualityGateState,
-        environment,
-        knownIssues,
-      });
-
-      // process only fast-failed checks here
-      if (!fastFailed) {
-        return;
-      }
-
-      allureReport.realtimeDispatcher.sendQualityGateResults(results);
-      qualityGateResults = results;
-
-      try {
-        await stopProcessTree(testProcess.pid!);
-      } catch (err) {
-        if ((err as Error).message.includes("kill ESRCH")) {
-          return;
-        }
-
-        throw err;
-      }
-    });
-  }
-
-  if (logs === "pipe") {
-    testProcess.stdout?.setEncoding("utf8").on?.("data", (data: string) => {
-      testProcessStdout += data;
-
-      if (silent) {
-        return;
-      }
-
-      process.stdout.write(data);
-    });
-    testProcess.stderr?.setEncoding("utf8").on?.("data", async (data: string) => {
-      testProcessStderr += data;
-
-      if (silent) {
-        return;
-      }
-
-      process.stderr.write(data);
-    });
-  }
-
-  const code = await terminationOf(testProcess);
-  const afterProcess = Date.now();
-
-  if (code !== null) {
-    console.log(`process finished with code ${code} (${afterProcess - beforeProcess}ms)`);
-  } else {
-    console.log(`process terminated (${afterProcess - beforeProcess}ms)`);
-  }
-
-  await allureResultsWatch.abort();
-
-  for (const [ar, watcher] of allureResultsWatchers) {
-    await watcher.abort();
-
-    allureResultsWatchers.delete(ar);
-  }
-
-  await processWatcher.abort();
-
-  qualityGateUnsub?.();
-
-  return {
-    code,
-    stdout: testProcessStdout,
-    stderr: testProcessStderr,
-    qualityGateResults,
-  };
-};
+import { createChildAllureCliEnvironment, getActiveAllureCliCommand } from "../utils/execution-context.js";
 
 export class RunCommand extends Command {
   static paths = [["run"]];
@@ -309,12 +105,23 @@ export class RunCommand extends Command {
       throw new UsageError("expecting command to be specified after --, e.g. allure run -- npm run test");
     }
 
-    const environmentOptions = {
-      environment: this.environment,
-      environmentName: this.environmentName,
-    };
+    const legacyAgentOutput = process.env.ALLURE_AGENT_OUTPUT;
 
-    normalizeCommandEnvironmentOptions(environmentOptions);
+    if (legacyAgentOutput) {
+      await executeAgentMode({
+        configPath: this.config,
+        cwd: this.cwd,
+        output: resolve(process.cwd(), legacyAgentOutput),
+        expectations: process.env.ALLURE_AGENT_EXPECTATIONS
+          ? resolve(process.cwd(), process.env.ALLURE_AGENT_EXPECTATIONS)
+          : undefined,
+        environment: this.environment,
+        environmentName: this.environmentName,
+        silent: this.silent,
+        args,
+      });
+      return;
+    }
 
     const before = new Date().getTime();
 
@@ -330,6 +137,25 @@ export class RunCommand extends Command {
     const hideLabels = this.hideLabels?.length ? this.hideLabels : undefined;
 
     console.log(`${command} ${commandArgs.join(" ")}`);
+
+    if (getActiveAllureCliCommand()) {
+      const exitCode = await executeNestedAllureCommand({
+        command,
+        commandArgs,
+        cwd,
+        silent: this.silent,
+      });
+
+      exit(exitCode ?? -1);
+      return;
+    }
+
+    const environmentOptions = {
+      environment: this.environment,
+      environmentName: this.environmentName,
+    };
+
+    normalizeCommandEnvironmentOptions(environmentOptions);
 
     const maxRerun = this.rerun ? parseInt(this.rerun, 10) : 0;
     const config = await readConfig(cwd, this.config, {
@@ -378,145 +204,20 @@ export class RunCommand extends Command {
       ],
     });
     const knownIssues = await allureReport.store.allKnownIssues();
-
-    await allureReport.start();
-
-    const globalExitCode: ExitCode = {
-      original: 0,
-      actual: undefined,
-    };
-    let qualityGateResults: QualityGateValidationResult[];
-    let testProcessResult: TestProcessResult | null = null;
-
-    try {
-      testProcessResult = await runTests({
-        logs: this.logs,
-        silent: this.silent,
-        allureReport,
-        knownIssues,
-        cwd,
-        command,
-        commandArgs,
-        environment: resolvedEnvironment?.id,
-        environmentVariables: {},
-        withQualityGate,
-      });
-
-      for (let rerun = 0; rerun < maxRerun; rerun++) {
-        const failed = await allureReport.store.failedTestResults();
-
-        if (failed.length === 0) {
-          console.log("no failed tests is detected.");
-          break;
-        }
-
-        const testPlan = createTestPlan(failed);
-
-        console.log(`rerun number ${rerun} of ${testPlan.tests.length} tests:`);
-        logTests(failed);
-
-        const tmpDir = await mkdtemp(join(tmpdir(), "allure-run-"));
-        const testPlanPath = resolve(tmpDir, `${rerun}-testplan.json`);
-
-        await writeFile(testPlanPath, JSON.stringify(testPlan));
-
-        testProcessResult = await runTests({
-          silent: this.silent,
-          logs: this.logs,
-          allureReport,
-          knownIssues,
-          cwd,
-          command,
-          commandArgs,
-          environment: resolvedEnvironment?.id,
-          environmentVariables: {
-            ALLURE_TESTPLAN_PATH: testPlanPath,
-            ALLURE_RERUN: `${rerun}`,
-          },
-          withQualityGate,
-        });
-
-        await rm(tmpDir, { recursive: true });
-
-        logTests(await allureReport.store.allTestResults());
-      }
-
-      const trs = await allureReport.store.allTestResults({ includeHidden: false });
-      qualityGateResults = testProcessResult?.qualityGateResults ?? [];
-
-      if (withQualityGate && !qualityGateResults?.length) {
-        const { results } = await allureReport.validate({
-          trs,
-          knownIssues,
-          environment: resolvedEnvironment?.id,
-        });
-
-        qualityGateResults = results;
-      }
-
-      if (qualityGateResults?.length) {
-        const qualityGateMessage = stringifyQualityGateResults(qualityGateResults);
-
-        console.error(qualityGateMessage);
-
-        allureReport.realtimeDispatcher.sendQualityGateResults(qualityGateResults);
-      }
-
-      globalExitCode.original = testProcessResult?.code ?? -1;
-
-      if (withQualityGate) {
-        globalExitCode.actual = qualityGateResults.length > 0 ? 1 : 0;
-      }
-    } catch (error) {
-      globalExitCode.actual = 1;
-
-      if (error instanceof KnownError) {
-        // eslint-disable-next-line no-console
-        console.error(red(error.message));
-
-        allureReport.realtimeDispatcher.sendGlobalError({
-          message: error.message,
-        });
-      } else {
-        await logError("Failed to run tests using Allure due to unexpected error", error as Error);
-
-        allureReport.realtimeDispatcher.sendGlobalError({
-          message: (error as Error).message,
-          trace: (error as Error).stack,
-        });
-      }
-    }
-
-    const processFailed = Math.abs(globalExitCode.actual ?? globalExitCode.original) !== 0;
-
-    if (!this.ignoreLogs && testProcessResult?.stdout) {
-      const fileName = randomUUID();
-      const stdoutResultFile = new BufferResultFile(Buffer.from(testProcessResult.stdout, "utf8"), `${fileName}`);
-
-      stdoutResultFile.contentType = "text/plain";
-
-      allureReport.realtimeDispatcher.sendGlobalAttachment(stdoutResultFile, "stdout.txt");
-    }
-
-    if (!this.ignoreLogs && testProcessResult?.stderr) {
-      const fileName = randomUUID();
-      const stderrResultFile = new BufferResultFile(Buffer.from(testProcessResult.stderr, "utf8"), fileName);
-
-      stderrResultFile.contentType = "text/plain";
-
-      allureReport.realtimeDispatcher.sendGlobalAttachment(stderrResultFile, "stderr.txt");
-
-      if (processFailed) {
-        allureReport.realtimeDispatcher.sendGlobalError({
-          message: "Test process has failed",
-          trace: testProcessResult.stderr,
-        });
-      }
-    }
-
-    allureReport.realtimeDispatcher.sendGlobalExitCode(globalExitCode);
-
-    await allureReport.done();
+    const { globalExitCode } = await executeAllureRun({
+      allureReport,
+      knownIssues,
+      cwd,
+      command,
+      commandArgs,
+      environmentVariables: createChildAllureCliEnvironment("run"),
+      environment: resolvedEnvironment?.id,
+      withQualityGate,
+      logs: this.logs,
+      silent: this.silent,
+      ignoreLogs: this.ignoreLogs,
+      maxRerun,
+    });
 
     if (config.open) {
       await serve({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,10 @@ import { argv } from "node:process";
 import { Builtins, Cli } from "clipanion";
 
 import {
+  AgentCommand,
+  AgentLatestCommand,
+  AgentSelectCommand,
+  AgentStateDirCommand,
   Allure2Command,
   AwesomeCommand,
   ClassicCommand,
@@ -39,6 +43,10 @@ const cli = new Cli({
 
 cli.register(AwesomeCommand);
 cli.register(Allure2Command);
+cli.register(AgentLatestCommand);
+cli.register(AgentSelectCommand);
+cli.register(AgentStateDirCommand);
+cli.register(AgentCommand);
 cli.register(ClassicCommand);
 cli.register(CsvCommand);
 cli.register(DashboardCommand);

--- a/packages/cli/src/utils/agent-select.ts
+++ b/packages/cli/src/utils/agent-select.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import type { TestLabel, TestPlan, TestPlanTest } from "@allurereport/core-api";
+import {
+  loadAgentOutput,
+  planAgentEnrichmentReview,
+  type AgentOutputBundle,
+  type AgentTestManifestLine,
+} from "@allurereport/plugin-agent";
+import { UsageError } from "clipanion";
+
+import { readLatestAgentState } from "./agent-state.js";
+
+export type AgentRerunPreset = "review" | "failed" | "unsuccessful" | "all";
+
+export type AgentLabelFilter = {
+  name: string;
+  value: string;
+};
+
+export type AgentSelectionResult = {
+  outputDir: string;
+  preset: AgentRerunPreset;
+  selectedTests: AgentTestManifestLine[];
+  testPlan: TestPlan;
+};
+
+export type AgentTestPlanContext = {
+  outputDir: string;
+  preset: AgentRerunPreset;
+  selectedCount: number;
+  testPlanPath: string;
+  cleanup: () => Promise<void>;
+};
+
+const AGENT_RERUN_PRESETS: AgentRerunPreset[] = ["review", "failed", "unsuccessful", "all"];
+
+const ALLURE_ID_LABEL = "ALLURE_ID";
+
+const isAgentRerunPreset = (value: string): value is AgentRerunPreset =>
+  AGENT_RERUN_PRESETS.includes(value as AgentRerunPreset);
+
+const readAllureId = (labels: TestLabel[]) => labels.find((label) => label.name === ALLURE_ID_LABEL)?.value;
+
+const matchesLabelFilters = (labels: TestLabel[], filters: AgentLabelFilter[]) =>
+  filters.every((filter) => labels.some((label) => label.name === filter.name && label.value === filter.value));
+
+const buildTestPlan = (tests: AgentTestManifestLine[]): TestPlan => {
+  const seenSelectors = new Set<string>();
+  const seenIds = new Set<string>();
+  const selected: TestPlanTest[] = [];
+
+  for (const test of tests) {
+    const selector = test.full_name || undefined;
+    const id = readAllureId(test.labels);
+
+    if (selector && !seenSelectors.has(selector)) {
+      seenSelectors.add(selector);
+      if (id) {
+        seenIds.add(id);
+      }
+      selected.push({
+        selector,
+        ...(id ? { id } : {}),
+      });
+      continue;
+    }
+
+    if (id && !seenIds.has(id)) {
+      seenIds.add(id);
+      selected.push({ id });
+    }
+  }
+
+  return {
+    version: "1.0",
+    tests: selected,
+  };
+};
+
+const selectTestsByPreset = (
+  output: AgentOutputBundle,
+  preset: AgentRerunPreset,
+): AgentTestManifestLine[] => {
+  switch (preset) {
+    case "review": {
+      const review = planAgentEnrichmentReview(output);
+      const targeted = new Set(review.rerun.targetedTests);
+
+      return output.tests.filter((test) => targeted.has(test.full_name));
+    }
+
+    case "failed":
+      return output.tests.filter((test) => test.status === "failed" || test.status === "broken");
+
+    case "unsuccessful":
+      return output.tests.filter((test) => test.status !== "passed");
+
+    case "all":
+      return output.tests;
+  }
+};
+
+export const normalizeAgentRerunPreset = (value?: string): AgentRerunPreset => {
+  if (!value) {
+    return "review";
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (!isAgentRerunPreset(normalized)) {
+    throw new UsageError(
+      `Invalid rerun preset ${JSON.stringify(value)}. Expected one of: ${AGENT_RERUN_PRESETS.join(", ")}`,
+    );
+  }
+
+  return normalized;
+};
+
+export const parseAgentLabelFilters = (values?: string[]): AgentLabelFilter[] =>
+  (values ?? []).map((value) => {
+    const separatorIndex = value.indexOf("=");
+
+    if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+      throw new UsageError(
+        `Invalid label filter ${JSON.stringify(value)}. Expected the form name=value, for example feature=checkout`,
+      );
+    }
+
+    const name = value.slice(0, separatorIndex).trim();
+    const filterValue = value.slice(separatorIndex + 1).trim();
+
+    if (!name || !filterValue) {
+      throw new UsageError(
+        `Invalid label filter ${JSON.stringify(value)}. Expected the form name=value, for example feature=checkout`,
+      );
+    }
+
+    return {
+      name,
+      value: filterValue,
+    };
+  });
+
+export const resolveAgentSelectionOutputDir = async (params: {
+  cwd: string;
+  from?: string;
+  latest?: boolean;
+}): Promise<string> => {
+  const { cwd, from, latest } = params;
+
+  if (from && latest) {
+    throw new UsageError("Use either --from or --latest, not both");
+  }
+
+  if (!from && !latest) {
+    throw new UsageError("Expected either --from <path> or --latest");
+  }
+
+  if (from) {
+    return resolve(cwd, from);
+  }
+
+  const latestState = await readLatestAgentState(cwd);
+
+  if (!latestState) {
+    throw new UsageError(`No latest agent output found for ${cwd}`);
+  }
+
+  return latestState.outputDir;
+};
+
+export const selectAgentTestPlan = async (params: {
+  outputDir: string;
+  preset?: AgentRerunPreset;
+  environments?: string[];
+  labelFilters?: AgentLabelFilter[];
+}): Promise<AgentSelectionResult> => {
+  const preset = params.preset ?? "review";
+  const output = await loadAgentOutput(params.outputDir);
+  const selectedTests = selectTestsByPreset(output, preset)
+    .filter((test) =>
+      params.environments?.length ? params.environments.includes(test.environment_id) : true,
+    )
+    .filter((test) => (params.labelFilters?.length ? matchesLabelFilters(test.labels, params.labelFilters) : true));
+
+  return {
+    outputDir: output.outputDir,
+    preset,
+    selectedTests,
+    testPlan: buildTestPlan(selectedTests),
+  };
+};
+
+export const createAgentTestPlanContext = async (params: {
+  cwd: string;
+  from?: string;
+  latest?: boolean;
+  preset?: AgentRerunPreset;
+  environments?: string[];
+  labelFilters?: AgentLabelFilter[];
+}): Promise<AgentTestPlanContext | undefined> => {
+  const { from, latest } = params;
+
+  if (!from && !latest) {
+    return undefined;
+  }
+
+  const outputDir = await resolveAgentSelectionOutputDir({
+    cwd: params.cwd,
+    from,
+    latest,
+  });
+  const selection = await selectAgentTestPlan({
+    outputDir,
+    preset: params.preset,
+    environments: params.environments,
+    labelFilters: params.labelFilters,
+  });
+
+  if (!selection.testPlan.tests.length) {
+    throw new UsageError(
+      `No tests matched rerun selection in ${selection.outputDir}. Adjust the preset or filters before rerunning.`,
+    );
+  }
+
+  const tempDir = await mkdtemp(join(tmpdir(), "allure-agent-select-"));
+  const testPlanPath = join(tempDir, "testplan.json");
+
+  await writeFile(testPlanPath, `${JSON.stringify(selection.testPlan, null, 2)}\n`, "utf-8");
+
+  return {
+    outputDir: selection.outputDir,
+    preset: selection.preset,
+    selectedCount: selection.testPlan.tests.length,
+    testPlanPath,
+    cleanup: async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    },
+  };
+};

--- a/packages/cli/src/utils/agent-select.ts
+++ b/packages/cli/src/utils/agent-select.ts
@@ -80,10 +80,7 @@ const buildTestPlan = (tests: AgentTestManifestLine[]): TestPlan => {
   };
 };
 
-const selectTestsByPreset = (
-  output: AgentOutputBundle,
-  preset: AgentRerunPreset,
-): AgentTestManifestLine[] => {
+const selectTestsByPreset = (output: AgentOutputBundle, preset: AgentRerunPreset): AgentTestManifestLine[] => {
   switch (preset) {
     case "review": {
       const review = planAgentEnrichmentReview(output);
@@ -181,9 +178,7 @@ export const selectAgentTestPlan = async (params: {
   const preset = params.preset ?? "review";
   const output = await loadAgentOutput(params.outputDir);
   const selectedTests = selectTestsByPreset(output, preset)
-    .filter((test) =>
-      params.environments?.length ? params.environments.includes(test.environment_id) : true,
-    )
+    .filter((test) => (params.environments?.length ? params.environments.includes(test.environment_id) : true))
     .filter((test) => (params.labelFilters?.length ? matchesLabelFilters(test.labels, params.labelFilters) : true));
 
   return {

--- a/packages/cli/src/utils/agent-state.ts
+++ b/packages/cli/src/utils/agent-state.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type AgentLatestState = {
+  schema: "allure-agent-latest/v1";
+  cwd: string;
+  outputDir: string;
+  expectationsPath?: string;
+  command: string;
+  startedAt: string;
+  finishedAt?: string;
+  status: "running" | "finished";
+  exitCode?: number | null;
+};
+
+const AGENT_STATE_SCHEMA = "allure-agent-latest/v1";
+export const ALLURE_AGENT_STATE_DIR_ENV = "ALLURE_AGENT_STATE_DIR";
+
+const isFileNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+
+const projectHash = (cwd: string) => createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+
+export const resolveAgentStateDir = (cwd: string) => {
+  const configuredDir = process.env[ALLURE_AGENT_STATE_DIR_ENV]?.trim();
+
+  if (configuredDir) {
+    return resolve(configuredDir);
+  }
+
+  return join(tmpdir(), `allure-agent-state-${projectHash(resolve(cwd))}`);
+};
+
+const projectStatePath = (cwd: string) => join(resolveAgentStateDir(cwd), "latest.json");
+
+const writeJsonAtomic = async (filePath: string, value: unknown) => {
+  await mkdir(dirname(filePath), { recursive: true });
+
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+
+  await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+  await rename(tempPath, filePath);
+};
+
+const isAgentLatestState = (value: unknown): value is AgentLatestState => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<AgentLatestState>;
+
+  return (
+    candidate.schema === AGENT_STATE_SCHEMA &&
+    typeof candidate.cwd === "string" &&
+    typeof candidate.outputDir === "string" &&
+    typeof candidate.command === "string" &&
+    typeof candidate.startedAt === "string" &&
+    (candidate.expectationsPath === undefined || typeof candidate.expectationsPath === "string") &&
+    (candidate.finishedAt === undefined || typeof candidate.finishedAt === "string") &&
+    (candidate.status === "running" || candidate.status === "finished") &&
+    (candidate.exitCode === undefined || typeof candidate.exitCode === "number" || candidate.exitCode === null)
+  );
+};
+
+export const writeLatestAgentState = async (
+  value: Omit<AgentLatestState, "schema">,
+): Promise<AgentLatestState> => {
+  const normalizedState: AgentLatestState = {
+    schema: AGENT_STATE_SCHEMA,
+    cwd: resolve(value.cwd),
+    outputDir: resolve(value.outputDir),
+    expectationsPath: value.expectationsPath ? resolve(value.expectationsPath) : undefined,
+    command: value.command,
+    startedAt: value.startedAt,
+    finishedAt: value.finishedAt,
+    status: value.status,
+    exitCode: value.exitCode,
+  };
+
+  await writeJsonAtomic(projectStatePath(normalizedState.cwd), normalizedState);
+
+  return normalizedState;
+};
+
+export const readLatestAgentState = async (cwd: string): Promise<AgentLatestState | undefined> => {
+  const normalizedCwd = resolve(cwd);
+  const statePath = projectStatePath(normalizedCwd);
+  let raw: string;
+
+  try {
+    raw = await readFile(statePath, "utf-8");
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (!isAgentLatestState(parsed)) {
+    throw new Error(`Invalid latest agent state in ${statePath}`);
+  }
+
+  if (parsed.cwd !== normalizedCwd) {
+    return undefined;
+  }
+
+  try {
+    await stat(parsed.outputDir);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+
+  return parsed;
+};

--- a/packages/cli/src/utils/agent-state.ts
+++ b/packages/cli/src/utils/agent-state.ts
@@ -64,9 +64,7 @@ const isAgentLatestState = (value: unknown): value is AgentLatestState => {
   );
 };
 
-export const writeLatestAgentState = async (
-  value: Omit<AgentLatestState, "schema">,
-): Promise<AgentLatestState> => {
+export const writeLatestAgentState = async (value: Omit<AgentLatestState, "schema">): Promise<AgentLatestState> => {
   const normalizedState: AgentLatestState = {
     schema: AGENT_STATE_SCHEMA,
     cwd: resolve(value.cwd),

--- a/packages/cli/src/utils/environment.ts
+++ b/packages/cli/src/utils/environment.ts
@@ -1,7 +1,6 @@
 import {
   environmentIdentityById,
   environmentIdentityByName,
-  type FullConfig,
   validateAllowedEnvironmentId,
 } from "@allurereport/core";
 import type { EnvironmentIdentity } from "@allurereport/core-api";
@@ -22,6 +21,7 @@ type CommandEnvironmentOptions = {
 type EnvironmentConfig = {
   environment?: string;
   environments?: EnvironmentsConfig;
+  allowedEnvironments?: string[];
 };
 
 export const environmentOption = () =>
@@ -65,7 +65,7 @@ const resolveConfigEnvironment = (config: Pick<EnvironmentConfig, "environment" 
 };
 
 export const resolveCommandEnvironment = (
-  config: Pick<FullConfig, "environment" | "environments" | "allowedEnvironments">,
+  config: Pick<EnvironmentConfig, "environment" | "environments" | "allowedEnvironments">,
   options: CommandEnvironmentOptions & { source?: string },
 ): EnvironmentIdentity | undefined => {
   const source = options.source ?? "cli";
@@ -85,7 +85,7 @@ export const resolveCommandEnvironment = (
   }
 
   const identity = identityFromId ?? identityFromName ?? configIdentity;
-  const allowedEnvironmentIds = new Set(config.allowedEnvironments ?? []);
+  const allowedEnvironmentIds = new Set<string>(config.allowedEnvironments ?? []);
   const allowlistError =
     identity?.id !== undefined ? validateAllowedEnvironmentId(identity.id, allowedEnvironmentIds, source) : undefined;
 

--- a/packages/cli/src/utils/environment.ts
+++ b/packages/cli/src/utils/environment.ts
@@ -1,8 +1,4 @@
-import {
-  environmentIdentityById,
-  environmentIdentityByName,
-  validateAllowedEnvironmentId,
-} from "@allurereport/core";
+import { environmentIdentityById, environmentIdentityByName, validateAllowedEnvironmentId } from "@allurereport/core";
 import type { EnvironmentIdentity } from "@allurereport/core-api";
 import { validateEnvironmentId, validateEnvironmentName, type EnvironmentsConfig } from "@allurereport/core-api";
 import { Option, UsageError } from "clipanion";

--- a/packages/cli/src/utils/execution-context.ts
+++ b/packages/cli/src/utils/execution-context.ts
@@ -1,0 +1,15 @@
+import process from "node:process";
+
+export const ALLURE_CLI_ACTIVE_COMMAND_ENV = "ALLURE_CLI_ACTIVE_COMMAND";
+
+export type AllureCliActiveCommand = "agent" | "run";
+
+export const getActiveAllureCliCommand = (): AllureCliActiveCommand | undefined => {
+  const activeCommand = process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV];
+
+  return activeCommand === "agent" || activeCommand === "run" ? activeCommand : undefined;
+};
+
+export const createChildAllureCliEnvironment = (command: AllureCliActiveCommand): Record<string, string> => ({
+  [ALLURE_CLI_ACTIVE_COMMAND_ENV]: command,
+});

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,3 +1,6 @@
 export * from "./process.js";
 export * from "./terminal.js";
 export * from "./logs.js";
+export * from "./execution-context.js";
+export * from "./agent-state.js";
+export * from "./agent-select.js";

--- a/packages/cli/src/utils/process.ts
+++ b/packages/cli/src/utils/process.ts
@@ -41,13 +41,14 @@ export const runProcess = (params: {
       COLORTERM: "truecolor",
       TERM: "xterm-256color",
     });
+    delete env.NO_COLOR;
   }
 
   return spawn(command, commandArgs, {
     env,
     cwd,
     stdio: logs,
-    shell: true,
+    shell: IS_WIN,
   });
 };
 

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -54,7 +54,7 @@ vi.mock("../../src/utils/agent-state.js", () => ({
   readLatestAgentState: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("../../src/utils/agent-select.js", () => ({
-  normalizeAgentRerunPreset: vi.fn((value?: string) => (value ?? "review")),
+  normalizeAgentRerunPreset: vi.fn((value?: string) => value ?? "review"),
   parseAgentLabelFilters: vi.fn((values?: string[]) =>
     (values ?? []).map((value) => {
       const [name, filterValue] = value.split("=");
@@ -203,7 +203,9 @@ describe("agent command", () => {
     const stateDir = "/tmp/allure-agent-state-0f0810f05e3f7d8f";
 
     (writeLatestAgentState as Mock)
-      .mockRejectedValueOnce(Object.assign(new Error(`EACCES: permission denied, mkdir '${stateDir}'`), { code: "EACCES" }))
+      .mockRejectedValueOnce(
+        Object.assign(new Error(`EACCES: permission denied, mkdir '${stateDir}'`), { code: "EACCES" }),
+      )
       .mockResolvedValueOnce(undefined);
 
     await run(AgentCommand, ["agent", "--", "npm", "test"]);

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -1,0 +1,382 @@
+import { readConfig } from "@allurereport/core";
+import { run, UsageError } from "clipanion";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentCommand } from "../../src/commands/agent.js";
+import { executeAllureRun, executeNestedAllureCommand } from "../../src/commands/commons/run.js";
+import { createAgentTestPlanContext } from "../../src/utils/agent-select.js";
+import { writeLatestAgentState } from "../../src/utils/agent-state.js";
+import { ALLURE_CLI_ACTIVE_COMMAND_ENV } from "../../src/utils/execution-context.js";
+
+const { exitMock } = vi.hoisted(() => {
+  return {
+    exitMock: vi.fn(),
+  };
+});
+
+vi.mock("node:console", async (importOriginal) => ({
+  ...(await importOriginal()),
+  log: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock("node:process", async (importOriginal) => ({
+  ...(await importOriginal()),
+  exit: (...args: unknown[]) => exitMock(...args),
+}));
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal()),
+  realpath: vi.fn().mockResolvedValue("/cwd"),
+  mkdtemp: vi.fn().mockResolvedValue("/tmp/allure-agent-123"),
+  rm: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@allurereport/core", async () => {
+  const { AllureReportMock } = await import("../utils.js");
+
+  return {
+    AllureReport: AllureReportMock,
+    readConfig: vi.fn(),
+    isFileNotFoundError: vi.fn().mockReturnValue(false),
+  };
+});
+vi.mock("../../src/commands/commons/run.js", () => ({
+  executeAllureRun: vi.fn().mockResolvedValue({
+    globalExitCode: {
+      original: 0,
+      actual: undefined,
+    },
+    testProcessResult: null,
+  }),
+  executeNestedAllureCommand: vi.fn().mockResolvedValue(0),
+}));
+vi.mock("../../src/utils/agent-state.js", () => ({
+  resolveAgentStateDir: vi.fn().mockReturnValue("/tmp/allure-agent-state-0f0810f05e3f7d8f"),
+  writeLatestAgentState: vi.fn().mockResolvedValue(undefined),
+  readLatestAgentState: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/utils/agent-select.js", () => ({
+  normalizeAgentRerunPreset: vi.fn((value?: string) => (value ?? "review")),
+  parseAgentLabelFilters: vi.fn((values?: string[]) =>
+    (values ?? []).map((value) => {
+      const [name, filterValue] = value.split("=");
+
+      return {
+        name,
+        value: filterValue,
+      };
+    }),
+  ),
+  resolveAgentSelectionOutputDir: vi.fn(),
+  selectAgentTestPlan: vi.fn(),
+  createAgentTestPlanContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  delete process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV];
+
+  const { AllureReportMock } = await import("../utils.js");
+
+  AllureReportMock.prototype.store = {
+    allKnownIssues: vi.fn().mockResolvedValue([]),
+  };
+  (readConfig as Mock).mockResolvedValue({
+    output: "./allure-report",
+    open: true,
+    qualityGate: {
+      rules: [],
+    },
+    allureService: {
+      accessToken: "token",
+    },
+    plugins: [
+      {
+        id: "agent",
+        enabled: true,
+        options: {
+          outputDir: "/tmp/allure-agent-123",
+        },
+        plugin: { name: "agent-plugin" },
+      },
+    ],
+  });
+});
+
+describe("agent command", () => {
+  it("should fail with usage error when command to run is missing", async () => {
+    const command = new AgentCommand();
+
+    command.commandToRun = [];
+
+    await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+  });
+
+  it("should reject expectations files placed inside the output directory", async () => {
+    const command = new AgentCommand();
+
+    command.output = "./custom-output";
+    command.expectations = "./custom-output/expected.yaml";
+    command.commandToRun = ["--", "npm", "test"];
+
+    await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(executeAllureRun).not.toHaveBeenCalled();
+  });
+
+  it("should use an auto-created agent output dir and pass agent-only overrides to readConfig", async () => {
+    const { AllureReportMock } = await import("../utils.js");
+    const consoleModule = await import("node:console");
+    const logMock = consoleModule.log as Mock;
+
+    await run(AgentCommand, ["agent", "--", "npm", "test"]);
+
+    expect(readConfig).toHaveBeenCalledWith("/cwd", undefined, {
+      output: "/tmp/allure-agent-123",
+      plugins: {
+        agent: {
+          options: {
+            outputDir: "/tmp/allure-agent-123",
+          },
+        },
+      },
+    });
+    expect(AllureReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: "/tmp/allure-agent-123",
+        open: false,
+        port: undefined,
+        qualityGate: undefined,
+        allureService: undefined,
+        plugins: expect.arrayContaining([
+          expect.objectContaining({
+            id: "agent",
+          }),
+        ]),
+      }),
+    );
+    expect(executeAllureRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "npm",
+        commandArgs: ["test"],
+        cwd: "/cwd",
+        environmentVariables: {
+          ALLURE_CLI_ACTIVE_COMMAND: "agent",
+        },
+        withQualityGate: false,
+        logs: "pipe",
+        ignoreLogs: false,
+        logProcessExit: false,
+      }),
+    );
+    expect(logMock).toHaveBeenNthCalledWith(1, "agent output: /tmp/allure-agent-123");
+    expect(logMock).toHaveBeenNthCalledWith(2, "npm test");
+    expect(logMock.mock.invocationCallOrder[0]).toBeLessThan((executeAllureRun as Mock).mock.invocationCallOrder[0]);
+    expect(writeLatestAgentState).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cwd: "/cwd",
+        outputDir: "/tmp/allure-agent-123",
+        expectationsPath: undefined,
+        command: "npm test",
+        startedAt: expect.any(String),
+        status: "running",
+      }),
+    );
+    expect(writeLatestAgentState).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        cwd: "/cwd",
+        outputDir: "/tmp/allure-agent-123",
+        expectationsPath: undefined,
+        command: "npm test",
+        startedAt: expect.any(String),
+        finishedAt: expect.any(String),
+        status: "finished",
+        exitCode: 0,
+      }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("should continue the run when latest-state persistence in the resolved state dir is not permitted", async () => {
+    const consoleModule = await import("node:console");
+    const stateDir = "/tmp/allure-agent-state-0f0810f05e3f7d8f";
+
+    (writeLatestAgentState as Mock)
+      .mockRejectedValueOnce(Object.assign(new Error(`EACCES: permission denied, mkdir '${stateDir}'`), { code: "EACCES" }))
+      .mockResolvedValueOnce(undefined);
+
+    await run(AgentCommand, ["agent", "--", "npm", "test"]);
+
+    expect(consoleModule.error).toHaveBeenCalledWith(
+      `Could not update latest agent output in ${stateDir}: EACCES: permission denied, mkdir '${stateDir}'`,
+    );
+    expect(executeAllureRun).toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("should resolve explicit output and expectations paths relative to cwd", async () => {
+    const consoleModule = await import("node:console");
+
+    await run(AgentCommand, [
+      "agent",
+      "--output",
+      "./custom-output",
+      "--expectations",
+      "./expected.yaml",
+      "--",
+      "npm",
+      "test",
+    ]);
+
+    expect(readConfig).toHaveBeenCalledWith("/cwd", undefined, {
+      output: "/cwd/custom-output",
+      plugins: {
+        agent: {
+          options: {
+            outputDir: "/cwd/custom-output",
+          },
+        },
+      },
+    });
+    expect(consoleModule.log).toHaveBeenCalledWith("agent output: /cwd/custom-output");
+    expect(consoleModule.log).toHaveBeenCalledWith("agent expectations: /cwd/expected.yaml");
+  });
+
+  it("should pass ALLURE_TESTPLAN_PATH to the child process when rerun-from is enabled", async () => {
+    const cleanupMock = vi.fn().mockResolvedValue(undefined);
+
+    (createAgentTestPlanContext as Mock).mockResolvedValueOnce({
+      outputDir: "/tmp/previous-agent",
+      preset: "review",
+      selectedCount: 1,
+      testPlanPath: "/tmp/testplan.json",
+      cleanup: cleanupMock,
+    });
+
+    await run(AgentCommand, ["agent", "--rerun-from", "./previous-agent", "--", "npm", "test"]);
+
+    expect(createAgentTestPlanContext).toHaveBeenCalledWith({
+      cwd: "/cwd",
+      from: "./previous-agent",
+      latest: false,
+      preset: "review",
+      environments: undefined,
+      labelFilters: [],
+    });
+    expect(executeAllureRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environmentVariables: {
+          ALLURE_CLI_ACTIVE_COMMAND: "agent",
+          ALLURE_TESTPLAN_PATH: "/tmp/testplan.json",
+        },
+      }),
+    );
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should resolve rerun-latest through the shared test-plan context", async () => {
+    const cleanupMock = vi.fn().mockResolvedValue(undefined);
+
+    (createAgentTestPlanContext as Mock).mockResolvedValueOnce({
+      outputDir: "/tmp/latest-agent",
+      preset: "review",
+      selectedCount: 1,
+      testPlanPath: "/tmp/latest-testplan.json",
+      cleanup: cleanupMock,
+    });
+
+    await run(AgentCommand, ["agent", "--rerun-latest", "--", "npm", "test"]);
+
+    expect(createAgentTestPlanContext).toHaveBeenCalledWith({
+      cwd: "/cwd",
+      from: undefined,
+      latest: true,
+      preset: "review",
+      environments: undefined,
+      labelFilters: [],
+    });
+    expect(executeAllureRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environmentVariables: {
+          ALLURE_CLI_ACTIVE_COMMAND: "agent",
+          ALLURE_TESTPLAN_PATH: "/tmp/latest-testplan.json",
+        },
+      }),
+    );
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should bypass nested allure wrappers and execute the child command directly", async () => {
+    process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV] = "run";
+    const consoleModule = await import("node:console");
+
+    await run(AgentCommand, ["agent", "--silent", "--", "npm", "test"]);
+
+    expect(consoleModule.log).toHaveBeenCalledWith("npm test");
+    expect(executeNestedAllureCommand).toHaveBeenCalledWith({
+      command: "npm",
+      commandArgs: ["test"],
+      cwd: "/cwd",
+      silent: true,
+    });
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(executeAllureRun).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(0);
+
+    delete process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV];
+  });
+
+  it("should sandbox ALLURE_AGENT_* variables during execution and restore them afterwards", async () => {
+    process.env.ALLURE_AGENT_OUTPUT = "ambient-output";
+    process.env.ALLURE_AGENT_EXPECTATIONS = "ambient-expected";
+    process.env.ALLURE_AGENT_NAME = "ambient-name";
+    process.env.ALLURE_AGENT_LOOP_ID = "ambient-loop";
+    process.env.ALLURE_AGENT_TASK_ID = "ambient-task";
+    process.env.ALLURE_AGENT_CONVERSATION_ID = "ambient-conversation";
+
+    (executeAllureRun as Mock).mockImplementationOnce(async () => {
+      expect(process.env.ALLURE_AGENT_OUTPUT).toBe("/cwd/custom-output");
+      expect(process.env.ALLURE_AGENT_EXPECTATIONS).toBe("/cwd/expected.yaml");
+      expect(process.env.ALLURE_AGENT_COMMAND).toBe("npm test");
+      expect(process.env.ALLURE_AGENT_PROJECT_ROOT).toBe("/cwd");
+      expect(process.env.ALLURE_AGENT_NAME).toBeUndefined();
+      expect(process.env.ALLURE_AGENT_LOOP_ID).toBeUndefined();
+      expect(process.env.ALLURE_AGENT_TASK_ID).toBeUndefined();
+      expect(process.env.ALLURE_AGENT_CONVERSATION_ID).toBeUndefined();
+
+      return {
+        globalExitCode: {
+          original: 0,
+          actual: undefined,
+        },
+        testProcessResult: null,
+      };
+    });
+
+    await run(AgentCommand, [
+      "agent",
+      "--output",
+      "./custom-output",
+      "--expectations",
+      "./expected.yaml",
+      "--",
+      "npm",
+      "test",
+    ]);
+
+    expect(process.env.ALLURE_AGENT_OUTPUT).toBe("ambient-output");
+    expect(process.env.ALLURE_AGENT_EXPECTATIONS).toBe("ambient-expected");
+    expect(process.env.ALLURE_AGENT_NAME).toBe("ambient-name");
+    expect(process.env.ALLURE_AGENT_LOOP_ID).toBe("ambient-loop");
+    expect(process.env.ALLURE_AGENT_TASK_ID).toBe("ambient-task");
+    expect(process.env.ALLURE_AGENT_CONVERSATION_ID).toBe("ambient-conversation");
+
+    delete process.env.ALLURE_AGENT_OUTPUT;
+    delete process.env.ALLURE_AGENT_EXPECTATIONS;
+    delete process.env.ALLURE_AGENT_NAME;
+    delete process.env.ALLURE_AGENT_LOOP_ID;
+    delete process.env.ALLURE_AGENT_TASK_ID;
+    delete process.env.ALLURE_AGENT_CONVERSATION_ID;
+  });
+});

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 import { readConfig } from "@allurereport/core";
 import { run, UsageError } from "clipanion";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
@@ -219,6 +221,8 @@ describe("agent command", () => {
 
   it("should resolve explicit output and expectations paths relative to cwd", async () => {
     const consoleModule = await import("node:console");
+    const resolvedOutput = resolve("/cwd", "./custom-output");
+    const resolvedExpectations = resolve("/cwd", "./expected.yaml");
 
     await run(AgentCommand, [
       "agent",
@@ -232,17 +236,17 @@ describe("agent command", () => {
     ]);
 
     expect(readConfig).toHaveBeenCalledWith("/cwd", undefined, {
-      output: "/cwd/custom-output",
+      output: resolvedOutput,
       plugins: {
         agent: {
           options: {
-            outputDir: "/cwd/custom-output",
+            outputDir: resolvedOutput,
           },
         },
       },
     });
-    expect(consoleModule.log).toHaveBeenCalledWith("agent output: /cwd/custom-output");
-    expect(consoleModule.log).toHaveBeenCalledWith("agent expectations: /cwd/expected.yaml");
+    expect(consoleModule.log).toHaveBeenCalledWith(`agent output: ${resolvedOutput}`);
+    expect(consoleModule.log).toHaveBeenCalledWith(`agent expectations: ${resolvedExpectations}`);
   });
 
   it("should pass ALLURE_TESTPLAN_PATH to the child process when rerun-from is enabled", async () => {
@@ -330,6 +334,9 @@ describe("agent command", () => {
   });
 
   it("should sandbox ALLURE_AGENT_* variables during execution and restore them afterwards", async () => {
+    const resolvedOutput = resolve("/cwd", "./custom-output");
+    const resolvedExpectations = resolve("/cwd", "./expected.yaml");
+
     process.env.ALLURE_AGENT_OUTPUT = "ambient-output";
     process.env.ALLURE_AGENT_EXPECTATIONS = "ambient-expected";
     process.env.ALLURE_AGENT_NAME = "ambient-name";
@@ -338,8 +345,8 @@ describe("agent command", () => {
     process.env.ALLURE_AGENT_CONVERSATION_ID = "ambient-conversation";
 
     (executeAllureRun as Mock).mockImplementationOnce(async () => {
-      expect(process.env.ALLURE_AGENT_OUTPUT).toBe("/cwd/custom-output");
-      expect(process.env.ALLURE_AGENT_EXPECTATIONS).toBe("/cwd/expected.yaml");
+      expect(process.env.ALLURE_AGENT_OUTPUT).toBe(resolvedOutput);
+      expect(process.env.ALLURE_AGENT_EXPECTATIONS).toBe(resolvedExpectations);
       expect(process.env.ALLURE_AGENT_COMMAND).toBe("npm test");
       expect(process.env.ALLURE_AGENT_PROJECT_ROOT).toBe("/cwd");
       expect(process.env.ALLURE_AGENT_NAME).toBeUndefined();

--- a/packages/cli/test/commands/agentLatest.test.ts
+++ b/packages/cli/test/commands/agentLatest.test.ts
@@ -1,0 +1,71 @@
+import { run } from "clipanion";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentLatestCommand, AgentStateDirCommand } from "../../src/commands/agent.js";
+import { readLatestAgentState, resolveAgentStateDir } from "../../src/utils/agent-state.js";
+
+vi.mock("node:console", async (importOriginal) => ({
+  ...(await importOriginal()),
+  log: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock("node:process", async (importOriginal) => ({
+  ...(await importOriginal()),
+  exit: vi.fn(),
+}));
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal()),
+  realpath: vi.fn().mockResolvedValue("/cwd"),
+}));
+vi.mock("../../src/utils/agent-state.js", () => ({
+  readLatestAgentState: vi.fn(),
+  resolveAgentStateDir: vi.fn(),
+  writeLatestAgentState: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("agent latest command", () => {
+  it("should print the latest output directory for the resolved project cwd", async () => {
+    const consoleModule = await import("node:console");
+
+    (readLatestAgentState as Mock).mockResolvedValueOnce({
+      schema: "allure-agent-latest/v1",
+      cwd: "/cwd",
+      outputDir: "/tmp/allure-agent-123",
+      command: "npm test",
+      startedAt: "2026-04-15T18:00:00.000Z",
+      status: "finished",
+    });
+
+    await run(AgentLatestCommand, ["agent", "latest"]);
+
+    expect(readLatestAgentState).toHaveBeenCalledWith("/cwd");
+    expect(consoleModule.log).toHaveBeenCalledWith("/tmp/allure-agent-123");
+  });
+
+  it("should exit with code 1 when no latest output exists for the project", async () => {
+    const consoleModule = await import("node:console");
+    const processModule = await import("node:process");
+
+    (readLatestAgentState as Mock).mockResolvedValueOnce(undefined);
+
+    await run(AgentLatestCommand, ["agent", "latest"]);
+
+    expect(consoleModule.error).toHaveBeenCalledWith("No latest agent output found for /cwd");
+    expect(processModule.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should print the resolved state directory for the current project", async () => {
+    const consoleModule = await import("node:console");
+
+    (resolveAgentStateDir as Mock).mockReturnValueOnce("/tmp/allure-agent-state-abcdef1234567890");
+
+    await run(AgentStateDirCommand, ["agent", "state-dir"]);
+
+    expect(resolveAgentStateDir).toHaveBeenCalledWith("/cwd");
+    expect(consoleModule.log).toHaveBeenCalledWith("/tmp/allure-agent-state-abcdef1234567890");
+  });
+});

--- a/packages/cli/test/commands/agentSelect.test.ts
+++ b/packages/cli/test/commands/agentSelect.test.ts
@@ -20,7 +20,7 @@ vi.mock("node:fs/promises", async (importOriginal) => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("../../src/utils/agent-select.js", () => ({
-  normalizeAgentRerunPreset: vi.fn((value?: string) => (value ?? "review")),
+  normalizeAgentRerunPreset: vi.fn((value?: string) => value ?? "review"),
   parseAgentLabelFilters: vi.fn((values?: string[]) =>
     (values ?? []).map((value) => {
       const [name, filterValue] = value.split("=");
@@ -72,6 +72,8 @@ describe("agent select command", () => {
       from: "./agent-output",
       latest: false,
     });
-    expect(consoleModule.log).toHaveBeenCalledWith(`{\n  "version": "1.0",\n  "tests": [\n    {\n      "selector": "suite feature A"\n    }\n  ]\n}`);
+    expect(consoleModule.log).toHaveBeenCalledWith(
+      `{\n  "version": "1.0",\n  "tests": [\n    {\n      "selector": "suite feature A"\n    }\n  ]\n}`,
+    );
   });
 });

--- a/packages/cli/test/commands/agentSelect.test.ts
+++ b/packages/cli/test/commands/agentSelect.test.ts
@@ -1,0 +1,77 @@
+import { run, UsageError } from "clipanion";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentSelectCommand } from "../../src/commands/agent.js";
+import { resolveAgentSelectionOutputDir, selectAgentTestPlan } from "../../src/utils/agent-select.js";
+
+vi.mock("node:console", async (importOriginal) => ({
+  ...(await importOriginal()),
+  log: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock("node:process", async (importOriginal) => ({
+  ...(await importOriginal()),
+  exit: vi.fn(),
+}));
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal()),
+  realpath: vi.fn().mockResolvedValue("/cwd"),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/utils/agent-select.js", () => ({
+  normalizeAgentRerunPreset: vi.fn((value?: string) => (value ?? "review")),
+  parseAgentLabelFilters: vi.fn((values?: string[]) =>
+    (values ?? []).map((value) => {
+      const [name, filterValue] = value.split("=");
+
+      return {
+        name,
+        value: filterValue,
+      };
+    }),
+  ),
+  resolveAgentSelectionOutputDir: vi.fn(),
+  selectAgentTestPlan: vi.fn(),
+  createAgentTestPlanContext: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("agent select command", () => {
+  it("should fail with usage error when neither --from nor --latest is provided", async () => {
+    const command = new AgentSelectCommand();
+
+    (resolveAgentSelectionOutputDir as Mock).mockRejectedValueOnce(
+      new UsageError("Expected either --from <path> or --latest"),
+    );
+
+    await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+  });
+
+  it("should print the selected test plan to stdout", async () => {
+    const consoleModule = await import("node:console");
+
+    (resolveAgentSelectionOutputDir as Mock).mockResolvedValueOnce("/tmp/agent-output");
+    (selectAgentTestPlan as Mock).mockResolvedValueOnce({
+      outputDir: "/tmp/agent-output",
+      preset: "review",
+      selectedTests: [{ full_name: "suite feature A" }],
+      testPlan: {
+        version: "1.0",
+        tests: [{ selector: "suite feature A" }],
+      },
+    });
+
+    await run(AgentSelectCommand, ["agent", "select", "--from", "./agent-output"]);
+
+    expect(resolveAgentSelectionOutputDir).toHaveBeenCalledWith({
+      cwd: "/cwd",
+      from: "./agent-output",
+      latest: false,
+    });
+    expect(consoleModule.log).toHaveBeenCalledWith(`{\n  "version": "1.0",\n  "tests": [\n    {\n      "selector": "suite feature A"\n    }\n  ]\n}`);
+  });
+});

--- a/packages/cli/test/commands/run.integration.test.ts
+++ b/packages/cli/test/commands/run.integration.test.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import process from "node:process";
@@ -19,11 +20,16 @@ const maxBuffer = 10 * 1024 * 1024;
 type RunCommandOptions = Parameters<typeof execFileAsync>[2];
 
 const runCommand = async (command: string, args: string[], options: RunCommandOptions = {}) => {
+  const { env: customEnv, ...restOptions } = options;
+  const env = { ...process.env, ...customEnv };
+
+  delete env.ALLURE_CLI_ACTIVE_COMMAND;
+
   return await execFileAsync(command, args, {
     cwd: repoRoot,
-    env: process.env,
+    env,
     maxBuffer,
-    ...options,
+    ...restOptions,
   });
 };
 
@@ -34,6 +40,14 @@ const pathExists = async (filePath: string) => {
   } catch {
     return false;
   }
+};
+
+const writeJson = async (filePath: string, value: unknown) => {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+};
+
+const writeJsonl = async (filePath: string, lines: unknown[]) => {
+  await writeFile(filePath, lines.map((line) => JSON.stringify(line)).join("\n"), "utf-8");
 };
 
 const resolveYarnInvocation = async () => {
@@ -94,9 +108,6 @@ describe("run command integration", () => {
   beforeAll(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "allure-cli-agent-"));
 
-    await runYarnCommand(["workspace", "@allurereport/core", "build"]);
-    await runYarnCommand(["workspace", "@allurereport/plugin-log", "build"]);
-    await runYarnCommand(["workspace", "@allurereport/plugin-agent", "build"]);
     await runYarnCommand(["workspace", "allure", "build"]);
   }, 240_000);
 
@@ -111,13 +122,18 @@ describe("run command integration", () => {
     const expectationsPath = join(fixtureDir, "expected.yaml");
     const configPath = join(fixtureDir, "allurerc.mjs");
     const emitResultsPath = join(fixtureDir, "emit-results.mjs");
+    const projectGuidePath = join(fixtureDir, "docs", "allure-agent-mode.md");
     const expectationsSource = `goal: Validate built CLI agent output
 task_id: cli-integration
 expected:
   environments:
     - default
 notes:
-  - The built CLI path should produce the same manifest contract as source tests.
+  - The legacy run invocation should delegate to the agent command contract.
+`;
+    const projectGuideSource = `# Fixture Agent Guide
+
+- This guide belongs to the fixture cwd used by the legacy run compatibility test.
 `;
     const configSource = `
 export default {
@@ -128,6 +144,14 @@ export default {
       options: {
         reportName: "CLI Integration Report"
       }
+    },
+    dashboard: {
+      options: {
+        reportName: "CLI Integration Dashboard"
+      }
+    },
+    testops: {
+      options: {}
     }
   }
 };
@@ -145,12 +169,13 @@ await cp(fixture, join(outDir, \`\${randomUUID()}-result.json\`));
 console.log("emitted simple result");
 `.trimStart();
 
-    await mkdir(fixtureDir, { recursive: true });
+    await mkdir(join(fixtureDir, "docs"), { recursive: true });
     await writeFile(expectationsPath, expectationsSource, "utf-8");
     await writeFile(configPath, configSource, "utf-8");
     await writeFile(emitResultsPath, emitResultsSource, "utf-8");
+    await writeFile(projectGuidePath, projectGuideSource, "utf-8");
 
-    const { stdout } = await runCommand(
+    const { stdout, stderr } = await runCommand(
       process.execPath,
       [cliPath, "run", "--config", configPath, "--cwd", fixtureDir, "--", "node", emitResultsPath, simpleResultFixture],
       {
@@ -175,28 +200,484 @@ console.log("emitted simple result");
         expected_manifest: string | null;
         project_guide: string | null;
       };
-      check_summary: {
-        total: number;
-      };
     };
     const indexContent = await readFile(join(outputDir, "index.md"), "utf-8");
     const findingsContent = await readFile(join(outputDir, "manifest", "findings.jsonl"), "utf-8");
     const expectedCopy = await readFile(join(outputDir, "manifest", "expected.json"), "utf-8");
     const agentsGuide = await readFile(join(outputDir, "AGENTS.md"), "utf-8");
+    const copiedProjectGuide = await readFile(join(outputDir, "project", "docs", "allure-agent-mode.md"), "utf-8");
 
-    expect(runManifest.command).toBeNull();
+    expect(runManifest.command).toBe(`node ${emitResultsPath} ${simpleResultFixture}`);
     expect(runManifest.expectations_present).toBe(true);
     expect(runManifest.paths.expected_manifest).toBe("manifest/expected.json");
     expect(runManifest.paths.project_guide).toBe("project/docs/allure-agent-mode.md");
-    expect(runManifest.check_summary.total).toBe(0);
     expect(expectedCopy).toContain('"task_id": "cli-integration"');
     expect(agentsGuide).toContain("[project guidance](project/docs/allure-agent-mode.md)");
+    expect(copiedProjectGuide).toContain("# Fixture Agent Guide");
     expect(indexContent).toContain("# CLI Integration Report");
     expect(indexContent).toContain("## Expected Scope");
     expect(indexContent).toContain("## Advisory Check Summary");
     expect(indexContent).toContain("## Passed");
     expect(findingsContent).toBe("");
+    expect(await pathExists(join(outputDir, "awesome"))).toBe(false);
+    expect(await pathExists(join(outputDir, "dashboard"))).toBe(false);
+    expect(stdout).toContain(`agent output: ${outputDir}`);
+    expect(stdout).toContain(`agent expectations: ${expectationsPath}`);
     expect(stdout).toContain(`node ${emitResultsPath} ${simpleResultFixture}`);
     expect(stdout).toContain("emitted simple result");
+    expect(stdout).not.toContain("process finished with code");
+    expect(stdout).not.toContain("exit code ");
+    expect(stdout).not.toContain("[DEP0190]");
+    expect(stdout).not.toContain("NO_COLOR");
+    expect(stderr).not.toContain("[DEP0190]");
+    expect(stderr).not.toContain("NO_COLOR");
+    expect(stderr).not.toContain("Allure TestOps");
+  }, 240_000);
+
+  it("runs the built agent command with an agent-only profile", async () => {
+    const fixtureDir = join(tempDir, "built-agent");
+    const homeDir = join(fixtureDir, "home");
+    const outputDir = join(fixtureDir, "agent-output");
+    const reportDir = join(fixtureDir, "report");
+    const expectationsPath = join(fixtureDir, "expected.yaml");
+    const configPath = join(fixtureDir, "allurerc.mjs");
+    const emitResultsPath = join(fixtureDir, "emit-results.mjs");
+    const projectGuidePath = join(fixtureDir, "docs", "allure-agent-mode.md");
+    const expectationsSource = `goal: Validate built CLI agent command
+task_id: cli-agent-integration
+expected:
+  environments:
+    - default
+notes:
+  - The agent command should ignore configured report and export plugins.
+`;
+    const projectGuideSource = `# Fixture Agent Guide
+
+- This guide belongs to the fixture cwd used by the built agent integration test.
+`;
+    const configSource = `
+export default {
+  name: "CLI Agent Report",
+  output: ${JSON.stringify(reportDir)},
+  plugins: {
+    awesome: {
+      options: {
+        reportName: "CLI Agent Report"
+      }
+    },
+    dashboard: {
+      options: {
+        reportName: "CLI Agent Dashboard"
+      }
+    },
+    testops: {
+      options: {}
+    }
+  }
+};
+`.trimStart();
+    const emitResultsSource = `
+import { cp, mkdir } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+const fixture = process.argv[2];
+const outDir = join(process.cwd(), "allure-results");
+
+await mkdir(outDir, { recursive: true });
+await cp(fixture, join(outDir, \`\${randomUUID()}-result.json\`));
+console.log("emitted simple result");
+`.trimStart();
+
+    await mkdir(join(fixtureDir, "docs"), { recursive: true });
+    const resolvedFixtureDir = await realpath(fixtureDir);
+    const expectedStateDir = join(
+      tmpdir(),
+      `allure-agent-state-${createHash("sha256").update(resolvedFixtureDir).digest("hex").slice(0, 16)}`,
+    );
+    await writeFile(expectationsPath, expectationsSource, "utf-8");
+    await writeFile(configPath, configSource, "utf-8");
+    await writeFile(emitResultsPath, emitResultsSource, "utf-8");
+    await writeFile(projectGuidePath, projectGuideSource, "utf-8");
+
+    const { stdout, stderr } = await runCommand(
+      process.execPath,
+      [
+        cliPath,
+        "agent",
+        "--config",
+        configPath,
+        "--cwd",
+        fixtureDir,
+        "--output",
+        outputDir,
+        "--expectations",
+        expectationsPath,
+        "--",
+        "node",
+        emitResultsPath,
+        simpleResultFixture,
+      ],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      },
+    );
+    const { stdout: latestStdout, stderr: latestStderr } = await runCommand(
+      process.execPath,
+      [cliPath, "agent", "latest", "--cwd", fixtureDir],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      },
+    );
+    const { stdout: stateDirStdout, stderr: stateDirStderr } = await runCommand(
+      process.execPath,
+      [cliPath, "agent", "state-dir", "--cwd", fixtureDir],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      },
+    );
+
+    await expect(stat(join(outputDir, "index.md"))).resolves.toBeTruthy();
+    await expect(stat(join(outputDir, "AGENTS.md"))).resolves.toBeTruthy();
+    await expect(stat(join(outputDir, "manifest", "run.json"))).resolves.toBeTruthy();
+    await expect(stat(join(outputDir, "manifest", "tests.jsonl"))).resolves.toBeTruthy();
+    await expect(stat(join(outputDir, "manifest", "findings.jsonl"))).resolves.toBeTruthy();
+
+    const runManifest = JSON.parse(await readFile(join(outputDir, "manifest", "run.json"), "utf-8")) as {
+      command: string | null;
+      expectations_present: boolean;
+      paths: {
+        expected_manifest: string | null;
+        project_guide: string | null;
+      };
+    };
+    const agentsGuide = await readFile(join(outputDir, "AGENTS.md"), "utf-8");
+    const copiedProjectGuide = await readFile(join(outputDir, "project", "docs", "allure-agent-mode.md"), "utf-8");
+    const findingsContent = await readFile(join(outputDir, "manifest", "findings.jsonl"), "utf-8");
+
+    expect(runManifest.command).toBe(`node ${emitResultsPath} ${simpleResultFixture}`);
+    expect(runManifest.expectations_present).toBe(true);
+    expect(runManifest.paths.expected_manifest).toBe("manifest/expected.json");
+    expect(runManifest.paths.project_guide).toBe("project/docs/allure-agent-mode.md");
+    expect(agentsGuide).toContain("[project guidance](project/docs/allure-agent-mode.md)");
+    expect(copiedProjectGuide).toContain("# Fixture Agent Guide");
+    expect(findingsContent).toBe("");
+    expect(await pathExists(join(outputDir, "awesome"))).toBe(false);
+    expect(await pathExists(join(outputDir, "dashboard"))).toBe(false);
+    expect(stdout).toContain(`node ${emitResultsPath} ${simpleResultFixture}`);
+    expect(stdout).toContain(`agent output: ${outputDir}`);
+    expect(stdout).toContain(`agent expectations: ${expectationsPath}`);
+    expect(stdout).toContain("emitted simple result");
+    expect(stdout).not.toContain("process finished with code");
+    expect(stdout).not.toContain("exit code ");
+    expect(stdout).not.toContain("[DEP0190]");
+    expect(stdout).not.toContain("NO_COLOR");
+    expect(stderr).not.toContain("[DEP0190]");
+    expect(stderr).not.toContain("NO_COLOR");
+    expect(stderr).not.toContain("Allure TestOps");
+    expect(latestStdout.trim()).toBe(outputDir);
+    expect(latestStderr).toBe("");
+    expect(stateDirStdout.trim()).toBe(expectedStateDir);
+    expect(stateDirStderr).toBe("");
+  }, 240_000);
+
+  it("supports agent select and rerun-from with the default review preset", async () => {
+    const fixtureDir = join(tempDir, "agent-select-rerun");
+    const homeDir = join(fixtureDir, "home");
+    const previousOutputDir = join(fixtureDir, "previous-agent-output");
+    const outputDir = join(fixtureDir, "agent-output");
+    const reportDir = join(fixtureDir, "report");
+    const configPath = join(fixtureDir, "allurerc.mjs");
+    const emitResultsPath = join(fixtureDir, "emit-plan-results.mjs");
+    const fixturesManifestPath = join(fixtureDir, "fixtures.json");
+    const featureAFixturePath = join(fixtureDir, "feature-a-result.json");
+    const featureBFixturePath = join(fixtureDir, "feature-b-result.json");
+    const previousManifestDir = join(previousOutputDir, "manifest");
+    const configSource = `
+export default {
+  name: "CLI Agent Select Report",
+  output: ${JSON.stringify(reportDir)},
+  plugins: {
+    awesome: {
+      options: {
+        reportName: "CLI Agent Select Report"
+      }
+    }
+  }
+};
+`.trimStart();
+    const emitResultsSource = `
+import { cp, mkdir, readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+
+const fixtures = JSON.parse(await readFile(process.argv[2], "utf-8"));
+const outDir = join(process.cwd(), "allure-results");
+const testPlanPath = process.env.ALLURE_TESTPLAN_PATH;
+const testPlan = testPlanPath ? JSON.parse(await readFile(testPlanPath, "utf-8")) : { tests: [] };
+const selectors = new Set(testPlan.tests.flatMap((entry) => (entry.selector ? [entry.selector] : [])));
+
+await mkdir(outDir, { recursive: true });
+
+for (const fixture of fixtures) {
+  if (selectors.size && !selectors.has(fixture.selector)) {
+    continue;
+  }
+
+  await cp(fixture.file, join(outDir, \`\${randomUUID()}-result.json\`));
+}
+
+console.log(\`selected selectors: \${Array.from(selectors).join(",")}\`);
+`.trimStart();
+
+    await mkdir(previousManifestDir, { recursive: true });
+    await writeFile(configPath, configSource, "utf-8");
+    await writeFile(emitResultsPath, emitResultsSource, "utf-8");
+
+    const baseResult = JSON.parse(await readFile(simpleResultFixture, "utf-8")) as Record<string, unknown>;
+    const featureAResult = {
+      ...baseResult,
+      uuid: "feature-a-uuid",
+      historyId: "feature-a-history",
+      name: "feature A",
+      fullName: "suite feature A",
+      status: "passed",
+      labels: [
+        { name: "suite", value: "suite" },
+        { name: "feature", value: "checkout" },
+        { name: "priority", value: "high" },
+      ],
+    };
+    const featureBResult = {
+      ...baseResult,
+      uuid: "feature-b-uuid",
+      historyId: "feature-b-history",
+      name: "feature B",
+      fullName: "suite feature B",
+      status: "passed",
+      labels: [
+        { name: "suite", value: "suite" },
+        { name: "feature", value: "payments" },
+        { name: "priority", value: "low" },
+      ],
+    };
+
+    await writeJson(featureAFixturePath, featureAResult);
+    await writeJson(featureBFixturePath, featureBResult);
+    await writeJson(fixturesManifestPath, [
+      {
+        selector: "suite feature A",
+        file: featureAFixturePath,
+      },
+      {
+        selector: "suite feature B",
+        file: featureBFixturePath,
+      },
+    ]);
+
+    await writeJson(join(previousManifestDir, "run.json"), {
+      schema_version: "allure-agent-output/v1",
+      report_uuid: "previous-report",
+      generated_at: "2026-04-15T18:00:00.000Z",
+      command: "node prior-run",
+      actual_exit_code: 0,
+      original_exit_code: 0,
+      exit_code: {
+        original: 0,
+        actual: 0,
+      },
+      summary: {
+        stats: {
+          total: 2,
+          failed: 1,
+          broken: 0,
+          skipped: 0,
+          unknown: 0,
+          passed: 1,
+        },
+        duration_ms: {
+          total: 10,
+          average: 5,
+          max: 5,
+        },
+        environments: [
+          {
+            environmentId: "default",
+            total: 2,
+            failed: 1,
+            broken: 0,
+            skipped: 0,
+            unknown: 0,
+            passed: 1,
+          },
+        ],
+      },
+      paths: {
+        index_md: "index.md",
+        agents_md: "AGENTS.md",
+        tests_manifest: "manifest/tests.jsonl",
+        findings_manifest: "manifest/findings.jsonl",
+        expected_manifest: null,
+        project_guide: null,
+        process_logs: {
+          stdout: null,
+          stderr: null,
+        },
+      },
+      expectations_present: false,
+      check_summary: {
+        total: 1,
+        countsBySeverity: {
+          high: 1,
+          warning: 0,
+          info: 0,
+        },
+        countsByCategory: {
+          bootstrap: 0,
+          scope: 0,
+          metadata: 0,
+          evidence: 1,
+          smells: 0,
+        },
+      },
+      agent_context: {
+        agent_name: null,
+        loop_id: null,
+        task_id: null,
+        conversation_id: null,
+      },
+    });
+    await writeJsonl(join(previousManifestDir, "tests.jsonl"), [
+      {
+        environment_id: "default",
+        history_id: "feature-a-history",
+        test_result_id: "feature-a-tr",
+        full_name: "suite feature A",
+        package: "suite",
+        labels: [
+          { name: "feature", value: "checkout" },
+          { name: "priority", value: "high" },
+        ],
+        status: "failed",
+        duration_ms: 5,
+        retries: 0,
+        flaky: false,
+        scope_match: "match",
+        finding_counts: {
+          total: 1,
+          high: 1,
+          warning: 0,
+          info: 0,
+        },
+        markdown_path: "tests/default/feature-a.md",
+        assets_dir: "tests/default/feature-a.assets",
+      },
+      {
+        environment_id: "default",
+        history_id: "feature-b-history",
+        test_result_id: "feature-b-tr",
+        full_name: "suite feature B",
+        package: "suite",
+        labels: [
+          { name: "feature", value: "payments" },
+          { name: "priority", value: "low" },
+        ],
+        status: "passed",
+        duration_ms: 5,
+        retries: 0,
+        flaky: false,
+        scope_match: "match",
+        finding_counts: {
+          total: 0,
+          high: 0,
+          warning: 0,
+          info: 0,
+        },
+        markdown_path: "tests/default/feature-b.md",
+        assets_dir: "tests/default/feature-b.assets",
+      },
+    ]);
+    await writeJsonl(join(previousManifestDir, "findings.jsonl"), [
+      {
+        finding_id: "finding-feature-a",
+        subject: "tests/default/feature-a.md",
+        severity: "high",
+        category: "evidence",
+        check_name: "failed-without-useful-steps",
+        message: "Feature A needs focused rerun coverage",
+        explanation: "Feature A should be the only review-targeted rerun candidate.",
+        evidence_paths: [],
+        remediation_hint: "Rerun only feature A.",
+      },
+    ]);
+
+    const { stdout: selectStdout, stderr: selectStderr } = await runCommand(
+      process.execPath,
+      [cliPath, "agent", "select", "--from", previousOutputDir],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      },
+    );
+    const { stdout, stderr } = await runCommand(
+      process.execPath,
+      [
+        cliPath,
+        "agent",
+        "--config",
+        configPath,
+        "--cwd",
+        fixtureDir,
+        "--output",
+        outputDir,
+        "--rerun-from",
+        previousOutputDir,
+        "--",
+        "node",
+        emitResultsPath,
+        fixturesManifestPath,
+      ],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+      },
+    );
+
+    expect(JSON.parse(selectStdout)).toEqual({
+      version: "1.0",
+      tests: [
+        {
+          selector: "suite feature A",
+        },
+      ],
+    });
+    expect(selectStderr).toBe("");
+    expect(stdout).toContain("selected selectors: suite feature A");
+    expect(stderr).toBe("");
+
+    const selectedTests = (await readFile(join(outputDir, "manifest", "tests.jsonl"), "utf-8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { full_name: string });
+
+    expect(selectedTests).toEqual([
+      expect.objectContaining({
+        full_name: "suite feature A",
+      }),
+    ]);
   }, 240_000);
 });

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -1,9 +1,13 @@
+import { resolve } from "node:path";
+
 import { readConfig } from "@allurereport/core";
 import AwesomePlugin from "@allurereport/plugin-awesome";
 import { run, UsageError } from "clipanion";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { executeAgentMode } from "../../src/commands/agent.js";
 import { RunCommand } from "../../src/commands/run.js";
+import { ALLURE_CLI_ACTIVE_COMMAND_ENV } from "../../src/utils/execution-context.js";
 
 const { exitMock, processStream } = vi.hoisted(() => {
   const exitMock = vi.fn();
@@ -85,9 +89,15 @@ vi.mock("@allurereport/static-server", async (importOriginal) => ({
   ...(await importOriginal()),
   serve: vi.fn(),
 }));
+vi.mock("../../src/commands/agent.js", () => ({
+  executeAgentMode: vi.fn().mockResolvedValue(undefined),
+}));
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  delete process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV];
+  delete process.env.ALLURE_AGENT_OUTPUT;
+  delete process.env.ALLURE_AGENT_EXPECTATIONS;
 
   const { AllureReportMock } = await import("../utils.js");
 
@@ -118,6 +128,7 @@ describe("run command", () => {
 
   it("should pass hideLabels override to readConfig and apply normalized value to default awesome plugin", async () => {
     const { AllureReportMock } = await import("../utils.js");
+    const { runProcess } = await import("../../src/utils/index.js");
 
     (readConfig as Mock).mockResolvedValueOnce({
       output: "./allure-report",
@@ -145,6 +156,13 @@ describe("run command", () => {
             plugin: expect.any(AwesomePlugin),
           }),
         ]),
+      }),
+    );
+    expect(runProcess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environmentVariables: {
+          ALLURE_CLI_ACTIVE_COMMAND: "run",
+        },
       }),
     );
     expect(exitMock).toHaveBeenCalledWith(0);
@@ -190,5 +208,53 @@ describe("run command", () => {
       }),
     );
     expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("should bypass nested allure wrappers and execute the child command directly", async () => {
+    const { AllureReportMock } = await import("../utils.js");
+    const { runProcess } = await import("../../src/utils/index.js");
+
+    process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV] = "agent";
+
+    await run(RunCommand, ["run", "--silent", "--", "npm", "test"]);
+
+    expect(runProcess).toHaveBeenCalledWith({
+      command: "npm",
+      commandArgs: ["test"],
+      cwd: "/cwd",
+      logs: "ignore",
+    });
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(AllureReportMock).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(0);
+
+    delete process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV];
+  });
+
+  it("should delegate legacy env-based agent mode to the agent command", async () => {
+    const { AllureReportMock } = await import("../utils.js");
+    const { runProcess } = await import("../../src/utils/index.js");
+    const consoleModule = await import("node:console");
+
+    process.env.ALLURE_AGENT_OUTPUT = "./legacy-agent-output";
+    process.env.ALLURE_AGENT_EXPECTATIONS = "./legacy-expected.yaml";
+
+    await run(RunCommand, ["run", "--cwd", "./fixture", "--silent", "--", "npm", "test"]);
+
+    expect(executeAgentMode).toHaveBeenCalledWith({
+      configPath: undefined,
+      cwd: "./fixture",
+      output: resolve(process.cwd(), "./legacy-agent-output"),
+      expectations: resolve(process.cwd(), "./legacy-expected.yaml"),
+      environment: undefined,
+      environmentName: undefined,
+      silent: true,
+      args: ["npm", "test"],
+    });
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(AllureReportMock).not.toHaveBeenCalled();
+    expect(runProcess).not.toHaveBeenCalled();
+    expect(consoleModule.log).not.toHaveBeenCalled();
+    expect(exitMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/utils/agent-select.test.ts
+++ b/packages/cli/test/utils/agent-select.test.ts
@@ -1,0 +1,89 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  normalizeAgentRerunPreset,
+  parseAgentLabelFilters,
+  resolveAgentSelectionOutputDir,
+  selectAgentTestPlan,
+} from "../../src/utils/agent-select.js";
+
+vi.mock("../../src/utils/agent-state.js", () => ({
+  readLatestAgentState: vi.fn(),
+}));
+vi.mock("@allurereport/plugin-agent", () => ({
+  loadAgentOutput: vi.fn(),
+  planAgentEnrichmentReview: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("agent-select utils", () => {
+  it("should select review-targeted tests and apply environment and label filters", async () => {
+    const { loadAgentOutput, planAgentEnrichmentReview } = await import("@allurereport/plugin-agent");
+
+    (loadAgentOutput as Mock).mockResolvedValueOnce({
+      outputDir: "/tmp/agent-output",
+      run: {},
+      tests: [
+        {
+          environment_id: "default",
+          full_name: "suite feature A",
+          labels: [
+            { name: "feature", value: "checkout" },
+            { name: "priority", value: "high" },
+          ],
+          status: "failed",
+          markdown_path: "tests/default/feature-a.md",
+        },
+        {
+          environment_id: "api",
+          full_name: "suite feature B",
+          labels: [{ name: "feature", value: "payments" }],
+          status: "passed",
+          markdown_path: "tests/api/feature-b.md",
+        },
+      ],
+      findings: [],
+    });
+    (planAgentEnrichmentReview as Mock).mockReturnValueOnce({
+      rerun: {
+        targetedTests: ["suite feature A", "suite feature B"],
+      },
+    });
+
+    const selection = await selectAgentTestPlan({
+      outputDir: "/tmp/agent-output",
+      preset: "review",
+      environments: ["default"],
+      labelFilters: [{ name: "feature", value: "checkout" }],
+    });
+
+    expect(selection.outputDir).toBe("/tmp/agent-output");
+    expect(selection.preset).toBe("review");
+    expect(selection.selectedTests).toHaveLength(1);
+    expect(selection.selectedTests[0].full_name).toBe("suite feature A");
+    expect(selection.testPlan).toEqual({
+      version: "1.0",
+      tests: [{ selector: "suite feature A" }],
+    });
+  });
+
+  it("should resolve latest output directories and parse supported filters", async () => {
+    const { readLatestAgentState } = await import("../../src/utils/agent-state.js");
+
+    (readLatestAgentState as Mock).mockResolvedValueOnce({
+      outputDir: "/tmp/latest-agent-output",
+    });
+
+    await expect(resolveAgentSelectionOutputDir({ cwd: "/cwd", latest: true })).resolves.toBe(
+      "/tmp/latest-agent-output",
+    );
+    expect(normalizeAgentRerunPreset("failed")).toBe("failed");
+    expect(parseAgentLabelFilters(["feature=checkout", "priority=high"])).toEqual([
+      { name: "feature", value: "checkout" },
+      { name: "priority", value: "high" },
+    ]);
+  });
+});

--- a/packages/cli/test/utils/agent-state.test.ts
+++ b/packages/cli/test/utils/agent-state.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -32,7 +32,8 @@ describe("agent-state utils", () => {
   it("should persist latest state under the computed temp state dir for each project cwd", async () => {
     const fsModule = await import("node:fs/promises");
     const cwd = "/repo";
-    const projectHash = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+    const normalizedCwd = resolve(cwd);
+    const projectHash = createHash("sha256").update(normalizedCwd).digest("hex").slice(0, 16);
     const statePath = join("/tmp", `allure-agent-state-${projectHash}`, "latest.json");
 
     await writeLatestAgentState({
@@ -55,7 +56,7 @@ describe("agent-state utils", () => {
   it("should resolve an explicit state dir override from the environment", () => {
     process.env[ALLURE_AGENT_STATE_DIR_ENV] = "/custom-agent-state";
 
-    expect(resolveAgentStateDir("/repo")).toBe("/custom-agent-state");
+    expect(resolveAgentStateDir("/repo")).toBe(resolve("/custom-agent-state"));
   });
 
   it("should return undefined when no latest state exists for the project", async () => {

--- a/packages/cli/test/utils/agent-state.test.ts
+++ b/packages/cli/test/utils/agent-state.test.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ALLURE_AGENT_STATE_DIR_ENV,
+  readLatestAgentState,
+  resolveAgentStateDir,
+  writeLatestAgentState,
+} from "../../src/utils/agent-state.js";
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal()),
+  tmpdir: vi.fn().mockReturnValue("/tmp"),
+}));
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal()),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn(),
+  rename: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env[ALLURE_AGENT_STATE_DIR_ENV];
+});
+
+describe("agent-state utils", () => {
+  it("should persist latest state under the computed temp state dir for each project cwd", async () => {
+    const fsModule = await import("node:fs/promises");
+    const cwd = "/repo";
+    const projectHash = createHash("sha256").update(cwd).digest("hex").slice(0, 16);
+    const statePath = join("/tmp", `allure-agent-state-${projectHash}`, "latest.json");
+
+    await writeLatestAgentState({
+      cwd,
+      outputDir: "/tmp/allure-agent-123",
+      command: "npm test",
+      startedAt: "2026-04-15T18:00:00.000Z",
+      status: "running",
+    });
+
+    expect(fsModule.mkdir).toHaveBeenCalledWith(dirname(statePath), { recursive: true });
+    expect(fsModule.writeFile).toHaveBeenCalledWith(
+      `${statePath}.${process.pid}.tmp`,
+      expect.stringContaining('"schema": "allure-agent-latest/v1"'),
+      "utf-8",
+    );
+    expect(fsModule.rename).toHaveBeenCalledWith(`${statePath}.${process.pid}.tmp`, statePath);
+  });
+
+  it("should resolve an explicit state dir override from the environment", () => {
+    process.env[ALLURE_AGENT_STATE_DIR_ENV] = "/custom-agent-state";
+
+    expect(resolveAgentStateDir("/repo")).toBe("/custom-agent-state");
+  });
+
+  it("should return undefined when no latest state exists for the project", async () => {
+    const fsModule = await import("node:fs/promises");
+
+    (fsModule.readFile as Mock).mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+    await expect(readLatestAgentState("/repo")).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -16,6 +16,7 @@ export interface FullConfig
     Omit<Config, "name" | "output" | "open" | "knownIssuesPath" | "plugins" | "port">,
     FullConfigRequiredFromConfig {
   port: Config["port"] | undefined;
+  allowedEnvironments?: Config["allowedEnvironments"];
   reportFiles: ReportFiles;
   readers?: ResultsReader[];
   plugins?: PluginInstance[];

--- a/packages/plugin-agent/README.md
+++ b/packages/plugin-agent/README.md
@@ -16,7 +16,7 @@ This plugin writes AI-friendly markdown summaries for a test run. It is designed
 flows like:
 
 ```shell
-ALLURE_AGENT_OUTPUT=./out/agent-report npx allure run -- npm test
+npx allure agent -- npm test
 ```
 
 When enabled, the plugin writes:
@@ -38,8 +38,8 @@ accept. See [the enrichment loop guide](../../docs/agent_enrichment_loop.md).
 
 ## Verification Standard
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 
 ## Skills-First Workflow
@@ -84,7 +84,24 @@ export default defineConfig({
 });
 ```
 
-You can also enable it through an environment variable:
+The preferred CLI entrypoint is:
+
+```shell
+npx allure agent -- npm test
+```
+
+You can provide an explicit expectations file and output directory when you need deterministic paths:
+
+```shell
+npx allure agent \
+  --output ./out/agent-report \
+  --expectations ./out/agent-expected.yaml \
+  -- npm test
+```
+
+That command uses an agent-only profile by default, so configured presentation and export plugins such as Awesome, Dashboard, or TestOps are ignored for that run.
+
+You can also enable the plugin through lower-level environment variables when you need direct env control:
 
 ```shell
 ALLURE_AGENT_OUTPUT=./out/agent-report npx allure run -- npm test
@@ -184,7 +201,7 @@ markdown and `manifest/findings.jsonl`.
 
 The intended usage pattern is:
 
-1. Run tests with `allure run -- <command>`.
+1. Run tests with `allure agent -- <command>`.
 2. Watch `manifest/run.json` and `manifest/test-events.jsonl` while the run is active.
 3. Review `index.md` plus the manifest files.
 4. If evidence is weak, add steps, attachments, labels, or parameters.
@@ -252,9 +269,17 @@ the same policy in a project-level skill or agent prompt, you can start with:
 ```md
 ## Allure Agent Mode Instructions
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
+- After each agent-mode test run, print the `index.md` path from that run's output directory so users can open the run overview quickly.
+- Use `allure agent latest` to reopen the newest run when `--output` was omitted.
+- Use `allure agent state-dir` to inspect where the current project stores its latest-agent state.
+- Use `allure agent select --latest` or `allure agent select --from <output-dir>` to inspect the review-targeted test plan before rerunning.
+- Use `allure agent --rerun-latest -- <command>` or `allure agent --rerun-from <output-dir> -- <command>` to rerun only the selected tests.
+- Use `--rerun-preset review|failed|unsuccessful|all`, repeated `--rerun-environment <id>`, and repeated `--rerun-label name=value` when you need a narrower rerun selection from the previous output.
+- Use `ALLURE_AGENT_STATE_DIR` when you need to override where the current project stores latest-agent state for `latest`, `state-dir`, or `--rerun-latest`.
+- Use `ALLURE_AGENT_*` with `allure run` only as the lower-level fallback when you need direct environment control.
 - Generate or refresh `ALLURE_AGENT_EXPECTATIONS` before each targeted rerun.
 - Run tests with `ALLURE_AGENT_OUTPUT` and review `manifest/run.json`, `manifest/test-events.jsonl`, `index.md`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 - Enrich only the intended tests. Add real steps for real setup, actions, and assertions.

--- a/packages/plugin-agent/src/guidance.ts
+++ b/packages/plugin-agent/src/guidance.ts
@@ -134,21 +134,28 @@ export const ENRICHMENT_ACTIONS_BY_CHECK_NAME: Record<string, EnrichmentActionDe
 
 export const AGENT_ENRICHMENT_WORKFLOW = [
   "Generate or refresh `ALLURE_AGENT_EXPECTATIONS` before each targeted enrichment iteration.",
-  "Run tests with `allure run -- <command>` and `ALLURE_AGENT_OUTPUT` enabled.",
+  "Run tests with `allure agent --output <dir> --expectations <file> -- <command>`.",
+  "After each test run, print the `index.md` path from that output directory so collaborators can open the run overview quickly.",
+  "Use `allure agent latest` to recover the newest output directory when a prior run omitted `--output`.",
+  "Use `allure agent state-dir` to inspect where the current project stores its latest-agent state.",
+  "Use `ALLURE_AGENT_STATE_DIR` when you need to override where the current project stores latest-agent state for `latest`, `state-dir`, or `--rerun-latest`.",
+  "Use `allure agent select --latest` or `allure agent select --from <output-dir>` to inspect the review-targeted test plan before rerunning.",
+  "Use `allure agent --rerun-latest -- <command>` or `allure agent --rerun-from <output-dir> -- <command>` to rerun only the selected tests through Allure testplan support. Add `--rerun-preset`, repeated `--rerun-environment`, or repeated `--rerun-label name=value` filters when you need a narrower rerun slice.",
   "Inspect `manifest/run.json`, tail `manifest/test-events.jsonl`, then review `index.md`, `manifest/tests.jsonl`, and `manifest/findings.jsonl` before editing tests.",
   "Enrich only the intended tests, rerun the same scope, and compare the rerun against `manifest/expected.json` when present.",
   "Accept the rerun only when scope is clean, evidence is strong enough to review, and no high-confidence dummy findings remain.",
 ] as const;
 
 export const AGENT_VERIFICATION_RULES = [
-  "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.",
-  "Use `allure run` for smoke checks too, even when the change is small or mechanical.",
+  "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.",
+  "Use `allure agent` for smoke checks too, even when the change is small or mechanical.",
   "Only skip agent mode when it is impossible or when you are debugging agent mode itself.",
+  "After each agent-mode test run, print the `index.md` path from that run's output directory so users can open the run overview quickly.",
 ] as const;
 
 export const AGENT_SMALL_TEST_CHANGE_WORKFLOW = [
   "Create a fresh temp `ALLURE_AGENT_OUTPUT` and `ALLURE_AGENT_EXPECTATIONS` for the touched scope before closing the task.",
-  "Run the touched scope with `allure run`, even if the goal is only a smoke check after a mechanical change such as typing cleanup, mock refactors, or helper extraction.",
+  "Run the touched scope with `allure agent`, even if the goal is only a smoke check after a mechanical change such as typing cleanup, mock refactors, or helper extraction.",
   "Review `manifest/run.json`, `manifest/test-events.jsonl`, `index.md`, `manifest/tests.jsonl`, and `manifest/findings.jsonl` before making any final claim.",
 ] as const;
 
@@ -193,11 +200,19 @@ export const AGENT_PARTIAL_RUNTIME_REVIEW_RULES = [
 
 export const AGENT_INSTRUCTIONS_TEMPLATE = `## Allure Agent Mode Instructions
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through \`allure run\`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use \`allure run\` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through \`allure agent\`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use \`allure agent\` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
+- After each agent-mode test run, print the \`index.md\` path from that run's output directory so users can open the run overview quickly.
+- Use \`ALLURE_AGENT_*\` with \`allure run\` only as the lower-level fallback when you need direct environment control.
+- Use \`allure agent latest\` to reopen the newest run when \`--output\` was omitted.
+- Use \`allure agent state-dir\` to inspect where the current project stores its latest-agent state.
+- Use \`allure agent select --latest\` or \`allure agent select --from <output-dir>\` to inspect the review-targeted test plan before rerunning.
+- Use \`allure agent --rerun-latest -- <command>\` or \`allure agent --rerun-from <output-dir> -- <command>\` to rerun only the selected tests.
+- Use \`--rerun-preset review|failed|unsuccessful|all\`, repeated \`--rerun-environment <id>\`, and repeated \`--rerun-label name=value\` when you need a narrower rerun selection from the previous output.
+- Use \`ALLURE_AGENT_STATE_DIR\` when you need to override where the current project stores latest-agent state for \`latest\`, \`state-dir\`, or \`--rerun-latest\`.
 - Generate or refresh \`ALLURE_AGENT_EXPECTATIONS\` before each targeted rerun.
-- Run tests with \`ALLURE_AGENT_OUTPUT\` and review \`manifest/run.json\`, \`manifest/test-events.jsonl\`, \`index.md\`, \`manifest/tests.jsonl\`, and \`manifest/findings.jsonl\`.
+- Run tests with \`allure agent\` and review \`manifest/run.json\`, \`manifest/test-events.jsonl\`, \`index.md\`, \`manifest/tests.jsonl\`, and \`manifest/findings.jsonl\`.
 - Enrich only the intended tests. Add real steps for real setup, actions, and assertions.
 - Attach only real runtime evidence such as payloads, responses, screenshots, DOM snapshots, diffs, logs, or traces.
 - Keep metadata minimal. Add labels or severity only when scope review, debugging, or quality policy uses them.

--- a/packages/plugin-agent/src/plugin.ts
+++ b/packages/plugin-agent/src/plugin.ts
@@ -2162,7 +2162,7 @@ const buildRunAndTestFindings = (params: {
           "Global process logs help agents debug bootstrap failures and compare the recorded results with console output.",
         evidencePaths: [],
         remediationHint:
-          "Run tests through `allure run -- <command>` without disabling log capture when you need bootstrap diagnostics.",
+          "Run tests through `allure agent -- <command>` without `--silent` when you need bootstrap diagnostics, or use `ALLURE_AGENT_*` with `allure run` for lower-level control.",
         confidence: 0.9,
       }),
     );

--- a/packages/plugin-agent/test/index.test.ts
+++ b/packages/plugin-agent/test/index.test.ts
@@ -506,10 +506,19 @@ describe("AgentPlugin", () => {
     expect(guide).toContain("## Enrichment Loop Workflow");
     expect(guide).toContain("## Verification Standard");
     expect(guide).toContain("manifest/test-events.jsonl");
+    expect(guide).toContain("allure agent latest");
+    expect(guide).toContain("allure agent state-dir");
+    expect(guide).toContain("allure agent select --latest");
+    expect(guide).toContain("allure agent --rerun-latest");
+    expect(guide).toContain("--rerun-preset");
+    expect(guide).toContain("--rerun-environment");
+    expect(guide).toContain("--rerun-label");
+    expect(guide).toContain("ALLURE_AGENT_STATE_DIR");
+    expect(guide).toContain("print the `index.md` path");
     expect(guide).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.",
     );
-    expect(guide).toContain("Use `allure run` for smoke checks too, even when the change is small or mechanical.");
+    expect(guide).toContain("Use `allure agent` for smoke checks too, even when the change is small or mechanical.");
     expect(guide).toContain("Only skip agent mode when it is impossible or when you are debugging agent mode itself.");
     expect(guide).toContain("## Small Test Change Workflow");
     expect(guide).toContain("## Coverage Review Workflow");

--- a/packages/plugin-agent/test/skills.test.ts
+++ b/packages/plugin-agent/test/skills.test.ts
@@ -24,8 +24,12 @@ describe("allure agent-mode skills bundle", () => {
 
     expect(setupSkill).toContain("name: allure-agent-mode-setup");
     expect(setupSkill).toContain("docs/allure-agent-mode.md");
+    expect(setupSkill).toContain("allure agent latest");
+    expect(setupSkill).toContain("allure agent state-dir");
+    expect(setupSkill).toContain("allure agent select --latest");
+    expect(setupSkill).toContain("allure agent --rerun-latest");
     expect(setupSkill).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`.",
     );
     expect(setupUi).toContain('display_name: "Allure Agent Setup"');
     expect(featureSkill).toContain("name: allure-agent-mode-feature-delivery");
@@ -34,10 +38,10 @@ describe("allure agent-mode skills bundle", () => {
     expect(featureSkill).toContain("auditing coverage");
     expect(featureSkill).toContain("triaging failing suites");
     expect(featureSkill).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`.",
     );
     expect(featureSkill).toContain(
-      "Use `allure run` for smoke checks too, even when the change is small or mechanical.",
+      "Use `allure agent` for smoke checks too, even when the change is small or mechanical.",
     );
     expect(featureSkill).toContain(
       "Only skip agent mode when it is impossible or when you are debugging agent mode itself.",
@@ -64,11 +68,21 @@ describe("allure agent-mode skills bundle", () => {
     expect(projectGuide).toContain("### Test Review Loop");
     expect(projectGuide).toContain("Runtime first, source second.");
     expect(projectGuide).toContain("## Verification Standard");
+    expect(projectGuide).toContain("## Helpful Commands");
+    expect(projectGuide).toContain("allure agent latest");
+    expect(projectGuide).toContain("allure agent state-dir");
+    expect(projectGuide).toContain("allure agent select --latest");
+    expect(projectGuide).toContain("allure agent --rerun-latest");
+    expect(projectGuide).toContain("--rerun-preset review|failed|unsuccessful|all");
+    expect(projectGuide).toContain("--rerun-environment <id>");
+    expect(projectGuide).toContain("--rerun-label name=value");
+    expect(projectGuide).toContain("ALLURE_AGENT_STATE_DIR");
+    expect(projectGuide).toContain("print the `index.md` path");
     expect(projectGuide).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`.",
     );
     expect(projectGuide).toContain(
-      "Use `allure run` for smoke checks too, even when the change is small or mechanical.",
+      "Use `allure agent` for smoke checks too, even when the change is small or mechanical.",
     );
     expect(projectGuide).toContain(
       "Only skip agent mode when it is impossible or when you are debugging agent mode itself.",
@@ -77,17 +91,27 @@ describe("allure agent-mode skills bundle", () => {
     expect(projectGuide).toContain("### Coverage Review Workflow");
     expect(projectGuide).toContain("## Acceptance Rules");
     expect(projectGuide).toContain("When Console Errors Are Not Represented As Test Results");
-    expect(projectGuide).toContain("yarn allure run -- yarn workspace allure test");
+    expect(projectGuide).toContain("yarn allure agent --");
     expect(projectGuide).toContain("test/commands/run.integration.test.ts");
     expect(rootAgents).toContain("docs/allure-agent-mode.md");
     expect(rootAgents).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`.",
     );
-    expect(rootAgents).toContain("Use `allure run` for smoke checks too");
+    expect(rootAgents).toContain("Use `allure agent` for smoke checks too");
     expect(rootAgents).toContain("reasoning, review, coverage analysis, debugging, or any user-facing conclusion");
     expect(rootAgents).toContain("console-only review");
     expect(templateGuide).toContain("ALLURE_AGENT_EXPECTATIONS");
     expect(templateGuide).toContain("## Verification Standard");
+    expect(templateGuide).toContain("## Helpful Commands");
+    expect(templateGuide).toContain("allure agent latest");
+    expect(templateGuide).toContain("allure agent state-dir");
+    expect(templateGuide).toContain("allure agent select --latest");
+    expect(templateGuide).toContain("allure agent --rerun-latest");
+    expect(templateGuide).toContain("--rerun-preset review|failed|unsuccessful|all");
+    expect(templateGuide).toContain("--rerun-environment <id>");
+    expect(templateGuide).toContain("--rerun-label name=value");
+    expect(templateGuide).toContain("ALLURE_AGENT_STATE_DIR");
+    expect(templateGuide).toContain("print the `index.md` path");
     expect(templateGuide).toContain("### Test Review Loop");
     expect(templateGuide).toContain("### Small Test Change Workflow");
     expect(templateGuide).toContain("### Coverage Review Workflow");
@@ -95,14 +119,14 @@ describe("allure agent-mode skills bundle", () => {
     expect(templateGuide).toContain("partial runtime review");
     expect(agentsSnippet).toContain("Use [Allure Agent Mode](docs/allure-agent-mode.md)");
     expect(agentsSnippet).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`.",
     );
-    expect(agentsSnippet).toContain("Use `allure run` for smoke checks too");
+    expect(agentsSnippet).toContain("Use `allure agent` for smoke checks too");
     expect(agentsSnippet).toContain("reasoning, review, coverage analysis, debugging, or any user-facing conclusion");
     expect(readme).toContain("## Verification Standard");
     expect(readme).toContain("For small mechanical test changes, use a scoped agent-mode run for the smoke check");
     expect(readme).toContain(
-      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`.",
+      "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`.",
     );
     expect(readme).toContain("treat the review as partial");
   });

--- a/skills/allure-agent-mode-feature-delivery/SKILL.md
+++ b/skills/allure-agent-mode-feature-delivery/SKILL.md
@@ -7,8 +7,8 @@ description: Use Allure agent-mode to design or review test scope, create per-ru
 
 Use this skill for feature or bug work that changes tests, for reviewing existing tests, auditing coverage, triaging failing suites, investigating weak evidence, or debugging flaky and environment-sensitive failures.
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 
 ## Read First
@@ -22,7 +22,7 @@ If it does not, use the guidance in this skill and suggest running the setup ski
 1. Understand the feature, issue, or review goal and decide the intended test scope.
 2. Create a fresh expectations file for this run in a temp directory.
 3. Write or update the tests, or keep the current tests unchanged if the task is review-only.
-4. Run only the intended scope with `allure run` before relying on raw console output.
+4. Run only the intended scope with `allure agent` before relying on raw console output.
 5. Review `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, `manifest/findings.jsonl`, and the relevant test markdown files before inspecting source code.
 6. If evidence is weak, enrich the tests with real steps, attachments, or minimal metadata.
 7. Rerun with a new temp output directory and a new expectations file.
@@ -33,7 +33,7 @@ If it does not, use the guidance in this skill and suggest running the setup ski
 ### Small Test Change Workflow
 
 1. Create a fresh expectations file and temp output directory for the touched scope.
-2. Run the touched scope with `allure run`, even if the goal is only a smoke check after a mechanical change such as typing cleanup, mock refactors, or helper extraction.
+2. Run the touched scope with `allure agent`, even if the goal is only a smoke check after a mechanical change such as typing cleanup, mock refactors, or helper extraction.
 3. Review `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 4. Only then make a final statement about regression safety or test correctness.
 
@@ -41,7 +41,7 @@ If it does not, use the guidance in this skill and suggest running the setup ski
 
 1. Split command or package audits into scoped groups.
 2. Give each group its own expectations file and temp output directory.
-3. Run each group with `allure run`.
+3. Run each group with `allure agent`.
 4. Review runtime artifacts first, then inspect source code only after the run explains what actually executed.
 5. Mark the review incomplete until each scoped group either matched expectations or was explicitly documented as a broad package-health audit.
 
@@ -51,9 +51,10 @@ Compact coverage-review pattern:
 TMP_DIR="$(mktemp -d)"
 EXPECTATIONS="$TMP_DIR/expectations.yaml"
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-npx allure run -- npm test -- <scope>
+npx allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- npm test -- <scope>
 ```
 
 Coverage-review expectations example:

--- a/skills/allure-agent-mode-setup/SKILL.md
+++ b/skills/allure-agent-mode-setup/SKILL.md
@@ -7,8 +7,8 @@ description: Set up Allure agent-mode guidance in a project by checking whether 
 
 Use this skill when a project wants to adopt Allure agent-mode for test work and test reviews.
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 
 ## Goal
@@ -25,7 +25,8 @@ Leave the project with:
 2. If Allure is missing, add or suggest the smallest viable install/config path for the project. Treat this as best-effort bootstrap, not the main acceptance path.
 3. Create or update root `AGENTS.md` so test-related work points to `docs/allure-agent-mode.md`.
 4. Create `docs/allure-agent-mode.md` from the bundled template and adapt only the parts that must be project-specific.
-5. Keep changes minimal and additive. Preserve unrelated project guidance in `AGENTS.md`.
+5. Keep the helper-command descriptions short and practical. Include `allure agent latest`, `allure agent state-dir`, `allure agent select --latest` / `--from <output-dir>`, and `allure agent --rerun-latest` / `--rerun-from <output-dir>` as small Helpful Commands entries so agents can recover the latest output directory, inspect where state is stored, inspect the review-targeted test plan, and rerun the same focused scope. Add one compact Advanced Reruns section that documents `--rerun-preset`, `--rerun-environment`, `--rerun-label`, and `ALLURE_AGENT_STATE_DIR` without turning the guide into a full CLI reference. Keep the verification section explicit that agents should print the run's `index.md` path after test execution.
+6. Keep changes minimal and additive. Preserve unrelated project guidance in `AGENTS.md`.
 
 ## Files To Use
 
@@ -35,6 +36,7 @@ Leave the project with:
 ## Guardrails
 
 - Keep `AGENTS.md` short. It should route, not duplicate the whole guide.
+- Keep helper-command notes short. Prefer one-line descriptions over a growing command catalog.
 - Do not invent project-specific metadata conventions unless the repo already uses them.
 - Do not create persistent output or expectations paths in the project guide. Those are per-run temp artifacts.
 - If the project already has better Allure instructions, merge carefully instead of overwriting them.

--- a/skills/allure-agent-mode-setup/references/project-guide-template.md
+++ b/skills/allure-agent-mode-setup/references/project-guide-template.md
@@ -6,13 +6,29 @@ Use Allure agent-mode to design, review, validate, debug, and enrich tests in th
 
 Runtime first, source second.
 
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `ALLURE_AGENT_*` with `allure run` only as the lower-level fallback when you need direct environment control.
 - If the agent-mode output is missing or incomplete, debug that first and treat console-only conclusions as provisional.
 
 ## Verification Standard
 
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
+- After each agent-mode test run, print the `index.md` path from that run's output directory so users can open the run overview quickly.
+
+## Helpful Commands
+
+- `allure agent latest` prints the latest agent output directory for the current project cwd. Use it when a prior run omitted `--output` and you want to reopen the most recent agent-mode artifacts.
+- `allure agent state-dir` prints the state directory for the current project cwd. Use it when you need to inspect where `latest` pointers are stored or debug sandbox behavior.
+- `allure agent select --latest` or `allure agent select --from <output-dir>` prints the review-targeted test plan from a prior agent run. Add `--preset failed` or exact `--label name=value` / `--environment <id>` filters when you need a narrower rerun plan.
+- `allure agent --rerun-latest -- <command>` or `allure agent --rerun-from <output-dir> -- <command>` reruns only the selected tests through the framework-agnostic Allure testplan flow. The default rerun preset is `review`.
+
+## Advanced Reruns
+
+- `--rerun-preset review|failed|unsuccessful|all` changes how the rerun seed set is chosen. Use `review` for the default agent-targeted loop, `failed` for classic failure reruns, `unsuccessful` for any non-passed tests, and `all` when you want the whole previously observed set.
+- `--rerun-environment <id>` narrows the rerun selection to one or more environment ids from the previous agent output. Repeat the flag for multiple environments.
+- `--rerun-label name=value` narrows the rerun selection to tests whose prior results carried exact matching labels. Repeat the flag for multiple label filters.
+- `ALLURE_AGENT_STATE_DIR` overrides the default project-scoped state directory used by `allure agent latest`, `allure agent state-dir`, and `--rerun-latest`. Use it when you need a deterministic shared location in CI or a constrained sandbox.
 
 ## Core Loops
 
@@ -20,18 +36,19 @@ Runtime first, source second.
 
 1. Identify the exact review scope.
 2. Create a fresh expectations file for this run in a temp directory.
-3. Run only that scope with `allure run`.
+3. Run only that scope with `allure agent`.
 4. Read `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 5. Read per-test markdown only for tests that failed, drifted, or have findings.
 6. Only after runtime review, inspect source code for root cause or coverage gaps.
 7. If evidence is weak or partial, enrich the tests and rerun.
+8. When iterating on the same scope, prefer `allure agent --rerun-latest -- <command>` or `allure agent --rerun-from <output-dir> -- <command>` so the rerun stays focused on the review-targeted tests.
 
 ### Feature Delivery Loop
 
 1. Understand the feature or issue.
 2. Create a fresh expectations file for this run in a temp directory.
 3. Write or update the tests.
-4. Run the target scope with `allure run`.
+4. Run the target scope with `allure agent`.
 5. Review `index.md`, manifests, and per-test markdown.
 6. Enrich tests when evidence is weak.
 7. Rerun until scope and evidence are acceptable.
@@ -48,7 +65,7 @@ Use this when the run is functionally correct but too weak to review:
 ### Small Test Change Workflow
 
 1. Create a fresh expectations file and temp output directory for the touched scope.
-2. Run the touched scope with `allure run`, even if the goal is only a smoke check after a mechanical change such as typing cleanup, mock refactors, or helper extraction.
+2. Run the touched scope with `allure agent`, even if the goal is only a smoke check after a mechanical change such as typing cleanup, mock refactors, or helper extraction.
 3. Review `index.md`, `manifest/run.json`, `manifest/tests.jsonl`, and `manifest/findings.jsonl`.
 4. Only then make a final statement about regression safety or test correctness.
 
@@ -56,7 +73,7 @@ Use this when the run is functionally correct but too weak to review:
 
 1. Split command or package audits into scoped groups.
 2. Give each group its own expectations file and temp output directory.
-3. Run each group with `allure run`.
+3. Run each group with `allure agent`.
 4. Review runtime artifacts first, then inspect source code only after the run explains what actually executed.
 5. Mark the review incomplete until each scoped group either matched expectations or was explicitly documented as a broad package-health audit.
 
@@ -88,9 +105,10 @@ Compact coverage-review pattern:
 TMP_DIR="$(mktemp -d)"
 EXPECTATIONS="$TMP_DIR/expectations.yaml"
 
-ALLURE_AGENT_OUTPUT="$TMP_DIR/agent-output" \
-ALLURE_AGENT_EXPECTATIONS="$EXPECTATIONS" \
-npx allure run -- npm test -- <scope>
+npx allure agent \
+  --output "$TMP_DIR/agent-output" \
+  --expectations "$EXPECTATIONS" \
+  -- npm test -- <scope>
 ```
 
 Single-spec expectations example:

--- a/skills/allure-agent-mode-setup/references/root-agents-snippet.md
+++ b/skills/allure-agent-mode-setup/references/root-agents-snippet.md
@@ -3,8 +3,8 @@
 Use [Allure Agent Mode](docs/allure-agent-mode.md) for all test-related work in this repository.
 
 - Read `docs/allure-agent-mode.md` before designing, writing, reviewing, validating, debugging, or enriching tests.
-- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure run`. It preserves the original console logs and adds agent-mode artifacts when you need them.
-- Use `allure run` for smoke checks too, even when the change is small or mechanical.
+- If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
+- Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 - If agent-mode output is missing or incomplete, debug that first rather than silently falling back to console-only review.
 - Use Allure agent-mode when adding tests for features or fixes so expectations, evidence quality, and scope review are part of the loop.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8142,6 +8142,7 @@ __metadata:
     "@allurereport/core": "workspace:*"
     "@allurereport/core-api": "workspace:*"
     "@allurereport/directory-watcher": "workspace:*"
+    "@allurereport/plugin-agent": "workspace:*"
     "@allurereport/plugin-allure2": "workspace:*"
     "@allurereport/plugin-api": "workspace:*"
     "@allurereport/plugin-awesome": "workspace:*"


### PR DESCRIPTION
This adds a dedicated `allure agent` workflow for agent-mode test runs.

What’s new:
- `allure agent -- <command>` for clean agent-only test runs
- `allure agent latest` to reopen the most recent run for the current project
- `allure agent state-dir` to show where latest-run state is stored
- `allure agent select` to inspect the review-targeted test plan from a previous run
- `allure agent --rerun-latest` and `allure agent --rerun-from <output-dir>` for focused reruns
- rerun filters such as `--rerun-preset`, `--rerun-environment`, and `--rerun-label`
- `ALLURE_AGENT_STATE_DIR` to override where agent state is stored
- compatibility for older env-based agent-mode runs

These commands are primarily meant for agents, not humans. Humans can still run them, but the main goal is to give coding agents a stable way to run tests, reopen the latest output, inspect scope, and rerun only the right slice.

How to use this with your agent:
1. Run `npx skills add allure-framework/allure3`
2. Ask your agent to enable Allure agent mode for the repo

Suggested prompt:
```text
Enable Allure agent mode in this repository and use it for test runs, smoke checks, debugging, review, and reruns.
```

Typical agent flow:
```bash
allure agent -- yarn test
allure agent latest
allure agent select --latest
allure agent --rerun-latest -- yarn test
```