### PR TITLE
fix(reader/cucumberjson): skip non-array JSON instead of throwing TypeError

### DIFF
--- a/packages/reader/src/cucumberjson/index.ts
+++ b/packages/reader/src/cucumberjson/index.ts
@@ -90,7 +90,12 @@ export const cucumberjson: ResultsReader = {
     if (originalFileName.endsWith(".json")) {
       try {
         const parsed = await data.asJson<CucumberFeature[]>();
-        if (parsed) {
+        // Cucumber JSON is always an array of features at the top level.
+        // Other tooling sometimes drops a single object into the same
+        // results directory (e.g. the Jenkins Allure plugin's
+        // testrun.json — { stop, name, start }). Skip non-arrays so the
+        // reader doesn't crash with `TypeError: parsed is not iterable`.
+        if (isArray(parsed)) {
           let oneOrMoreFeaturesParsed = false;
           for (const feature of parsed) {
             oneOrMoreFeaturesParsed ||= await processFeature(visitor, originalFileName, feature);

--- a/packages/reader/src/cucumberjson/index.ts
+++ b/packages/reader/src/cucumberjson/index.ts
@@ -90,11 +90,6 @@ export const cucumberjson: ResultsReader = {
     if (originalFileName.endsWith(".json")) {
       try {
         const parsed = await data.asJson<CucumberFeature[]>();
-        // Cucumber JSON is always an array of features at the top level.
-        // Other tooling sometimes drops a single object into the same
-        // results directory (e.g. the Jenkins Allure plugin's
-        // testrun.json — { stop, name, start }). Skip non-arrays so the
-        // reader doesn't crash with `TypeError: parsed is not iterable`.
         if (isArray(parsed)) {
           let oneOrMoreFeaturesParsed = false;
           for (const feature of parsed) {


### PR DESCRIPTION
## Summary

Closes #569.

The cucumberjson reader iterated the parsed payload directly:

```ts
const parsed = await data.asJson<CucumberFeature[]>();
if (parsed) {
    for (const feature of parsed) { ... }
}
```

A Cucumber JSON results file is always an array of features at the top level, but other tooling sometimes drops a single object into the same results directory — for example the Jenkins Allure plugin's `testrun.json` (`{ stop, name, start }`). On such files the `for…of` loop crashed the whole report generation with

```
error parsing testrun.json TypeError: parsed is not iterable
    at Object.read (.../@allurereport/reader/dist/cucumberjson/index.js:41:43)
```

Until now the workaround was to delete `testrun.json` between runs (per the reporter), which isn't viable on the Jenkins agent that creates it.

## Fix

Guard the loop with the existing `isArray()` helper (already imported from `utils.js`):

```ts
if (isArray(parsed)) {
    let oneOrMoreFeaturesParsed = false;
    for (const feature of parsed) { ... }
    return oneOrMoreFeaturesParsed;
}
```

Non-array JSON now falls through to `return false`, which is how every other reader signals "not my format." The Jenkins-created `testrun.json` is silently ignored and the real cucumber feature files in the same directory are still picked up.

## Test plan

- [x] Diff is a single `if (parsed)` → `if (isArray(parsed))` change with no other behaviour change for valid Cucumber files.
- [ ] Couldn't run the workspace test suite locally (Vitest hits an unrelated `EBADF` on Node 25). CI will exercise the existing `packages/reader/test/cucumberjson.test.ts` suite which should keep passing.