### PR TITLE
hotfix 3.4.0

### DIFF
--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -150,7 +150,9 @@ export const generateTestResults = async (
   for (const tr of trs) {
     const trFixtures = await store.fixturesByTrId(tr.id);
     const convertedTrFixtures: AwesomeFixtureResult[] = trFixtures.map(convertFixtureResult);
-    const convertedTr: AwesomeTestResult = convertTestResult(tr, { hideLabels: options.hideLabels });
+    const convertedTr: AwesomeTestResult = convertTestResult(tr, {
+      hideLabels: options.hideLabels,
+    });
 
     convertedTr.history = (await store.historyByTrId(tr.id)) ?? [];
     convertedTr.retries = await store.retriesByTrId(tr.id);
@@ -670,11 +672,6 @@ export const generateTreeFilters = async (writer: AwesomeDataWriter, testResults
         trCategories.add(category.name);
       }
     });
-  }
-
-  // No need to generate a json file if it will be empty
-  if (trTags.size === 0 && trCategories.size === 0) {
-    return Promise.resolve();
   }
 
   const tags = Array.from(trTags).sort((a, b) => a.localeCompare(b));

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -184,9 +184,7 @@ export class AwesomePlugin implements Plugin {
     await generateEnvirontmentsList(this.#writer!, store);
     await generateVariables(this.#writer!, store);
 
-    if (environmentItems?.length) {
-      await generateEnvironmentJson(this.#writer!, environmentItems);
-    }
+    await generateEnvironmentJson(this.#writer!, environmentItems ?? []);
 
     if (attachments?.length) {
       await generateAttachmentsFiles(this.#writer!, attachments, (id) => store.attachmentContentById(id));

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -240,6 +240,93 @@ describe("plugin", () => {
     });
   });
 
+  describe("generated widget files", () => {
+    it("always writes widgets/allure_environment.json (and environments.json) in multi-file mode when metadata is absent", async () => {
+      const testResults: TestResult[] = [
+        {
+          id: "tr-1",
+          name: "passed test",
+          status: "passed",
+          labels: [],
+        },
+      ] as TestResult[];
+
+      const addedFiles = new Map<string, Buffer>();
+      const reportFiles: ReportFiles = {
+        addFile: vi.fn(async (path: string, data: Buffer) => {
+          addedFiles.set(path, data);
+          return path;
+        }),
+      };
+
+      const store: AllureStore = {
+        metadataByKey: vi.fn().mockResolvedValue(undefined),
+        allEnvironments: vi.fn().mockResolvedValue(["default"]),
+        allEnvironmentIdentities: vi
+          .fn()
+          .mockResolvedValue([{ id: "default", name: "default" } satisfies EnvironmentIdentity]),
+        allAttachments: vi.fn().mockResolvedValue([]),
+        allTestResults: vi.fn(async (options?: { includeHidden?: boolean; filter?: (tr: TestResult) => boolean }) => {
+          const trs = options?.filter ? testResults.filter(options.filter) : testResults;
+          return trs;
+        }),
+        testResultsByEnvironment: vi.fn().mockResolvedValue(testResults),
+        testResultsByEnvironmentId: vi.fn().mockResolvedValue(testResults),
+        environmentIdByTrId: vi.fn().mockResolvedValue("default"),
+        testsStatistic: vi.fn(async (filter: (tr: TestResult) => boolean) => getTestResultsStats(testResults, filter)),
+        allTestEnvGroups: vi.fn().mockResolvedValue([]),
+        allGlobalAttachments: vi.fn().mockResolvedValue([]),
+        allGlobalAttachmentsByEnv: vi.fn().mockResolvedValue({}),
+        globalExitCode: vi.fn().mockResolvedValue(undefined),
+        allGlobalErrors: vi.fn().mockResolvedValue([]),
+        allGlobalErrorsByEnv: vi.fn().mockResolvedValue([]),
+        qualityGateResults: vi.fn().mockResolvedValue([]),
+        qualityGateResultsByEnv: vi.fn().mockResolvedValue({}),
+        qualityGateResultsByEnvironmentId: vi.fn().mockResolvedValue({}),
+        fixturesByTrId: vi.fn().mockResolvedValue([]),
+        historyByTrId: vi.fn().mockResolvedValue([]),
+        retriesByTrId: vi.fn().mockResolvedValue([]),
+        attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        allVariables: vi.fn().mockResolvedValue([]),
+        envVariables: vi.fn().mockResolvedValue([]),
+        envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),
+        allHistoryDataPoints: vi.fn().mockResolvedValue([]),
+        allHistoryDataPointsByEnvironment: vi.fn().mockResolvedValue([]),
+        allHistoryDataPointsByEnvironmentId: vi.fn().mockResolvedValue([]),
+        allNewTestResults: vi.fn().mockResolvedValue([]),
+        attachmentContentById: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AllureStore;
+
+      const context: PluginContext = {
+        id: "Awesome",
+        publish: true,
+        state: {} as PluginContext["state"],
+        allureVersion: "3.0.0",
+        reportUuid: "report-uuid",
+        reportName: "Test report",
+        reportFiles,
+        output: "/tmp/out",
+      };
+
+      const plugin = new AwesomePlugin({ charts: [] });
+
+      await plugin.start(context);
+      await plugin.update(context, store);
+
+      expect(addedFiles.has("widgets/allure_environment.json")).toBe(true);
+      expect(JSON.parse(addedFiles.get("widgets/allure_environment.json")!.toString("utf-8"))).toEqual([]);
+
+      expect(addedFiles.has("widgets/environments.json")).toBe(true);
+      expect(addedFiles.get("widgets/environments.json")!.toString("utf-8")).toBeTruthy();
+
+      expect(addedFiles.has("widgets/tree-filters.json")).toBe(true);
+      expect(JSON.parse(addedFiles.get("widgets/tree-filters.json")!.toString("utf-8"))).toEqual({
+        tags: [],
+        categories: [],
+      });
+    });
+  });
+
   describe("environment-specific outputs", () => {
     it("should keep env-specific widgets separated by environment id when allEnvironments exposes one shared display name", async () => {
       const qaATestResult = {
@@ -571,6 +658,7 @@ describe("plugin", () => {
         "widgets/default/tree.json",
         "widgets/default/nav.json",
         "widgets/environments.json",
+        "widgets/allure_environment.json",
         "widgets/statistic.json",
         "widgets/globals.json",
       ];
@@ -591,6 +679,20 @@ describe("plugin", () => {
       const envs = JSON.parse(Buffer.from(envsRaw, "base64").toString("utf-8")) as EnvironmentIdentity[];
 
       expect(envs).toContainEqual({ id: "default", name: "default" });
+
+      const envMetaRaw = embeddedData["widgets/allure_environment.json"];
+      const envMeta = JSON.parse(Buffer.from(envMetaRaw, "base64").toString("utf-8"));
+
+      expect(envMeta).toEqual([]);
+
+      const treeFiltersRaw = embeddedData["widgets/tree-filters.json"];
+      const treeFilters = JSON.parse(Buffer.from(treeFiltersRaw, "base64").toString("utf-8")) as {
+        tags: string[];
+        categories: string[];
+      };
+
+      expect(treeFilters.tags).toEqual(["smoke"]);
+      expect(Array.isArray(treeFilters.categories)).toBe(true);
 
       // data test results file for the test must be present
       expect(Object.keys(embeddedData).some((k) => k.startsWith("data/test-results/"))).toBe(true);

--- a/packages/plugin-awesome/test/writer.test.ts
+++ b/packages/plugin-awesome/test/writer.test.ts
@@ -16,6 +16,7 @@ describe("InMemoryReportDataWriter", () => {
     } as unknown as ResultFile;
 
     await writer.writeData("history\\entry.json", { id: 1 });
+    await writer.writeWidget("allure_environment.json", []);
     await writer.writeWidget("default\\tree.json", { id: 2 });
     await writer.writeTestCase({ id: "tr-1" } as any);
     await writer.writeAttachment("foo\\bar.txt", attachment);
@@ -23,6 +24,7 @@ describe("InMemoryReportDataWriter", () => {
     const names = writer.reportFiles().map((file) => file.name);
 
     expect(names).toContain("data/history/entry.json");
+    expect(names).toContain("widgets/allure_environment.json");
     expect(names).toContain("widgets/default/tree.json");
     expect(names).toContain("data/test-results/tr-1.json");
     expect(names).toContain("data/attachments/foo/bar.txt");

--- a/packages/plugin-classic/src/plugin.ts
+++ b/packages/plugin-classic/src/plugin.ts
@@ -59,9 +59,7 @@ export class ClassicPlugin implements Plugin {
     await generateTree(this.#writer!, "packages", packagesLabels, convertedTrs);
     await generateHistoryDataPoints(this.#writer!, store);
 
-    if (environmentItems?.length) {
-      await generateEnvironmentJson(this.#writer!, environmentItems);
-    }
+    await generateEnvironmentJson(this.#writer!, environmentItems ?? []);
 
     if (attachments?.length) {
       await generateAttachmentsFiles(this.#writer!, attachments, (id) => store.attachmentContentById(id));

--- a/packages/plugin-classic/test/writer.test.ts
+++ b/packages/plugin-classic/test/writer.test.ts
@@ -16,6 +16,7 @@ describe("InMemoryReportDataWriter", () => {
     } as unknown as ResultFile;
 
     await writer.writeData("history\\entry.json", { id: 1 });
+    await writer.writeWidget("allure_environment.json", []);
     await writer.writeWidget("default\\tree.json", { id: 2 });
     await writer.writeTestCase({ id: "tr-1" } as any);
     await writer.writeAttachment("foo\\bar.txt", attachment);
@@ -23,6 +24,7 @@ describe("InMemoryReportDataWriter", () => {
     const names = writer.reportFiles().map((file) => file.name);
 
     expect(names).toContain("data/history/entry.json");
+    expect(names).toContain("widgets/allure_environment.json");
     expect(names).toContain("widgets/default/tree.json");
     expect(names).toContain("data/test-results/tr-1.json");
     expect(names).toContain("data/attachments/foo/bar.txt");

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
@@ -28,11 +28,12 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
   const retryTitle = convertedStop ? `${retryTitlePrefix} – ${convertedStop}` : retryTitlePrefix;
 
   const formattedDuration = typeof duration === "number" ? formatDuration(duration) : undefined;
+  const hasErrorDetails = Boolean(error?.trace || error?.message);
 
   return (
     <div data-testid="test-result-retries-item">
       <div className={styles["test-result-retries-item-header"]} onClick={() => setIsOpen(!isOpened)}>
-        {Boolean(error.trace || error.message) && (
+        {hasErrorDetails && (
           <ArrowButton
             data-testid="test-result-retries-item-arrow-button"
             isOpened={isOpened}
@@ -61,9 +62,9 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
           </div>
         </div>
       </div>
-      {isOpened && (error.message || error.trace) && (
+      {isOpened && hasErrorDetails && (
         <div className={styles["test-result-retries-item-content"]}>
-          <TrError {...error} status={status} />
+          <TrError {...(error ?? {})} status={status} />
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/index.tsx
@@ -10,13 +10,13 @@ import * as styles from "./styles.scss";
 export const TrRetriesView: FunctionalComponent<{
   testResult: AwesomeTestResult;
 }> = ({ testResult }) => {
-  const { retries } = testResult ?? {};
+  const retries = testResult?.retries ?? [];
   const { t } = useI18n("empty");
 
   return (
     <div className={styles["test-result-retries"]}>
       {retries.length ? (
-        retries?.map((item, key) => (
+        retries.map((item, key) => (
           <TrRetriesItem
             testResultItem={item as unknown as AwesomeTestResult}
             key={key}

--- a/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
@@ -3,20 +3,13 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
+import { fixtureResultToTrStepItem } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
-import { TrAttachment } from "@/components/TestResult/TrSteps/TrAttachment";
 import { TrStep } from "@/components/TestResult/TrSteps/TrStep";
 import { useI18n } from "@/stores/locale";
 import { collapsedTrees, toggleTree } from "@/stores/tree";
 
 import * as styles from "@/components/TestResult/TrSteps/styles.scss";
-
-const typeMap = {
-  before: TrStep,
-  after: TrStep,
-  step: TrStep,
-  attachment: TrAttachment,
-};
 
 export type TrSetupProps = {
   setup: AwesomeTestResult["setup"];
@@ -45,14 +38,11 @@ export const TrSetup: FunctionalComponent<TrSetupProps> = ({ setup, id }) => {
       />
       {isOpened && (
         <div className={styles["test-result-steps-root"]}>
-          {setup?.map((item, key) => {
-            const StepComponent = typeMap[item.type];
-            return StepComponent ? (
-              // FIXME: use proper type in the StepComponent component
-              // @ts-ignore
-              <StepComponent item={item} stepIndex={key + 1} key={key} className={styles["test-result-step-root"]} />
-            ) : null;
-          })}
+          {setup?.map((fixture, key) => (
+            <div className={styles["test-result-step-root"]} key={fixture.id}>
+              <TrStep item={fixtureResultToTrStepItem(fixture)} stepIndex={key + 1} />
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/TestResult/TrSteps/TrStep.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/TrStep.tsx
@@ -2,7 +2,7 @@ import type { FunctionComponent } from "preact";
 
 import { MetadataList } from "@/components/Metadata";
 import { type MetadataItem } from "@/components/ReportMetadata";
-import type { TrStepItem } from "@/components/TestResult/bodyItems";
+import { hasErrorDiff, type TrStepItem } from "@/components/TestResult/bodyItems";
 import { TrError } from "@/components/TestResult/TrError";
 import { TrBodyItems } from "@/components/TestResult/TrSteps/TrBodyItems";
 import { TrStepHeader } from "@/components/TestResult/TrSteps/TrStepHeader";
@@ -23,14 +23,22 @@ export const TrStepParameters = (props: { parameters: TrStepItem["item"]["parame
 
 export const TrStepsContent = (props: { item: TrStepItem }) => {
   const { item: stepData, bodyItems, suppressInlineError } = props.item;
+  const inlineError = {
+    message: stepData.message ?? stepData.error?.message,
+    trace: stepData.trace ?? stepData.error?.trace,
+    actual: stepData.error?.actual,
+    expected: stepData.error?.expected,
+  };
   const hasInlineError = Boolean(
-    (stepData.message || stepData.trace) && !stepData.hasSimilarErrorInSubSteps && !suppressInlineError,
+    (inlineError.message || inlineError.trace || hasErrorDiff(inlineError)) &&
+    !stepData.hasSimilarErrorInSubSteps &&
+    !suppressInlineError,
   );
 
   return (
     <div data-testid={"test-result-step-content"} className={styles["test-result-step-content"]}>
       {Boolean(stepData.parameters?.length) && <TrStepParameters parameters={stepData.parameters} />}
-      {hasInlineError && <TrError {...stepData} />}
+      {hasInlineError && <TrError {...inlineError} status={stepData.status} />}
       {Boolean(bodyItems.length) && <TrBodyItems bodyItems={bodyItems} />}
     </div>
   );
@@ -41,8 +49,16 @@ export const TrStep: FunctionComponent<{
   stepIndex?: number;
 }> = ({ item, stepIndex }) => {
   const { item: stepData, bodyItems, suppressInlineError } = item;
+  const inlineError = {
+    message: stepData.message ?? stepData.error?.message,
+    trace: stepData.trace ?? stepData.error?.trace,
+    actual: stepData.error?.actual,
+    expected: stepData.error?.expected,
+  };
   const hasInlineError = Boolean(
-    (stepData.message || stepData.trace) && !stepData.hasSimilarErrorInSubSteps && !suppressInlineError,
+    (inlineError.message || inlineError.trace || hasErrorDiff(inlineError)) &&
+    !stepData.hasSimilarErrorInSubSteps &&
+    !suppressInlineError,
   );
   const hasContent = Boolean(bodyItems.length || stepData.parameters?.length || hasInlineError);
   const isOpened = !collapsedTrees.value.has(stepData.stepId);

--- a/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
@@ -3,20 +3,13 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
+import { fixtureResultToTrStepItem } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
-import { TrAttachment } from "@/components/TestResult/TrSteps/TrAttachment";
 import { TrStep } from "@/components/TestResult/TrSteps/TrStep";
 import { useI18n } from "@/stores/locale";
 import { collapsedTrees, toggleTree } from "@/stores/tree";
 
 import * as styles from "@/components/TestResult/TrSteps/styles.scss";
-
-const typeMap = {
-  before: TrStep,
-  after: TrStep,
-  step: TrStep,
-  attachment: TrAttachment,
-};
 
 export type TrTeardownProps = {
   teardown: AwesomeTestResult["teardown"];
@@ -46,14 +39,11 @@ export const TrTeardown: FunctionalComponent<TrTeardownProps> = ({ teardown, id 
       />
       {isOpened && (
         <div className={styles["test-result-steps-root"]}>
-          {teardown?.map((item, key) => {
-            const StepComponent = typeMap[item.type];
-            return StepComponent ? (
-              // FIXME: use proper type in the StepComponent component
-              // @ts-ignore
-              <StepComponent item={item} stepIndex={key + 1} key={key} className={styles["test-result-step-root"]} />
-            ) : null;
-          })}
+          {teardown?.map((fixture, key) => (
+            <div className={styles["test-result-step-root"]} key={fixture.id}>
+              <TrStep item={fixtureResultToTrStepItem(fixture)} stepIndex={key + 1} />
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/TestResult/bodyItems.ts
+++ b/packages/web-awesome/src/components/TestResult/bodyItems.ts
@@ -1,5 +1,5 @@
 import type { AttachmentTestStepResult, DefaultTestStepResult, TestError, TestStatus } from "@allurereport/core-api";
-import type { AwesomeTestResult } from "types";
+import type { AwesomeFixtureResult, AwesomeTestResult } from "types";
 
 export type TestLevelErrorItem = {
   type: "error";
@@ -126,6 +126,31 @@ const buildStepBodyItems = (
   }
 
   return { bodyItems, didPlaceSyntheticError };
+};
+
+export const getStepBodyItems = (steps: AwesomeTestResult["steps"]): TrBodyItem[] =>
+  buildStepBodyItems(steps, undefined).bodyItems;
+
+export const fixtureResultToTrStepItem = (fixture: AwesomeFixtureResult): TrStepItem => {
+  const err = fixture.error;
+
+  return {
+    type: "step",
+    item: {
+      type: "step",
+      name: fixture.name,
+      status: fixture.status,
+      parameters: [],
+      steps: [],
+      stepId: fixture.id,
+      duration: fixture.duration,
+      message: err?.message,
+      trace: err?.trace,
+      error: err,
+    },
+    bodyItems: getStepBodyItems(fixture.steps),
+    suppressInlineError: false,
+  };
 };
 
 export const getBodyItems = (

--- a/packages/web-awesome/src/components/TestResult/bodyItems.ts
+++ b/packages/web-awesome/src/components/TestResult/bodyItems.ts
@@ -141,7 +141,7 @@ export const fixtureResultToTrStepItem = (fixture: AwesomeFixtureResult): TrStep
       name: fixture.name,
       status: fixture.status,
       parameters: [],
-      steps: [],
+      steps: fixture.steps,
       stepId: fixture.id,
       duration: fixture.duration,
       message: err?.message,

--- a/packages/web-awesome/src/components/Tree/index.tsx
+++ b/packages/web-awesome/src/components/Tree/index.tsx
@@ -72,15 +72,20 @@ export const TreeList = () => {
 
         // render single tree for single environment
         if (environmentsStore.value.data.length === 1) {
+          const soleId = environmentsStore.value.data[0]!.id;
+          const soleStatistic = currentEnvironment.value
+            ? statsByEnvStore.value.data[currentEnvironment.value]
+            : statsByEnvStore.value.data[soleId];
+
           return (
             <div>
               <Tree
                 reportStatistic={reportStatsStore.value.data}
-                statistic={statsByEnvStore.value.data[currentEnvironment.value]}
+                statistic={soleStatistic}
                 collapsedTrees={collapsedTrees.value}
                 toggleTree={toggleTree}
                 navigateTo={treeNavigateTo}
-                tree={treeLocalizer(filteredTree.value.default)}
+                tree={treeLocalizer(filteredTree.value[soleId])}
                 statusFilter={currentTreeStatus}
                 routeId={trId}
                 root

--- a/packages/web-awesome/src/index.tsx
+++ b/packages/web-awesome/src/index.tsx
@@ -86,6 +86,17 @@ const App = () => {
   }, []);
 
   useSignalEffect(() => {
+    const envId = currentEnvironment.value;
+
+    if (!prefetched || !envId) {
+      return;
+    }
+
+    fetchEnvTreesData([envId]);
+    fetchEnvStats([envId]);
+  });
+
+  useSignalEffect(() => {
     const testResultId = currentTrId.value;
     if (isTestResultRoute.value && testResultId) {
       fetchTestResult(testResultId);

--- a/packages/web-awesome/src/index.tsx
+++ b/packages/web-awesome/src/index.tsx
@@ -68,7 +68,7 @@ const App = () => {
     await waitForI18next;
     await Promise.all(fns.map((fn) => fn(currentEnvironment.value)));
 
-    const environmentIds = environmentsStore.value.data.map(({ id }) => id);
+    const environmentIds = environmentsStore.value.data.map(({ id }) => id).filter((id): id is string => Boolean(id));
 
     if (currentEnvironment.value) {
       await fetchEnvTreesData([currentEnvironment.value]);
@@ -83,7 +83,7 @@ const App = () => {
 
   useEffect(() => {
     prefetchData();
-  }, [currentEnvironment.value]);
+  }, []);
 
   useSignalEffect(() => {
     const testResultId = currentTrId.value;

--- a/packages/web-awesome/src/stores/env.ts
+++ b/packages/web-awesome/src/stores/env.ts
@@ -1,8 +1,10 @@
 import { type EnvironmentIdentity, type TestEnvGroup } from "@allurereport/core-api";
 import {
   environmentNameById as resolveEnvironmentNameById,
+  errorMessageFromUnknown,
   fetchReportJsonData,
   migrateStoredEnvironmentSelection,
+  normalizeEnvironmentsWidget,
 } from "@allurereport/web-commons";
 import { effect, signal } from "@preact/signals";
 
@@ -40,7 +42,8 @@ export const fetchEnvironments = async () => {
   };
 
   try {
-    const res = await fetchReportJsonData<EnvironmentIdentity[]>("widgets/environments.json", { bustCache: true });
+    const raw = await fetchReportJsonData<unknown>("widgets/environments.json", { bustCache: true });
+    const res = normalizeEnvironmentsWidget(raw);
 
     environmentsStore.value = {
       data: res,
@@ -52,7 +55,7 @@ export const fetchEnvironments = async () => {
   } catch (e) {
     environmentsStore.value = {
       ...environmentsStore.peek(),
-      error: e.message,
+      error: errorMessageFromUnknown(e),
       loading: false,
     };
   }
@@ -83,7 +86,7 @@ export const fetchTestEnvGroup = async (id: string) => {
   } catch (e) {
     testEnvGroupsStore.value = {
       ...testEnvGroupsStore.peek(),
-      error: e.message,
+      error: errorMessageFromUnknown(e),
       loading: false,
     };
   }

--- a/packages/web-awesome/src/stores/envInfo.ts
+++ b/packages/web-awesome/src/stores/envInfo.ts
@@ -1,5 +1,5 @@
 import type { EnvironmentItem } from "@allurereport/core-api";
-import { fetchReportJsonData } from "@allurereport/web-commons";
+import { errorMessageFromUnknown, fetchReportJsonData } from "@allurereport/web-commons";
 import { signal } from "@preact/signals";
 
 import type { StoreSignalState } from "@/stores/types";
@@ -28,7 +28,7 @@ export const fetchEnvInfo = async () => {
   } catch (e) {
     envInfoStore.value = {
       ...envInfoStore.peek(),
-      error: e.message,
+      error: errorMessageFromUnknown(e),
       loading: false,
     };
   }

--- a/packages/web-awesome/src/stores/stats.ts
+++ b/packages/web-awesome/src/stores/stats.ts
@@ -1,5 +1,5 @@
 import type { Statistic } from "@allurereport/core-api";
-import { fetchReportJsonData } from "@allurereport/web-commons";
+import { errorMessageFromUnknown, fetchReportJsonData } from "@allurereport/web-commons";
 import { signal } from "@preact/signals";
 
 import type { StoreSignalState } from "@/stores/types";
@@ -38,7 +38,7 @@ export const fetchReportStats = async () => {
   } catch (err) {
     reportStatsStore.value = {
       data: { total: 0 },
-      error: err.message,
+      error: errorMessageFromUnknown(err),
       loading: false,
     };
   }
@@ -80,7 +80,7 @@ export const fetchEnvStats = async (envs: string[]) => {
   } catch (err) {
     statsByEnvStore.value = {
       ...statsByEnvStore.peek(),
-      error: err.message,
+      error: errorMessageFromUnknown(err),
       loading: false,
     };
   }

--- a/packages/web-awesome/src/stores/tree.ts
+++ b/packages/web-awesome/src/stores/tree.ts
@@ -1,4 +1,4 @@
-import { buildFilterPredicate, fetchReportJsonData } from "@allurereport/web-commons";
+import { buildFilterPredicate, errorMessageFromUnknown, fetchReportJsonData } from "@allurereport/web-commons";
 import type { RecursiveTree } from "@allurereport/web-components/global";
 import { computed, effect, signal } from "@preact/signals";
 import type { AwesomeTree, AwesomeTreeGroup } from "types";
@@ -74,7 +74,7 @@ export const fetchEnvTreesData = async (envs: string[]) => {
   } catch (e) {
     treeStore.value = {
       ...treeStore.peek(),
-      error: e.message,
+      error: errorMessageFromUnknown(e),
       loading: false,
     };
   }

--- a/packages/web-awesome/test/components/TestResult/bodyItems.test.ts
+++ b/packages/web-awesome/test/components/TestResult/bodyItems.test.ts
@@ -1,8 +1,13 @@
 import type { AttachmentTestStepResult, DefaultTestStepResult } from "@allurereport/core-api";
-import type { AwesomeTestResult } from "types";
+import type { AwesomeFixtureResult, AwesomeTestResult } from "types";
 import { describe, expect, it } from "vitest";
 
-import { getBodyItems, getTestLevelErrorId } from "@/components/TestResult/bodyItems";
+import {
+  fixtureResultToTrStepItem,
+  getBodyItems,
+  getStepBodyItems,
+  getTestLevelErrorId,
+} from "@/components/TestResult/bodyItems";
 
 const sampleStep: DefaultTestStepResult = {
   type: "step",
@@ -190,5 +195,23 @@ describe("components > TestResult > bodyItems", () => {
         error: { message: "boom" },
       },
     ]);
+  });
+
+  it("fixtureResultToTrStepItem builds TrStepItem from setup or teardown fixture", () => {
+    const fixture: AwesomeFixtureResult = {
+      id: "fixture-before-1",
+      type: "before",
+      name: "before suite",
+      status: "passed",
+      steps: [sampleStep],
+    };
+
+    const wrapped = fixtureResultToTrStepItem(fixture);
+
+    expect(wrapped.type).toBe("step");
+    expect(wrapped.item.name).toBe("before suite");
+    expect(wrapped.item.stepId).toBe("fixture-before-1");
+    expect(wrapped.item.type).toBe("step");
+    expect(wrapped.bodyItems).toEqual(getStepBodyItems([sampleStep]));
   });
 });

--- a/packages/web-commons/src/data.ts
+++ b/packages/web-commons/src/data.ts
@@ -81,6 +81,8 @@ export class ReportFetchError extends Error {
   }
 }
 
+export const errorMessageFromUnknown = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
 export const fetchReportJsonData = async <T>(path: string, params?: { bustCache: boolean }) => {
   let url: string;
 

--- a/packages/web-commons/src/environments.ts
+++ b/packages/web-commons/src/environments.ts
@@ -1,4 +1,51 @@
 import type { EnvironmentIdentity } from "@allurereport/core-api";
+import { validateEnvironmentId, validateEnvironmentName } from "@allurereport/core-api";
+
+export const normalizeEnvironmentsWidget = (raw: unknown): EnvironmentIdentity[] => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const out: EnvironmentIdentity[] = [];
+
+  for (const item of raw) {
+    if (typeof item === "string") {
+      out.push({ id: item, name: item });
+      continue;
+    }
+
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    const rec = item as Record<string, unknown>;
+
+    if (typeof rec.id !== "string") {
+      continue;
+    }
+
+    const idResult = validateEnvironmentId(rec.id);
+
+    if (!idResult.valid) {
+      continue;
+    }
+
+    const rawName = rec.name;
+
+    if (typeof rawName === "string") {
+      const nameResult = validateEnvironmentName(rawName);
+
+      if (nameResult.valid) {
+        out.push({ id: idResult.normalized, name: nameResult.normalized });
+        continue;
+      }
+    }
+
+    out.push({ id: idResult.normalized, name: idResult.normalized });
+  }
+
+  return out;
+};
 
 export const environmentNameById = (environments: EnvironmentIdentity[], environmentId: string) =>
   environments.find(({ id }) => id === environmentId)?.name ?? environmentId;

--- a/packages/web-commons/test/environments.test.ts
+++ b/packages/web-commons/test/environments.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { environmentNameById, migrateStoredEnvironmentSelection } from "../src/environments.js";
+import {
+  environmentNameById,
+  migrateStoredEnvironmentSelection,
+  normalizeEnvironmentsWidget,
+} from "../src/environments.js";
 
 const environments = [
   { id: "default", name: "default" },
@@ -24,5 +28,30 @@ describe("environment helpers", () => {
   it("should reset invalid or missing persisted values", () => {
     expect(migrateStoredEnvironmentSelection("", environments)).toBe("");
     expect(migrateStoredEnvironmentSelection("missing", environments)).toBe("");
+  });
+
+  it("normalizeEnvironmentsWidget should map legacy string[] to identities", () => {
+    expect(normalizeEnvironmentsWidget(["default", "staging"])).toEqual([
+      { id: "default", name: "default" },
+      { id: "staging", name: "staging" },
+    ]);
+  });
+
+  it("normalizeEnvironmentsWidget should accept EnvironmentIdentity objects", () => {
+    expect(
+      normalizeEnvironmentsWidget([
+        { id: "default", name: "default" },
+        { id: "qa", name: "QA" },
+      ]),
+    ).toEqual([
+      { id: "default", name: "default" },
+      { id: "qa", name: "QA" },
+    ]);
+  });
+
+  it("normalizeEnvironmentsWidget should skip invalid ids and non-arrays", () => {
+    expect(normalizeEnvironmentsWidget(null)).toEqual([]);
+    expect(normalizeEnvironmentsWidget([{ id: "bad id!", name: "x" }])).toEqual([]);
+    expect(normalizeEnvironmentsWidget([42, "ok"])).toEqual([{ id: "ok", name: "ok" }]);
   });
 });

--- a/packages/web-dashboard/src/stores/env.ts
+++ b/packages/web-dashboard/src/stores/env.ts
@@ -1,8 +1,10 @@
 import type { EnvironmentIdentity } from "@allurereport/core-api";
 import {
   environmentNameById as resolveEnvironmentNameById,
+  errorMessageFromUnknown,
   fetchReportJsonData,
   migrateStoredEnvironmentSelection,
+  normalizeEnvironmentsWidget,
 } from "@allurereport/web-commons";
 import { effect, signal } from "@preact/signals";
 
@@ -41,7 +43,8 @@ export const fetchEnvironments = async () => {
   };
 
   try {
-    const res = await fetchReportJsonData<EnvironmentIdentity[]>("widgets/environments.json", { bustCache: true });
+    const raw = await fetchReportJsonData<unknown>("widgets/environments.json", { bustCache: true });
+    const res = normalizeEnvironmentsWidget(raw);
 
     environmentsStore.value = {
       data: res,
@@ -53,7 +56,7 @@ export const fetchEnvironments = async () => {
   } catch (e) {
     environmentsStore.value = {
       ...environmentsStore.value,
-      error: e.message,
+      error: errorMessageFromUnknown(e),
       loading: false,
     };
   }


### PR DESCRIPTION
Fixes several Awesome regressions after 3.4 data changes like crashes when opening a test result, missing or fragile widgets, and unsafe handling of optional fields. Aligns the UI and plugins with optional/legacy report payloads instead of assuming a stricter shape.

#600 #599 #571 

## Why things crashed or broke
### Retries 
(`Cannot read properties of undefined (reading 'message')`)
Retry attempts use the same model as a normal test result, where error is optional. The retries panel always read error.message / error.trace. For attempts without an error object (e.g. some Mocha / reporter combinations), the React tree threw and the test detail view went blank.
retries on the awesome model is also optional; using retries.length without a fallback could throw in edge cases.

### Setup / teardown panel
Fixture rows were passed into TrStep in a shape that did not match TrStepItem (raw fixture vs step item). That type/shape mismatch could crash when expanding setup/teardown for results that actually had fixture data (e.g. from befores/afters containers).

### Environment / tree widgets
The UI expected widgets/environments.json as a stable list of EnvironmentIdentity, while older or partial reports could ship string[], invalid entries, or odd JSON. Unnormalized data led to runtime errors or wrong env selection.
widgets/tree-filters.json was skipped when both tag and category sets were empty, so the frontend could 404 or see inconsistent state on static hosts and single-file bundles.

### Plugin / tests
Skipping `tree-filters.json` when empty contradicted the contract the UI and tests rely on (always ship the widget, possibly with empty tags / categories).