### PR TITLE
chore: add build rule for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Use [Allure Agent Mode](docs/allure-agent-mode.md) for all test-related work in 
 - Read `docs/allure-agent-mode.md` before designing, writing, reviewing, validating, debugging, or enriching tests.
 - If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.
 - Use `allure agent` for smoke checks too, even when the change is small or mechanical.
+- After changing a package in this repository, treat package builds as part of validation and run the changed package build command before finalizing (for example, `yarn workspace <package-name> build`), because type-level regressions can break builds.
+- When multiple packages are affected, build them in dependency-graph order so upstream package changes are validated before dependent packages.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 - If agent-mode output is missing or incomplete, debug that first rather than silently falling back to console-only review.
 - Use Allure agent-mode when adding tests for features or fixes so expectations, evidence quality, and scope review are part of the loop.

--- a/docs/allure-agent-mode.md
+++ b/docs/allure-agent-mode.md
@@ -25,6 +25,7 @@ Runtime first, source second.
 - Use `allure agent` for smoke checks too, even when the change is small or mechanical.
 - Only skip agent mode when it is impossible or when you are debugging agent mode itself.
 - After each agent-mode test run, print the `index.md` path from that run's output directory so users can open the run overview quickly.
+- After changing a package in this repository, run that package build command before finalizing (for example, `yarn workspace <package-name> build`).
 
 ## Repository Status
 

--- a/packages/plugin-agent/src/guidance.ts
+++ b/packages/plugin-agent/src/guidance.ts
@@ -150,6 +150,7 @@ export const AGENT_VERIFICATION_RULES = [
   "If a command executes tests and its result will be used for smoke checking, reasoning, review, coverage analysis, debugging, or any user-facing conclusion, run it through `allure agent`. It preserves the original console logs and adds agent-mode artifacts without inheriting the normal report or export plugins from the project config.",
   "Use `allure agent` for smoke checks too, even when the change is small or mechanical.",
   "Only skip agent mode when it is impossible or when you are debugging agent mode itself.",
+  "After changing a package in this repository, run that package build command before finalizing (for example, `yarn workspace <package-name> build`).",
   "After each agent-mode test run, print the `index.md` path from that run's output directory so users can open the run overview quickly.",
 ] as const;
 


### PR DESCRIPTION
Agent instructions were updated to make package builds a required part of change validation.
This helps catch issues early and prevents invalid changes from reaching the shared codebase.