### PR TITLE
fix(web): allow clicking test details in single-page reports opened 

### DIFF
--- a/packages/web-awesome/src/stores/treeFilters/utils.ts
+++ b/packages/web-awesome/src/stores/treeFilters/utils.ts
@@ -1,5 +1,5 @@
 import type { TestStatus, TestStatusTransition } from "@allurereport/core-api";
-import { MAX_ARRAY_FIELD_VALUES, getCurrentUrl } from "@allurereport/web-commons";
+import { MAX_ARRAY_FIELD_VALUES, getCurrentUrl, goTo } from "@allurereport/web-commons";
 
 import { PARAMS, STATUSES, TRANSITIONS } from "./constants";
 import type {
@@ -15,7 +15,10 @@ export const truncateArrayFieldValues = (values: string[]): string[] => {
 };
 
 export const getTagsFilterUrl = (tags: string[]): string => {
-  const url = new URL(window.location.pathname, window.location.origin);
+  const url = new URL(getCurrentUrl());
+
+  url.search = "";
+  url.hash = "";
 
   tags.forEach((tag) => {
     url.searchParams.append("tags", tag);
@@ -74,8 +77,7 @@ export const migrateFilterParam = () => {
 
   currentUrl.searchParams.delete("filter");
 
-  window.history.replaceState(null, "", currentUrl.toString());
-  window.dispatchEvent(new Event("replaceState"));
+  goTo(currentUrl, { replace: true });
 };
 
 export const constructFilterParams = (filters: Filters) => {

--- a/packages/web-commons/src/stores/router/index.ts
+++ b/packages/web-commons/src/stores/router/index.ts
@@ -1,7 +1,7 @@
 import { computed } from "@preact/signals-core";
 
 import { paramsToSearchParams } from "../url/helpers.js";
-import { currentUrl, goTo } from "../url/index.js";
+import { currentUrl, getCurrentUrl, goTo } from "../url/index.js";
 
 export const router = computed(() => {
   const hash = currentUrl.value.hash.startsWith("#") ? currentUrl.value.hash.slice(1) : currentUrl.value.hash;
@@ -49,10 +49,10 @@ const createRouteUrl = (path: string, params: Record<string, string | undefined>
 
 export const navigateTo = (to: NavigateTo) => {
   const { path, params = {}, replace = false, searchParams = {}, keepSearchParams = false } = to;
-  const currentPathname = currentUrl.value.pathname;
 
-  const newUrl = new URL(currentPathname, currentUrl.value.origin);
+  const newUrl = new URL(getCurrentUrl());
   const routeUrl = createRouteUrl(path, params);
+  newUrl.search = "";
   newUrl.hash = routeUrl === "" || routeUrl === "/" ? "" : `#${routeUrl}`;
 
   if (keepSearchParams) {

--- a/packages/web-commons/src/stores/url/helpers.ts
+++ b/packages/web-commons/src/stores/url/helpers.ts
@@ -39,12 +39,50 @@ const getUrl = (to: NavigateTo) => {
   return new URL(to.path, getCurrentUrl());
 };
 
+export const isSameDocumentUrl = (url: URL, currentHref: string = getCurrentUrl()) => {
+  try {
+    const currentUrl = new URL(currentHref);
+
+    return url.protocol === currentUrl.protocol && url.host === currentUrl.host && url.pathname === currentUrl.pathname;
+  } catch {
+    return false;
+  }
+};
+
+export const toSameDocumentHistoryUrl = (url: URL) => {
+  if (url.search) {
+    return `${url.search}${url.hash}`;
+  }
+
+  if (url.hash) {
+    return url.hash;
+  }
+
+  return url.pathname.split("/").pop() || ".";
+};
+
+export const getHistoryUrl = (to: NavigateTo, currentHref: string = getCurrentUrl()) => {
+  const url = getUrl(to);
+
+  if (url instanceof URL) {
+    return isSameDocumentUrl(url, currentHref) ? toSameDocumentHistoryUrl(url) : url;
+  }
+
+  try {
+    const absoluteUrl = new URL(url, currentHref);
+
+    return isSameDocumentUrl(absoluteUrl, currentHref) ? toSameDocumentHistoryUrl(absoluteUrl) : url;
+  } catch {
+    return url;
+  }
+};
+
 export const goTo = (to: NavigateTo, options?: NavigateToOptions) => {
   if (typeof window === "undefined") {
     return;
   }
 
-  const url = getUrl(to);
+  const url = getHistoryUrl(to);
 
   if (options?.replace) {
     window.history.replaceState(null, "", url);

--- a/packages/web-commons/test/stores/url/helpers.test.ts
+++ b/packages/web-commons/test/stores/url/helpers.test.ts
@@ -1,0 +1,63 @@
+import { label } from "allure-js-commons";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getHistoryUrl, isSameDocumentUrl, toSameDocumentHistoryUrl } from "../../../src/stores/url/helpers.js";
+
+describe("stores > url > helpers", () => {
+  beforeEach(async () => {
+    await label("layer", "unit");
+    await label("component", "web-commons");
+  });
+
+  describe("isSameDocumentUrl", () => {
+    it("matches same Windows network-share file document URLs", () => {
+      const currentHref = "file://filer/share/report.html?filter=retry#old";
+      const nextUrl = new URL("file://filer/share/report.html?retry=true#testresult/1");
+
+      expect(isSameDocumentUrl(nextUrl, currentHref)).toBe(true);
+    });
+
+    it("rejects different Windows network-share file document URLs", () => {
+      const currentHref = "file://filer/share/report.html";
+      const nextUrl = new URL("file://filer/other/report.html#testresult/1");
+
+      expect(isSameDocumentUrl(nextUrl, currentHref)).toBe(false);
+    });
+  });
+
+  describe("toSameDocumentHistoryUrl", () => {
+    it("formats same-document query and hash as a relative history URL", () => {
+      const url = new URL("file://filer/share/report.html?retry=true#testresult/1");
+
+      expect(toSameDocumentHistoryUrl(url)).toBe("?retry=true#testresult/1");
+    });
+
+    it("formats same-document hash-only routes as relative history URLs", () => {
+      const url = new URL("file://filer/share/report.html#testresult/1");
+
+      expect(toSameDocumentHistoryUrl(url)).toBe("#testresult/1");
+    });
+
+    it("formats same-document root routes as a relative file URL", () => {
+      const url = new URL("file://filer/share/report.html");
+
+      expect(toSameDocumentHistoryUrl(url)).toBe("report.html");
+    });
+  });
+
+  describe("getHistoryUrl", () => {
+    it("uses a relative history URL for same-document Windows network-share file URLs", () => {
+      const currentHref = "file://filer/share/report.html";
+      const nextUrl = new URL("file://filer/share/report.html#testresult/1");
+
+      expect(getHistoryUrl(nextUrl, currentHref)).toBe("#testresult/1");
+    });
+
+    it("uses a relative history URL for same-document Windows network-share file URLs with query params", () => {
+      const currentHref = "file://filer/share/report.html?filter=retry";
+      const nextUrl = new URL("file://filer/share/report.html?retry=true#testresult/1");
+
+      expect(getHistoryUrl(nextUrl, currentHref)).toBe("?retry=true#testresult/1");
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/allure-framework/allure3/issues/607

Fixed this by keeping navigation relative whenever we're staying on the same document. Instead of passing the full file://filer/share/report.html#testresult/1 to pushState, we now pass just #testresult/1 (or ?filter=retry#testresult/1 when search params are involved). This works everywhere — network shares, mapped drives, and regular HTTP servers — because the browser resolves the relative URL against the current document automatically.