### PR TITLE
fix(web-awesome): crash opening test case with setup/teardown

### DIFF
--- a/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
@@ -3,20 +3,13 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
+import { getBodyItems } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
-import { TrAttachment } from "@/components/TestResult/TrSteps/TrAttachment";
-import { TrStep } from "@/components/TestResult/TrSteps/TrStep";
+import { TrBodyItems } from "@/components/TestResult/TrSteps/TrBodyItems";
 import { useI18n } from "@/stores/locale";
 import { collapsedTrees, toggleTree } from "@/stores/tree";
 
 import * as styles from "@/components/TestResult/TrSteps/styles.scss";
-
-const typeMap = {
-  before: TrStep,
-  after: TrStep,
-  step: TrStep,
-  attachment: TrAttachment,
-};
 
 export type TrSetupProps = {
   setup: AwesomeTestResult["setup"];
@@ -33,6 +26,7 @@ export const TrSetup: FunctionalComponent<TrSetupProps> = ({ setup, id }) => {
     toggleTree(teardownId);
   };
   const { t } = useI18n("execution");
+  const bodyItems = getBodyItems({ id: teardownId, status: "passed", steps: setup ?? [] });
 
   return (
     <div className={styles["test-result-steps"]}>
@@ -45,14 +39,7 @@ export const TrSetup: FunctionalComponent<TrSetupProps> = ({ setup, id }) => {
       />
       {isOpened && (
         <div className={styles["test-result-steps-root"]}>
-          {setup?.map((item, key) => {
-            const StepComponent = typeMap[item.type];
-            return StepComponent ? (
-              // FIXME: use proper type in the StepComponent component
-              // @ts-ignore
-              <StepComponent item={item} stepIndex={key + 1} key={key} className={styles["test-result-step-root"]} />
-            ) : null;
-          })}
+          <TrBodyItems bodyItems={bodyItems} />
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
@@ -3,7 +3,7 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
-import { getBodyItems } from "@/components/TestResult/bodyItems";
+import { getStepBodyItems } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
 import { TrBodyItems } from "@/components/TestResult/TrSteps/TrBodyItems";
 import { useI18n } from "@/stores/locale";
@@ -26,7 +26,7 @@ export const TrSetup: FunctionalComponent<TrSetupProps> = ({ setup, id }) => {
     toggleTree(teardownId);
   };
   const { t } = useI18n("execution");
-  const bodyItems = getBodyItems({ id: teardownId, status: "passed", steps: setup ?? [] });
+  const bodyItems = getStepBodyItems(setup ?? []);
 
   return (
     <div className={styles["test-result-steps"]}>

--- a/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
@@ -3,20 +3,13 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
+import { getBodyItems } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
-import { TrAttachment } from "@/components/TestResult/TrSteps/TrAttachment";
-import { TrStep } from "@/components/TestResult/TrSteps/TrStep";
+import { TrBodyItems } from "@/components/TestResult/TrSteps/TrBodyItems";
 import { useI18n } from "@/stores/locale";
 import { collapsedTrees, toggleTree } from "@/stores/tree";
 
 import * as styles from "@/components/TestResult/TrSteps/styles.scss";
-
-const typeMap = {
-  before: TrStep,
-  after: TrStep,
-  step: TrStep,
-  attachment: TrAttachment,
-};
 
 export type TrTeardownProps = {
   teardown: AwesomeTestResult["teardown"];
@@ -34,6 +27,7 @@ export const TrTeardown: FunctionalComponent<TrTeardownProps> = ({ teardown, id 
   };
 
   const { t } = useI18n("execution");
+  const bodyItems = getBodyItems({ id: teardownId, status: "passed", steps: teardown ?? [] });
 
   return (
     <div className={styles["test-result-steps"]}>
@@ -46,14 +40,7 @@ export const TrTeardown: FunctionalComponent<TrTeardownProps> = ({ teardown, id 
       />
       {isOpened && (
         <div className={styles["test-result-steps-root"]}>
-          {teardown?.map((item, key) => {
-            const StepComponent = typeMap[item.type];
-            return StepComponent ? (
-              // FIXME: use proper type in the StepComponent component
-              // @ts-ignore
-              <StepComponent item={item} stepIndex={key + 1} key={key} className={styles["test-result-step-root"]} />
-            ) : null;
-          })}
+          <TrBodyItems bodyItems={bodyItems} />
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
@@ -3,7 +3,7 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
-import { getBodyItems } from "@/components/TestResult/bodyItems";
+import { getStepBodyItems } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
 import { TrBodyItems } from "@/components/TestResult/TrSteps/TrBodyItems";
 import { useI18n } from "@/stores/locale";
@@ -27,7 +27,7 @@ export const TrTeardown: FunctionalComponent<TrTeardownProps> = ({ teardown, id 
   };
 
   const { t } = useI18n("execution");
-  const bodyItems = getBodyItems({ id: teardownId, status: "passed", steps: teardown ?? [] });
+  const bodyItems = getStepBodyItems(teardown ?? []);
 
   return (
     <div className={styles["test-result-steps"]}>

--- a/packages/web-awesome/src/components/TestResult/bodyItems.ts
+++ b/packages/web-awesome/src/components/TestResult/bodyItems.ts
@@ -128,6 +128,9 @@ const buildStepBodyItems = (
   return { bodyItems, didPlaceSyntheticError };
 };
 
+export const getStepBodyItems = (steps: AwesomeTestResult["steps"]): TrBodyItem[] =>
+  buildStepBodyItems(steps, undefined).bodyItems;
+
 export const getBodyItems = (
   testResult?: Pick<AwesomeTestResult, "id" | "status" | "steps" | "error">,
   fallbackTitle = "Error",


### PR DESCRIPTION
# Problem

Opening any test case that has a `setup` or `teardown` section throws `TypeError: Cannot read properties of undefined (reading 'message')` in `TrStep`, which cascades into follow-up `contextElement` / `getBoundingClientRect` errors as Preact unwinds the broken render. The main body (steps) renders fine; only setup/teardown crash.

- 3.3.1: works
- 3.4.0+: broken

ref. https://dopiz.github.io/pytest-api-automation/ — open any test case, e.g. https://dopiz.github.io/pytest-api-automation/#45806ddbee9742dd9dc2359d0c8063a1, and check DevTools Console.

<img width="1225" height="1148" alt="截圖 2026-04-18 03 33 46" src="https://github.com/user-attachments/assets/08c79c92-f917-4e12-960e-2de48ee22fda" />


# Root Cause

> Analysis by Claude Code

PR #553 ("Added error steps") wrapped raw step results into a new `TrStepItem` shape (`{ type, item, bodyItems, suppressInlineError }`) and changed `TrStep`'s prop type to match:

```ts
export const TrStep: FC<{ item: TrStepItem }>
// reads stepData = props.item.item  →  stepData.message
```

`TrOverview` was migrated to use the new `getBodyItems()` helper, so its body produces the wrapped shape correctly. **But `TrSetup` / `TrTeardown` were not updated** — they still iterate raw `AwesomeTestResult["setup" | "teardown"]` entries and pass them straight to `TrStep`, with an `@ts-ignore` silencing the type mismatch:

```tsx
// FIXME: use proper type in the StepComponent component
// @ts-ignore
<StepComponent item={item} stepIndex={key + 1} ... />
```

At runtime `props.item.item === undefined`, so `(stepData.message || stepData.trace) && !stepData.hasSimilarErrorInSubSteps` throws on the first property access. The other two console errors are downstream fallout from the failed render (tooltip refs resolving against a DOM node that never mounted).

# Fix

Extract a new `getStepBodyItems(steps)` helper in `bodyItems.ts` (thin wrapper over the existing `buildStepBodyItems` internal), and route `TrSetup` / `TrTeardown` through it + `<TrBodyItems>`. This reuses the same wrapping/dispatch path `TrOverview` already uses, without having to fake a `testResult` shape just to satisfy `getBodyItems`.

Files:
- `packages/web-awesome/src/components/TestResult/bodyItems.ts` — export `getStepBodyItems`
- `packages/web-awesome/src/components/TestResult/TrSetup/index.tsx`
- `packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx`

| | Before | After |
| --- | --- | --- |
| Step wrapping | Raw `DefaultTestStepResult` passed to `TrStep` (`@ts-ignore`) | Wrapped into `TrStepItem` via `getStepBodyItems()` |
| Dispatch | Local `typeMap` (`before`/`after`/`step`/`attachment`) | Shared `<TrBodyItems>` switch (also handles `error` items) |
| Nested steps | Not recursively built | Built recursively |
| Synthetic test-level error | N/A | Not injected — the helper is purely for wrapping, no need to fake a `status` |

# Tests

- [x] Open a test case with setup and/or teardown — no console errors; sections render and expand
- [x] Open a test case without setup/teardown — unchanged
- [x] `yarn workspace @allurereport/web-awesome test` — 13 files / 61 tests pass
