### PR TITLE
Added multiple paths/patterns support to `generate`, `open`, and other commands that work with Allure results

### DIFF
--- a/packages/cli/src/commands/allure2.ts
+++ b/packages/cli/src/commands/allure2.ts
@@ -72,9 +72,9 @@ export class Allure2Command extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/allure2.ts
+++ b/packages/cli/src/commands/allure2.ts
@@ -7,7 +7,7 @@ import Allure2Plugin, { type Allure2PluginOptions } from "@allurereport/plugin-a
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class Allure2Command extends Command {
   static paths = [["allure2"]];
@@ -72,7 +72,7 @@ export class Allure2Command extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/allure2.ts
+++ b/packages/cli/src/commands/allure2.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import process, { exit } from "node:process";
 
@@ -7,6 +6,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import Allure2Plugin, { type Allure2PluginOptions } from "@allurereport/plugin-allure2";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class Allure2Command extends Command {
   static paths = [["allure2"]];
@@ -21,10 +22,20 @@ export class Allure2Command extends Command {
         "allure2 ./allure-results --output custom-report",
         "Generate a report from the ./allure-results directory to the custom-report directory",
       ],
+      [
+        "allure2 ./packages/*/allure-results",
+        "Generate a report from all Allure result directories matching the pattern",
+      ],
+      [
+        "allure2 ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a report from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -59,13 +70,15 @@ export class Allure2Command extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const defaultAllure2Options = {
       singleFile: this.singleFile ?? false,
@@ -90,7 +103,11 @@ export class Allure2Command extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/awesome.ts
+++ b/packages/cli/src/commands/awesome.ts
@@ -7,7 +7,7 @@ import { default as AwesomePlugin, type AwesomePluginOptions } from "@allurerepo
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class AwesomeCommand extends Command {
   static paths = [["awesome"]];
@@ -88,7 +88,7 @@ export class AwesomeCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/awesome.ts
+++ b/packages/cli/src/commands/awesome.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import process, { exit } from "node:process";
 
@@ -7,6 +6,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import { default as AwesomePlugin, type AwesomePluginOptions } from "@allurereport/plugin-awesome";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class AwesomeCommand extends Command {
   static paths = [["awesome"]];
@@ -21,10 +22,20 @@ export class AwesomeCommand extends Command {
         "awesome ./allure-results --output custom-report",
         "Generate a report from the ./allure-results directory to the custom-report directory",
       ],
+      [
+        "awesome ./packages/*/allure-results",
+        "Generate a report from all Allure result directories matching the pattern",
+      ],
+      [
+        "awesome ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a report from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -75,13 +86,15 @@ export class AwesomeCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const hideLabels = this.hideLabels?.length ? this.hideLabels : undefined;
     const config = await readConfig(cwd, this.config, {
@@ -111,7 +124,11 @@ export class AwesomeCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/awesome.ts
+++ b/packages/cli/src/commands/awesome.ts
@@ -88,9 +88,9 @@ export class AwesomeCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/classic.ts
+++ b/packages/cli/src/commands/classic.ts
@@ -7,7 +7,7 @@ import ClassicPlugin, { type ClassicPluginOptions } from "@allurereport/plugin-c
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class ClassicCommand extends Command {
   static paths = [["classic"]];
@@ -72,7 +72,7 @@ export class ClassicCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/classic.ts
+++ b/packages/cli/src/commands/classic.ts
@@ -72,9 +72,9 @@ export class ClassicCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/classic.ts
+++ b/packages/cli/src/commands/classic.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import process, { exit } from "node:process";
 
@@ -7,6 +6,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import ClassicPlugin, { type ClassicPluginOptions } from "@allurereport/plugin-classic";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class ClassicCommand extends Command {
   static paths = [["classic"]];
@@ -21,10 +22,20 @@ export class ClassicCommand extends Command {
         "classic ./allure-results --output custom-report",
         "Generate a report from the ./allure-results directory to the custom-report directory",
       ],
+      [
+        "classic ./packages/*/allure-results",
+        "Generate a report from all Allure result directories matching the pattern",
+      ],
+      [
+        "classic ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a report from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -59,13 +70,15 @@ export class ClassicCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const defaultClassicOptions = {
       singleFile: this.singleFile ?? false,
@@ -90,7 +103,11 @@ export class ClassicCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/commons/generate.ts
+++ b/packages/cli/src/commands/commons/generate.ts
@@ -13,14 +13,14 @@ export const generate = async (params: { cwd: string; config: FullConfig; result
 
   // don't read allure results directories without the parameter when dump file has been found
   // or read allure results directory when it is explicitly provided
-  const resultsDirectories: string[] =
+  const { resultDirectories = [], patterns = params.resultsDir } =
     !!params?.resultsDir || dumpFiles.length === 0
       ? await searchAllureResultDirectories(params.cwd, params.resultsDir)
-      : [];
+      : {};
 
-  if (resultsDirectories.length === 0 && dumpFiles.length === 0) {
+  if (resultDirectories.length === 0 && dumpFiles.length === 0) {
     // eslint-disable-next-line no-console
-    console.error(red(`No test results directories found matching pattern: ${params.resultsDir}`));
+    console.error(red(`No test results directories found matching pattern: ${patterns}`));
     exit(1);
     return;
   }
@@ -31,7 +31,7 @@ export const generate = async (params: { cwd: string; config: FullConfig; result
     await allureReport.restoreState(Array.from(dumpFiles));
     await allureReport.start();
 
-    for (const dir of resultsDirectories) {
+    for (const dir of resultDirectories) {
       await allureReport.readDirectory(dir);
     }
 

--- a/packages/cli/src/commands/commons/generate.ts
+++ b/packages/cli/src/commands/commons/generate.ts
@@ -5,17 +5,17 @@ import { AllureReport } from "@allurereport/core";
 import { KnownError } from "@allurereport/service";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories, searchFilesByGlobs } from "../../utils/fileSystem.js";
+import { findAllureResultDirectories, findFilesByGlobs } from "../../utils/fileSystem.js";
 import { logError } from "../../utils/logs.js";
 
 export const generate = async (params: { cwd: string; config: FullConfig; resultsDir: string[]; dump?: string[] }) => {
-  const dumpFiles: string[] = params?.dump?.length ? await searchFilesByGlobs(params.cwd, params.dump) : [];
+  const dumpFiles: string[] = params?.dump?.length ? await findFilesByGlobs(params.cwd, params.dump) : [];
 
   // don't read allure results directories without the parameter when dump file has been found
   // or read allure results directory when it is explicitly provided
   const { resultDirectories = [], patterns = params.resultsDir } =
     !!params?.resultsDir || dumpFiles.length === 0
-      ? await searchAllureResultDirectories(params.cwd, params.resultsDir)
+      ? await findAllureResultDirectories(params.cwd, params.resultsDir)
       : {};
 
   if (resultDirectories.length === 0 && dumpFiles.length === 0) {

--- a/packages/cli/src/commands/commons/generate.ts
+++ b/packages/cli/src/commands/commons/generate.ts
@@ -3,45 +3,20 @@ import { exit } from "node:process";
 import type { FullConfig } from "@allurereport/core";
 import { AllureReport } from "@allurereport/core";
 import { KnownError } from "@allurereport/service";
-import { glob } from "glob";
 import { red } from "yoctocolors";
 
+import { searchAllureResultDirectories, searchFilesByGlobs } from "../../utils/fileSystem.js";
 import { logError } from "../../utils/logs.js";
 
-export const generate = async (params: { cwd: string; config: FullConfig; resultsDir: string; dump?: string[] }) => {
-  const dumpFiles: string[] = [];
-  const resultsDirectories: string[] = [];
-
-  if (params?.dump?.length) {
-    for (const dump of params.dump) {
-      const matchedFiles = await glob(dump, {
-        nodir: true,
-        dot: true,
-        absolute: true,
-        windowsPathsNoEscape: true,
-        cwd: params.cwd,
-      });
-
-      dumpFiles.push(...matchedFiles);
-    }
-  }
+export const generate = async (params: { cwd: string; config: FullConfig; resultsDir: string[]; dump?: string[] }) => {
+  const dumpFiles: string[] = params?.dump?.length ? await searchFilesByGlobs(params.cwd, params.dump) : [];
 
   // don't read allure results directories without the parameter when dump file has been found
   // or read allure results directory when it is explicitly provided
-  if (!!params?.resultsDir || dumpFiles.length === 0) {
-    const matchedDirs = (
-      await glob(params.resultsDir, {
-        mark: true,
-        nodir: false,
-        absolute: true,
-        dot: true,
-        windowsPathsNoEscape: true,
-        cwd: params.cwd,
-      })
-    ).filter((p) => /(\/|\\)$/.test(p));
-
-    resultsDirectories.push(...matchedDirs);
-  }
+  const resultsDirectories: string[] =
+    !!params?.resultsDir || dumpFiles.length === 0
+      ? await searchAllureResultDirectories(params.cwd, params.resultsDir)
+      : [];
 
   if (resultsDirectories.length === 0 && dumpFiles.length === 0) {
     // eslint-disable-next-line no-console

--- a/packages/cli/src/commands/csv.ts
+++ b/packages/cli/src/commands/csv.ts
@@ -62,9 +62,9 @@ export class CsvCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/csv.ts
+++ b/packages/cli/src/commands/csv.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 import process, { exit } from "node:process";
@@ -8,6 +7,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import CsvPlugin, { type CsvPluginOptions } from "@allurereport/plugin-csv";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class CsvCommand extends Command {
   static paths = [["csv"]];
@@ -22,10 +23,17 @@ export class CsvCommand extends Command {
         "csv ./allure-results --output custom-report.csv",
         "Generate a report from the ./allure-results directory to the custom-report.csv file",
       ],
+      ["csv ./packages/*/allure-results", "Generate a report from all Allure result directories matching the pattern"],
+      [
+        "csv ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a report from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -52,13 +60,15 @@ export class CsvCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const defaultCsvOptions = {
       separator: this.separator ?? ",",
@@ -82,7 +92,11 @@ export class CsvCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/csv.ts
+++ b/packages/cli/src/commands/csv.ts
@@ -8,7 +8,7 @@ import CsvPlugin, { type CsvPluginOptions } from "@allurereport/plugin-csv";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class CsvCommand extends Command {
   static paths = [["csv"]];
@@ -62,7 +62,7 @@ export class CsvCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import process, { exit } from "node:process";
 
@@ -7,6 +6,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import DashboardPlugin, { type DashboardPluginOptions } from "@allurereport/plugin-dashboard";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class DashboardCommand extends Command {
   static paths = [["dashboard"]];
@@ -21,10 +22,20 @@ export class DashboardCommand extends Command {
         "dashboard ./allure-results --output custom-report",
         "Generate a report from the ./allure-results directory to the custom-report directory",
       ],
+      [
+        "dashboard ./packages/*/allure-results",
+        "Generate a report from all Allure result directories matching the pattern",
+      ],
+      [
+        "dashboard ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a report from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -59,13 +70,15 @@ export class DashboardCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const defaultDashboardOptions = {
       singleFile: this.singleFile ?? false,
@@ -90,7 +103,11 @@ export class DashboardCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -7,7 +7,7 @@ import DashboardPlugin, { type DashboardPluginOptions } from "@allurereport/plug
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class DashboardCommand extends Command {
   static paths = [["dashboard"]];
@@ -72,7 +72,7 @@ export class DashboardCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -72,9 +72,9 @@ export class DashboardCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -10,8 +10,8 @@ export class GenerateCommand extends Command {
   static paths = [["generate"]];
 
   static usage = Command.Usage({
-    description: "Generates the report to specified directory",
-    details: "This command generates a report from the provided Allure Results directory.",
+    description: "Generates the report in the specified directory.",
+    details: "This command generates a report from the provided Allure Results directories.",
     examples: [
       ["generate ./allure-results", "Generate a report from the ./allure-results directory"],
       [
@@ -26,12 +26,15 @@ export class GenerateCommand extends Command {
         "generate --dump=allure-*.zip",
         "Generate a report using data from any dump archive that matches the given pattern and results directory if it exists",
       ],
+      [
+        "generate ./packages/foo/out/allure-results ./packages/bar/out/allure-results",
+        "Generate a report from two Allure results directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({
-    required: false,
-    name: "Pattern to match test results directories in the current working directory (default: ./**/allure-results)",
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
   });
 
   config = Option.String("--config,-c", {
@@ -51,7 +54,10 @@ export class GenerateCommand extends Command {
   });
 
   dump = Option.Array("--dump", {
-    description: "Dump archives to restore state from (default: empty string)",
+    description:
+      "Path or pattern that matches one or more archives created by `allure run --dump ...`. " +
+      "Allure loads the matched archives before generating the report. " +
+      "This option can be specified multiple times.",
   });
 
   open = Option.Boolean("--open", {
@@ -84,7 +90,7 @@ export class GenerateCommand extends Command {
 
     await generate({
       dump: this.dump,
-      resultsDir: this.resultsDir ?? "./**/allure-results",
+      resultsDir: this.resultsDir,
       cwd,
       config,
     });

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -1,10 +1,11 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
-import { exit } from "node:process";
+import process, { exit } from "node:process";
 
 import { AllureReport, resolveConfig } from "@allurereport/core";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class HistoryCommand extends Command {
   static paths = [["history"]];
@@ -18,10 +19,20 @@ export class HistoryCommand extends Command {
         "history ./allure-results --history-path custom-history.jsonl",
         "Generate history from the ./allure-results directory to the custom-history.jsonl file",
       ],
+      [
+        "history ./packages/*/allure-results",
+        "Generate history from all Allure result directories matching the pattern",
+      ],
+      [
+        "history ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate history from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   historyPath = Option.String("--history-path,-h", {
     description: "The path to history file",
@@ -36,9 +47,11 @@ export class HistoryCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const resultDirectories = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
+      return;
     }
 
     const config = await resolveConfig({
@@ -52,7 +65,11 @@ export class HistoryCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
   }
 }

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -47,9 +47,9 @@ export class HistoryCommand extends Command {
   });
 
   async execute() {
-    const resultDirectories = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -5,7 +5,7 @@ import { AllureReport, resolveConfig } from "@allurereport/core";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class HistoryCommand extends Command {
   static paths = [["history"]];
@@ -47,7 +47,7 @@ export class HistoryCommand extends Command {
   });
 
   async execute() {
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(process.cwd(), this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/knownIssue.ts
+++ b/packages/cli/src/commands/knownIssue.ts
@@ -6,7 +6,7 @@ import { AllureReport, resolveConfig, writeKnownIssues } from "@allurereport/cor
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class KnownIssueCommand extends Command {
   static paths = [["known-issue"]];
@@ -40,7 +40,7 @@ export class KnownIssueCommand extends Command {
   });
 
   async execute() {
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(process.cwd(), this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/knownIssue.ts
+++ b/packages/cli/src/commands/knownIssue.ts
@@ -40,9 +40,9 @@ export class KnownIssueCommand extends Command {
   });
 
   async execute() {
-    const resultDirectories = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/knownIssue.ts
+++ b/packages/cli/src/commands/knownIssue.ts
@@ -1,11 +1,12 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { exit } from "node:process";
+import process, { exit } from "node:process";
 
 import { AllureReport, resolveConfig, writeKnownIssues } from "@allurereport/core";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class KnownIssueCommand extends Command {
   static paths = [["known-issue"]];
@@ -19,18 +20,29 @@ export class KnownIssueCommand extends Command {
         "known-issue ./allure-results --output custom-issues.json",
         "Generate a known issue list from the ./allure-results directory to the custom-issues.json file",
       ],
+      [
+        "known-issue ./packages/*/allure-results",
+        "Generate a known issue list from all Allure result directories matching the pattern",
+      ],
+      [
+        "known-issue ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a known issue list from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   output = Option.String("--output,-o", {
     description: "The output file name. Absolute paths are accepted as well",
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const resultDirectories = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
@@ -42,7 +54,11 @@ export class KnownIssueCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const targetPath = resolve(outputPath);

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import process, { exit } from "node:process";
 
@@ -7,6 +6,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import LogPlugin, { type LogPluginOptions } from "@allurereport/plugin-log";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class LogCommand extends Command {
   static paths = [["log"]];
@@ -21,10 +22,17 @@ export class LogCommand extends Command {
         "log ./allure-results --all-steps --with-trace",
         "Print results with all steps and stack traces from the ./allure-results directory",
       ],
+      ["log ./packages/*/allure-results", "Print results from all Allure result directories matching the pattern"],
+      [
+        "log ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Print results from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -47,13 +55,15 @@ export class LogCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const defaultLogOptions = {
       allSteps: this.allSteps ?? false,
@@ -74,7 +84,11 @@ export class LogCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -57,9 +57,9 @@ export class LogCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -7,7 +7,7 @@ import LogPlugin, { type LogPluginOptions } from "@allurereport/plugin-log";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class LogCommand extends Command {
   static paths = [["log"]];
@@ -57,7 +57,7 @@ export class LogCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -8,7 +8,7 @@ import { readConfig } from "@allurereport/core";
 import { serve } from "@allurereport/static-server";
 import { Command, Option } from "clipanion";
 
-import { searchFilesByGlobs } from "./../utils/fileSystem.js";
+import { findFilesByGlobs } from "./../utils/fileSystem.js";
 import { generate } from "./commons/generate.js";
 
 export class OpenCommand extends Command {
@@ -103,7 +103,7 @@ export class OpenCommand extends Command {
       const [maybeRelativeReportPath = fallback] = inputs;
       const maybeAbsoluteReportPath = join(cwd, maybeRelativeReportPath);
       if (existsSync(maybeAbsoluteReportPath)) {
-        const summaryFiles = await searchFilesByGlobs(cwd, [join(maybeAbsoluteReportPath, "**", "summary.json")]);
+        const summaryFiles = await findFilesByGlobs(cwd, [join(maybeAbsoluteReportPath, "**", "summary.json")]);
         if (summaryFiles.length > 0) {
           return maybeAbsoluteReportPath;
         }

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -2,11 +2,12 @@ import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cwd as processCwd } from "node:process";
+import { cwd as processCwd, exit } from "node:process";
 
 import { readConfig } from "@allurereport/core";
 import { serve } from "@allurereport/static-server";
 import { Command, Option } from "clipanion";
+import { red } from "yoctocolors";
 
 import { findFilesByGlobs } from "./../utils/fileSystem.js";
 import { generate } from "./commons/generate.js";
@@ -58,15 +59,15 @@ export class OpenCommand extends Command {
     const config = await readConfig(cwd, this.config, {
       port: this.port,
     });
-    const servePath = await this.resolveReportPath(cwd, this.resultsDir, config.output);
+    const servePath = this.resolveReportPath(cwd, this.resultsDir, config.output);
 
-    if (servePath) {
+    if (await this.reportExists(servePath)) {
       await serve({
         port: config.port ? parseInt(config.port, 10) : undefined,
         servePath,
         open: true,
       });
-    } else {
+    } else if (this.resultsDir.length) {
       const tmpDir = await mkdtemp(join(tmpdir(), "allure-report-"));
       const config = await readConfig(cwd, this.config, {
         port: this.port,
@@ -95,19 +96,25 @@ export class OpenCommand extends Command {
         servePath: config.output,
         open: true,
       });
+    } else {
+      console.error(red(`A report doesn't exist in ${servePath} and no input was provided to generate.`));
+      exit(1);
+      return;
     }
   }
 
-  private async resolveReportPath(cwd: string, inputs: readonly string[], fallback: string = "allure-report") {
+  private resolveReportPath(cwd: string, inputs: readonly string[], fallback: string = "allure-report") {
     if (inputs.length <= 1) {
       const [maybeRelativeReportPath = fallback] = inputs;
-      const maybeAbsoluteReportPath = join(cwd, maybeRelativeReportPath);
-      if (existsSync(maybeAbsoluteReportPath)) {
-        const summaryFiles = await findFilesByGlobs(cwd, [join(maybeAbsoluteReportPath, "**", "summary.json")]);
-        if (summaryFiles.length > 0) {
-          return maybeAbsoluteReportPath;
-        }
-      }
+      return join(cwd, maybeRelativeReportPath);
     }
+  }
+
+  private async reportExists(reportPath: string | undefined) {
+    if (reportPath && existsSync(reportPath)) {
+      const summaryFiles = await findFilesByGlobs(reportPath, [join("**", "summary.json")]);
+      return summaryFiles.length > 0;
+    }
+    return false;
   }
 }

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -7,8 +7,8 @@ import { cwd as processCwd } from "node:process";
 import { readConfig } from "@allurereport/core";
 import { serve } from "@allurereport/static-server";
 import { Command, Option } from "clipanion";
-import { glob } from "glob";
 
+import { searchFilesByGlobs } from "./../utils/fileSystem.js";
 import { generate } from "./commons/generate.js";
 
 export class OpenCommand extends Command {
@@ -20,12 +20,19 @@ export class OpenCommand extends Command {
     examples: [
       ["open ./allure-results", "Generate and serve the report based on given test results directory"],
       ["open --port 8080 ./allure-report", "Serve the report on port 8080"],
+      [
+        "open ./packages/*/allure-results",
+        "Generate and serve the report from all Allure result directories matching the pattern",
+      ],
+      [
+        "open ./packages/foo/allure-results /packages/bar/allure-results",
+        "Generate and serve the report from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({
+  resultsDir = Option.Rest({
     name: "A report to open or a pattern to match test results directories in the current working directory (default: configured output)",
-    required: false,
   });
 
   config = Option.String("--config,-c", {
@@ -47,25 +54,16 @@ export class OpenCommand extends Command {
   async execute() {
     const cwd = this.cwd ?? processCwd();
     const hideLabels = this.hideLabels?.length ? this.hideLabels : undefined;
+
     const config = await readConfig(cwd, this.config, {
       port: this.port,
     });
-    const targetFullPath = this.resultsDir ? join(cwd, this.resultsDir) : config.output;
-    const summaryFiles = existsSync(targetFullPath)
-      ? await glob(join(targetFullPath, "**", "summary.json"), {
-          mark: true,
-          nodir: false,
-          absolute: true,
-          dot: true,
-          windowsPathsNoEscape: true,
-          cwd,
-        })
-      : [];
+    const servePath = await this.resolveReportPath(cwd, this.resultsDir, config.output);
 
-    if (summaryFiles.length > 0) {
+    if (servePath) {
       await serve({
         port: config.port ? parseInt(config.port, 10) : undefined,
-        servePath: targetFullPath,
+        servePath,
         open: true,
       });
     } else {
@@ -76,8 +74,9 @@ export class OpenCommand extends Command {
         hideLabels,
       });
 
+      // At this point, resultsDir contains at least one pattern
       await generate({
-        resultsDir: targetFullPath,
+        resultsDir: this.resultsDir,
         cwd,
         config,
       });
@@ -96,6 +95,19 @@ export class OpenCommand extends Command {
         servePath: config.output,
         open: true,
       });
+    }
+  }
+
+  private async resolveReportPath(cwd: string, inputs: readonly string[], fallback: string = "allure-report") {
+    if (inputs.length <= 1) {
+      const [maybeRelativeReportPath = fallback] = inputs;
+      const maybeAbsoluteReportPath = join(cwd, maybeRelativeReportPath);
+      if (existsSync(maybeAbsoluteReportPath)) {
+        const summaryFiles = await searchFilesByGlobs(cwd, [join(maybeAbsoluteReportPath, "**", "summary.json")]);
+        if (summaryFiles.length > 0) {
+          return maybeAbsoluteReportPath;
+        }
+      }
     }
   }
 }

--- a/packages/cli/src/commands/qualityGate.ts
+++ b/packages/cli/src/commands/qualityGate.ts
@@ -5,7 +5,6 @@ import { exit, cwd as processCwd } from "node:process";
 import { AllureReport, QualityGateState, readConfig, stringifyQualityGateResults } from "@allurereport/core";
 import { type TestResult } from "@allurereport/core-api";
 import { Command, Option } from "clipanion";
-import { glob } from "glob";
 import * as typanion from "typanion";
 import { red } from "yoctocolors";
 
@@ -15,6 +14,7 @@ import {
   normalizeCommandEnvironmentOptions,
   resolveCommandEnvironment,
 } from "../utils/environment.js";
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class QualityGateCommand extends Command {
   static paths = [["quality-gate"]];
@@ -28,12 +28,19 @@ export class QualityGateCommand extends Command {
         "quality-gate ./allure-results --config custom-config.js",
         "Validate the test results using a custom configuration file",
       ],
+      [
+        "quality-gate ./packages/*/allure-results",
+        "Validate the test results in all Allure result directories matching the pattern",
+      ],
+      [
+        "quality-gate ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Validate the test results in two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({
-    required: false,
-    name: "Pattern to match test results directories in the current working directory (default: ./**/allure-results)",
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
   });
 
   config = Option.String("--config,-c", {
@@ -80,7 +87,6 @@ export class QualityGateCommand extends Command {
     normalizeCommandEnvironmentOptions(environmentOptions);
 
     const cwd = await realpath(this.cwd ?? processCwd());
-    const resultsDir = (this.resultsDir ?? "./**/allure-results").replace(/[\\/]$/, "");
     const { maxFailures, minTestsCount, successRate, fastFail, knownIssues: knownIssuesPath } = this;
     const config = await readConfig(cwd, this.config, {
       knownIssuesPath,
@@ -130,20 +136,9 @@ export class QualityGateCommand extends Command {
       return;
     }
 
-    const resultsDirectories = (
-      await glob(resultsDir, {
-        mark: true,
-        nodir: false,
-        absolute: true,
-        dot: true,
-        windowsPathsNoEscape: true,
-        cwd,
-      })
-    ).filter((p) => /(\/|\\)$/.test(p));
-
-    if (resultsDirectories.length === 0) {
-      // eslint-disable-next-line no-console
-      console.error(red(`No test results directories found matching pattern: ${resultsDir}`));
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
@@ -173,8 +168,8 @@ export class QualityGateCommand extends Command {
 
     await allureReport.start();
 
-    for (const dir of resultsDirectories) {
-      await allureReport.readDirectory(dir);
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
     }
 
     await allureReport.done();

--- a/packages/cli/src/commands/qualityGate.ts
+++ b/packages/cli/src/commands/qualityGate.ts
@@ -14,7 +14,7 @@ import {
   normalizeCommandEnvironmentOptions,
   resolveCommandEnvironment,
 } from "../utils/environment.js";
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class QualityGateCommand extends Command {
   static paths = [["quality-gate"]];
@@ -136,7 +136,7 @@ export class QualityGateCommand extends Command {
       return;
     }
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/qualityGate.ts
+++ b/packages/cli/src/commands/qualityGate.ts
@@ -136,9 +136,9 @@ export class QualityGateCommand extends Command {
       return;
     }
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/slack.ts
+++ b/packages/cli/src/commands/slack.ts
@@ -57,9 +57,9 @@ export class SlackCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/slack.ts
+++ b/packages/cli/src/commands/slack.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import process, { exit } from "node:process";
 
@@ -7,6 +6,8 @@ import { AllureReport, readConfig } from "@allurereport/core";
 import SlackPlugin, { type SlackPluginOptions } from "@allurereport/plugin-slack";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class SlackCommand extends Command {
   static paths = [["slack"]];
@@ -20,10 +21,20 @@ export class SlackCommand extends Command {
         "slack ./allure-results --token xoxb-token --channel C12345",
         "Post test results from the ./allure-results directory to the specified Slack channel",
       ],
+      [
+        "slack ./packages/*/allure-results --token xoxb-token --channel C12345",
+        "Post test results from all Allure result directories matching the pattern",
+      ],
+      [
+        "slack ./packages/foo/allure-results ./packages/bar/allure-results --token xoxb-token --channel C12345",
+        "Post test results from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -44,13 +55,15 @@ export class SlackCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
 
-    const cwd = await realpath(this.cwd ?? process.cwd());
     const before = new Date().getTime();
     const defaultSlackOptions = {
       token: this.token,
@@ -70,7 +83,11 @@ export class SlackCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/slack.ts
+++ b/packages/cli/src/commands/slack.ts
@@ -7,7 +7,7 @@ import SlackPlugin, { type SlackPluginOptions } from "@allurereport/plugin-slack
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class SlackCommand extends Command {
   static paths = [["slack"]];
@@ -57,7 +57,7 @@ export class SlackCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/testplan.ts
+++ b/packages/cli/src/commands/testplan.ts
@@ -40,9 +40,9 @@ export class TestPlanCommand extends Command {
   });
 
   async execute() {
-    const resultDirectories = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/testplan.ts
+++ b/packages/cli/src/commands/testplan.ts
@@ -6,7 +6,7 @@ import { AllureReport, resolveConfig } from "@allurereport/core";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class TestPlanCommand extends Command {
   static paths = [["testplan"]];
@@ -40,7 +40,7 @@ export class TestPlanCommand extends Command {
   });
 
   async execute() {
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(process.cwd(), this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/testplan.ts
+++ b/packages/cli/src/commands/testplan.ts
@@ -1,11 +1,12 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 import { exit } from "node:process";
 
 import { AllureReport, resolveConfig } from "@allurereport/core";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class TestPlanCommand extends Command {
   static paths = [["testplan"]];
@@ -19,18 +20,29 @@ export class TestPlanCommand extends Command {
         "testplan ./allure-results --output custom-testplan.json",
         "Generate a custom-testplan.json file from the ./allure-results directory",
       ],
+      [
+        "testplan ./packages/*/allure-results",
+        "Generate a testplan.json file from all Allure result directories matching the pattern",
+      ],
+      [
+        "testplan ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Generate a testplan.json file from two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   output = Option.String("--output,-o", {
     description: "The output file name. Absolute paths are accepted as well",
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const resultDirectories = await searchAllureResultDirectories(process.cwd(), this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
@@ -51,7 +63,11 @@ export class TestPlanCommand extends Command {
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
-    await allureReport.readDirectory(this.resultsDir);
+
+    for (const directory of resultDirectories) {
+      await allureReport.readDirectory(directory);
+    }
+
     await allureReport.done();
 
     const after = new Date().getTime();

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -67,9 +67,9 @@ export class WatchCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
-      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
+      console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);
       return;
     }

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -14,7 +14,7 @@ import { serve } from "@allurereport/static-server";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
 
-import { searchAllureResultDirectories } from "../utils/fileSystem.js";
+import { findAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class WatchCommand extends Command {
   static paths = [["watch"]];
@@ -67,7 +67,7 @@ export class WatchCommand extends Command {
   async execute() {
     const cwd = await realpath(this.cwd ?? process.cwd());
 
-    const { resultDirectories, patterns } = await searchAllureResultDirectories(cwd, this.resultsDir);
+    const { resultDirectories, patterns } = await findAllureResultDirectories(cwd, this.resultsDir);
     if (!resultDirectories.length) {
       console.error(red(`No test results directories found matching pattern: ${patterns}`));
       exit(1);

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,7 +1,7 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
+import { realpath } from "node:fs/promises";
 import { rm } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import process, { exit } from "node:process";
 
 import { AllureReport, isFileNotFoundError, readConfig } from "@allurereport/core";
@@ -13,6 +13,8 @@ import { PathResultFile } from "@allurereport/reader-api";
 import { serve } from "@allurereport/static-server";
 import { Command, Option } from "clipanion";
 import { red } from "yoctocolors";
+
+import { searchAllureResultDirectories } from "../utils/fileSystem.js";
 
 export class WatchCommand extends Command {
   static paths = [["watch"]];
@@ -26,10 +28,17 @@ export class WatchCommand extends Command {
         "watch ./allure-results --port 8080",
         "Watch for changes in the ./allure-results directory and serve the report on port 8080",
       ],
+      ["watch ./packages/*/allure-results", "Watch for changes in all Allure result directories matching the pattern"],
+      [
+        "watch ./packages/foo/allure-results ./packages/bar/allure-results",
+        "Watch for changes in two Allure result directories",
+      ],
     ],
   });
 
-  resultsDir = Option.String({ required: true, name: "The directory with Allure results" });
+  resultsDir = Option.Rest({
+    name: "Patterns to match test results directories in the current working directory (default: ./**/allure-results)",
+  });
 
   config = Option.String("--config,-c", {
     description: "The path Allure config file",
@@ -56,8 +65,11 @@ export class WatchCommand extends Command {
   });
 
   async execute() {
-    if (!existsSync(this.resultsDir)) {
-      console.error(red(`The given test results directory doesn't exist: ${this.resultsDir}`));
+    const cwd = await realpath(this.cwd ?? process.cwd());
+
+    const resultDirectories = await searchAllureResultDirectories(cwd, this.resultsDir);
+    if (!resultDirectories.length) {
+      console.error(red(`No test results directories found matching pattern: ${this.resultsDir}`));
       exit(1);
       return;
     }
@@ -70,7 +82,7 @@ export class WatchCommand extends Command {
       console.log(`exit code ${code} (${after - before}ms)`);
     });
 
-    const config = await readConfig(this.cwd, this.config, {
+    const config = await readConfig(cwd, this.config, {
       output: this.output,
       name: this.reportName,
       open: this.open,
@@ -129,10 +141,14 @@ export class WatchCommand extends Command {
 
     await allureReport.start();
 
-    const input = resolve(this.resultsDir);
-    const { abort } = newFilesInDirectoryWatcher(input, async (path) => {
-      await allureReport.readResult(new PathResultFile(path));
-    });
+    const abortFunctions: (() => Promise<void>)[] = [];
+    for (const directory of resultDirectories) {
+      const { abort } = newFilesInDirectoryWatcher(directory, async (path) => {
+        await allureReport.readResult(new PathResultFile(path));
+      });
+      abortFunctions.push(abort);
+    }
+
     const pluginIdToOpen = config.plugins?.find((plugin) => !!plugin.options.open)?.id;
 
     if (pluginIdToOpen) {
@@ -144,7 +160,11 @@ export class WatchCommand extends Command {
     process.on("SIGINT", async () => {
       // new line for ctrl+C character
       console.log("");
-      await abort();
+
+      for (const abort of abortFunctions) {
+        await abort();
+      }
+
       await server.stop();
       await allureReport.done();
       process.exit(0);

--- a/packages/cli/src/utils/fileSystem.ts
+++ b/packages/cli/src/utils/fileSystem.ts
@@ -39,5 +39,7 @@ export const searchDirectoriesByGlobs = async (basePath: string, patterns: reado
 };
 
 export const searchAllureResultDirectories = async (basePath: string, patterns: readonly string[]) => {
-  return await searchDirectoriesByGlobs(basePath, patterns.length ? patterns : ["./**/allure-results"]);
+  const resolvedPatterns = patterns.length ? patterns : ["./**/allure-results"];
+  const resultDirectories = await searchDirectoriesByGlobs(basePath, resolvedPatterns);
+  return { patterns: resolvedPatterns, resultDirectories };
 };

--- a/packages/cli/src/utils/fileSystem.ts
+++ b/packages/cli/src/utils/fileSystem.ts
@@ -1,0 +1,43 @@
+import { glob } from "glob";
+
+export const searchFilesByGlobs = async (basePath: string, patterns: readonly string[]) => {
+  const files: string[] = [];
+
+  for (const pattern of patterns) {
+    const searchResults = await glob(pattern, {
+      nodir: true,
+      dot: true,
+      absolute: true,
+      windowsPathsNoEscape: true,
+      cwd: basePath,
+    });
+
+    files.push(...searchResults);
+  }
+
+  return files;
+};
+
+export const searchDirectoriesByGlobs = async (basePath: string, patterns: readonly string[]) => {
+  const directories: string[] = [];
+
+  for (const pattern of patterns) {
+    const searchResults = await glob(pattern, {
+      mark: true,
+      nodir: false,
+      absolute: true,
+      dot: true,
+      windowsPathsNoEscape: true,
+      cwd: basePath,
+    });
+    const matchedDirs = searchResults.filter((p) => /(\/|\\)$/.test(p));
+
+    directories.push(...matchedDirs);
+  }
+
+  return directories;
+};
+
+export const searchAllureResultDirectories = async (basePath: string, patterns: readonly string[]) => {
+  return await searchDirectoriesByGlobs(basePath, patterns.length ? patterns : ["./**/allure-results"]);
+};

--- a/packages/cli/src/utils/fileSystem.ts
+++ b/packages/cli/src/utils/fileSystem.ts
@@ -1,6 +1,6 @@
 import { glob } from "glob";
 
-export const searchFilesByGlobs = async (basePath: string, patterns: readonly string[]) => {
+export const findFilesByGlobs = async (basePath: string, patterns: readonly string[]) => {
   const files: string[] = [];
 
   for (const pattern of patterns) {
@@ -18,7 +18,7 @@ export const searchFilesByGlobs = async (basePath: string, patterns: readonly st
   return files;
 };
 
-export const searchDirectoriesByGlobs = async (basePath: string, patterns: readonly string[]) => {
+export const findDirectoriesByGlobs = async (basePath: string, patterns: readonly string[]) => {
   const directories: string[] = [];
 
   for (const pattern of patterns) {
@@ -38,8 +38,8 @@ export const searchDirectoriesByGlobs = async (basePath: string, patterns: reado
   return directories;
 };
 
-export const searchAllureResultDirectories = async (basePath: string, patterns: readonly string[]) => {
+export const findAllureResultDirectories = async (basePath: string, patterns: readonly string[]) => {
   const resolvedPatterns = patterns.length ? patterns : ["./**/allure-results"];
-  const resultDirectories = await searchDirectoriesByGlobs(basePath, resolvedPatterns);
+  const resultDirectories = await findDirectoriesByGlobs(basePath, resolvedPatterns);
   return { patterns: resolvedPatterns, resultDirectories };
 };

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./logs.js";
 export * from "./execution-context.js";
 export * from "./agent-state.js";
 export * from "./agent-select.js";
+export * from "./fileSystem.js";

--- a/packages/cli/test/commands/allure2.test.ts
+++ b/packages/cli/test/commands/allure2.test.ts
@@ -152,4 +152,20 @@ describe("allure2 command", () => {
       historyPath: undefined,
     });
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(Allure2Command, ["allure2", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/allure2.test.ts
+++ b/packages/cli/test/commands/allure2.test.ts
@@ -1,10 +1,10 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, readConfig } from "@allurereport/core";
 import Allure2Plugin from "@allurereport/plugin-allure2";
 import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Allure2Command } from "../../src/commands/allure2.js";
@@ -28,16 +28,17 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
 
   return {
     readConfig: vi.fn(),
     AllureReport: AllureReportMock,
+  };
+});
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
   };
 });
 
@@ -47,34 +48,24 @@ beforeEach(() => {
 
 describe("allure2 command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
-    const command = new Allure2Command();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(Allure2Command, ["allure2", "--cwd", ".", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new Allure2Command();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(Allure2Command, ["allure2", "--cwd", ".", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith({
@@ -88,7 +79,6 @@ describe("allure2 command", () => {
   });
 
   it("should initialize allure report with default plugin options even when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -105,13 +95,9 @@ describe("allure2 command", () => {
         },
       ],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new Allure2Command();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(Allure2Command, ["allure2", "--cwd", ".", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith(
@@ -127,8 +113,8 @@ describe("allure2 command", () => {
   });
 
   it("should prefer CLI arguments over config and defaults", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(Allure2Command, [
       "allure2",
@@ -153,8 +139,8 @@ describe("allure2 command", () => {
   });
 
   it("should not overwrite readConfig values if no CLI arguments provided", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(Allure2Command, ["allure2", "./allure-results"]);
 

--- a/packages/cli/test/commands/awesome.test.ts
+++ b/packages/cli/test/commands/awesome.test.ts
@@ -1,10 +1,10 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, readConfig } from "@allurereport/core";
 import AwesomePlugin from "@allurereport/plugin-awesome";
 import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AwesomeCommand } from "../../src/commands/awesome.js";
@@ -29,16 +29,17 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
 
   return {
     readConfig: vi.fn(),
     AllureReport: AllureReportMock,
+  };
+});
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
   };
 });
 
@@ -48,35 +49,25 @@ beforeEach(() => {
 
 describe("awesome command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
     (readConfig as Mock).mockResolvedValueOnce({ plugins: [] });
 
-    const command = new AwesomeCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(AwesomeCommand, ["awesome", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new AwesomeCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(AwesomeCommand, ["awesome", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith({
@@ -94,7 +85,6 @@ describe("awesome command", () => {
   });
 
   it("should initialize allure report with default plugin options even when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -111,13 +101,9 @@ describe("awesome command", () => {
         },
       ],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new AwesomeCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(AwesomeCommand, ["awesome", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith(
@@ -133,8 +119,8 @@ describe("awesome command", () => {
   });
 
   it("should prefer CLI arguments over config and defaults", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(AwesomeCommand, [
       "awesome",
@@ -160,8 +146,8 @@ describe("awesome command", () => {
   });
 
   it("should not overwrite readConfig values if no CLI arguments provided", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(AwesomeCommand, ["awesome", "./allure-results"]);
 
@@ -176,7 +162,7 @@ describe("awesome command", () => {
   });
 
   it("should pass hideLabels from CLI to awesome plugin options", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
     const config = {
       hideLabels: ["owner", "tag"],
     };

--- a/packages/cli/test/commands/awesome.test.ts
+++ b/packages/cli/test/commands/awesome.test.ts
@@ -194,4 +194,20 @@ describe("awesome command", () => {
       ]),
     );
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(AwesomeCommand, ["awesome", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/classic.test.ts
+++ b/packages/cli/test/commands/classic.test.ts
@@ -153,4 +153,20 @@ describe("classic command", () => {
       historyPath: undefined,
     });
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(ClassicCommand, ["classic", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/classic.test.ts
+++ b/packages/cli/test/commands/classic.test.ts
@@ -1,10 +1,10 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, readConfig } from "@allurereport/core";
 import ClassicPlugin from "@allurereport/plugin-classic";
 import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ClassicCommand } from "../../src/commands/classic.js";
@@ -28,16 +28,17 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
 
   return {
     readConfig: vi.fn(),
     AllureReport: AllureReportMock,
+  };
+});
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
   };
 });
 
@@ -47,34 +48,24 @@ beforeEach(() => {
 
 describe("classic command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
-    const command = new ClassicCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(ClassicCommand, ["classic", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new ClassicCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(ClassicCommand, ["classic", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith({
@@ -89,7 +80,6 @@ describe("classic command", () => {
   });
 
   it("should initialize allure report with default plugin options even when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -106,13 +96,9 @@ describe("classic command", () => {
         },
       ],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new ClassicCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(ClassicCommand, ["classic", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith(
@@ -128,8 +114,8 @@ describe("classic command", () => {
   });
 
   it("should prefer CLI arguments over config and defaults", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(ClassicCommand, [
       "classic",
@@ -154,8 +140,8 @@ describe("classic command", () => {
   });
 
   it("should not overwrite readConfig values if no CLI arguments provided", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(ClassicCommand, ["classic", "./allure-results"]);
 

--- a/packages/cli/test/commands/commons/generate.test.ts
+++ b/packages/cli/test/commands/commons/generate.test.ts
@@ -42,7 +42,7 @@ describe("generate function", () => {
     await generate({
       cwd: ".",
       config: {} as FullConfig,
-      resultsDir: "./notfound",
+      resultsDir: ["./notfound"],
       dump: [],
     });
 
@@ -62,7 +62,7 @@ describe("generate function", () => {
     await generate({
       cwd: ".",
       config: {} as FullConfig,
-      resultsDir: "./allure-results",
+      resultsDir: ["./allure-results"],
       dump: [],
     });
 
@@ -78,18 +78,21 @@ describe("generate function", () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
     (readConfig as Mock).mockResolvedValue({});
-    AllureReportMock.prototype.start.mockRejectedValueOnce(new KnownError("known error"));
+    const fence = new Promise<void>((r) => {
+      AllureReportMock.prototype.start.mockImplementationOnce(async () => {
+        r();
+        throw new KnownError("known error");
+      });
+    });
 
     const promise = generate({
       cwd: ".",
       config: {} as FullConfig,
-      resultsDir: "./allure-results",
+      resultsDir: ["./allure-results"],
       dump: [],
     });
 
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await fence;
     await Promise.resolve();
 
     expect(async () => await promise).not.toThrow();
@@ -103,18 +106,21 @@ describe("generate function", () => {
   it("should handle unknown errors and exit with code 1 with errors logging", async () => {
     (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
     (readConfig as Mock).mockResolvedValue({});
-    AllureReportMock.prototype.start.mockRejectedValueOnce(new Error("unknown error"));
+    const fence = new Promise<void>((r) => {
+      AllureReportMock.prototype.start.mockImplementationOnce(async () => {
+        r();
+        throw new Error("unknown error");
+      });
+    });
 
     const promise = generate({
       cwd: ".",
       config: {} as FullConfig,
-      resultsDir: "./allure-results",
+      resultsDir: ["./allure-results"],
       dump: [],
     });
 
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await fence;
     await Promise.resolve();
     await Promise.resolve();
 
@@ -135,7 +141,7 @@ describe("generate function", () => {
     await generate({
       cwd: ".",
       config: {} as FullConfig,
-      resultsDir: "",
+      resultsDir: [""],
       dump: ["dump1.zip", "dump2.zip"],
     });
 
@@ -158,7 +164,7 @@ describe("generate function", () => {
     await generate({
       cwd: ".",
       config: {} as FullConfig,
-      resultsDir: "./allure-results",
+      resultsDir: ["./allure-results"],
       dump: ["dump1.zip", "dump2.zip"],
     });
 

--- a/packages/cli/test/commands/commons/generate.test.ts
+++ b/packages/cli/test/commands/commons/generate.test.ts
@@ -174,4 +174,45 @@ describe("generate function", () => {
     expect(AllureReportMock.prototype.done).toHaveBeenCalled();
     expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledWith("./allure-results/");
   });
+
+  it("should support multiple result directories", async () => {
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo1/", "./foo2/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar1/", "./bar2/"]);
+    (readConfig as Mock).mockResolvedValue({});
+
+    await generate({
+      cwd: ".",
+      config: {} as FullConfig,
+      resultsDir: ["foo", "bar"],
+      dump: [],
+    });
+
+    expect(AllureReportMock).toHaveBeenCalled();
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", {
+      mark: true,
+      nodir: false,
+      absolute: true,
+      dot: true,
+      windowsPathsNoEscape: true,
+      cwd: ".",
+    });
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", {
+      mark: true,
+      nodir: false,
+      absolute: true,
+      dot: true,
+      windowsPathsNoEscape: true,
+      cwd: ".",
+    });
+    expect(AllureReportMock.prototype.restoreState).toHaveBeenCalledWith([]);
+    expect(AllureReportMock.prototype.start).toHaveBeenCalled();
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledTimes(4);
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo1/");
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./foo2/");
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenNthCalledWith(3, "./bar1/");
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenNthCalledWith(4, "./bar2/");
+    expect(AllureReportMock.prototype.done).toHaveBeenCalled();
+  });
 });

--- a/packages/cli/test/commands/csv.test.ts
+++ b/packages/cli/test/commands/csv.test.ts
@@ -1,5 +1,4 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { exit } from "node:process";
@@ -7,6 +6,7 @@ import { exit } from "node:process";
 import { AllureReport, readConfig } from "@allurereport/core";
 import CsvPlugin from "@allurereport/plugin-csv";
 import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CsvCommand } from "../../src/commands/csv.js";
@@ -30,10 +30,6 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("node:fs/promises", async (importOriginal) => ({
   ...(await importOriginal()),
   realpath: vi.fn(),
@@ -46,6 +42,11 @@ vi.mock("@allurereport/core", async () => {
     AllureReport: AllureReportMock,
   };
 });
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
+  };
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -54,22 +55,22 @@ beforeEach(() => {
 
 describe("csv command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
     await run(CsvCommand, ["csv", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, ["csv", fixtures.resultsDir]);
 
@@ -94,7 +95,6 @@ describe("csv command", () => {
   });
 
   it("should initialize allure report with default plugin options even when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -111,6 +111,7 @@ describe("csv command", () => {
         },
       ],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, ["csv", fixtures.resultsDir]);
 
@@ -128,8 +129,8 @@ describe("csv command", () => {
   });
 
   it("should prefer CLI arguments over config and defaults", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, [
       "csv",
@@ -164,8 +165,8 @@ describe("csv command", () => {
   });
 
   it("should set output to default and take other props from readConfig if no CLI arguments provided", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, ["csv", fixtures.resultsDir]);
 
@@ -190,8 +191,8 @@ describe("csv command", () => {
   });
 
   it("should use absolute path directly when output is absolute", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, ["csv", "--output", fixtures.absoluteOutput, fixtures.resultsDir]);
 
@@ -210,8 +211,8 @@ describe("csv command", () => {
   });
 
   it("should pass custom config path to readConfig", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, ["csv", "--config", fixtures.config, fixtures.resultsDir]);
 
@@ -222,9 +223,9 @@ describe("csv command", () => {
 
   it("should use custom cwd when provided", async () => {
     const customCwd = "/custom/working/directory";
-    (existsSync as Mock).mockReturnValueOnce(true);
     (realpath as Mock).mockResolvedValueOnce(customCwd);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, ["csv", "--cwd", customCwd, fixtures.resultsDir]);
 
@@ -236,9 +237,9 @@ describe("csv command", () => {
 
   it("should combine config, cwd, and output options correctly", async () => {
     const customCwd = "/custom/working/directory";
-    (existsSync as Mock).mockReturnValueOnce(true);
     (realpath as Mock).mockResolvedValueOnce(customCwd);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
     await run(CsvCommand, [
       "csv",

--- a/packages/cli/test/commands/csv.test.ts
+++ b/packages/cli/test/commands/csv.test.ts
@@ -269,4 +269,20 @@ describe("csv command", () => {
       }),
     );
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(CsvCommand, ["csv", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/dashboard.test.ts
+++ b/packages/cli/test/commands/dashboard.test.ts
@@ -1,10 +1,10 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, readConfig } from "@allurereport/core";
 import DashboardPlugin from "@allurereport/plugin-dashboard";
 import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DashboardCommand } from "../../src/commands/dashboard.js";
@@ -28,16 +28,17 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
 
   return {
     readConfig: vi.fn(),
     AllureReport: AllureReportMock,
+  };
+});
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
   };
 });
 
@@ -47,34 +48,24 @@ beforeEach(() => {
 
 describe("dashboard command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
-    const command = new DashboardCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(DashboardCommand, ["dashboard", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new DashboardCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(DashboardCommand, ["dashboard", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith({
@@ -89,7 +80,6 @@ describe("dashboard command", () => {
   });
 
   it("should initialize allure report with default plugin options even when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -106,13 +96,9 @@ describe("dashboard command", () => {
         },
       ],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new DashboardCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(DashboardCommand, ["dashboard", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith(
@@ -128,8 +114,8 @@ describe("dashboard command", () => {
   });
 
   it("should prefer CLI arguments over config and defaults", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
 
     await run(DashboardCommand, ["dashboard", "--output", "foo", "--report-name", "bar", "./allure-results"]);
 
@@ -141,8 +127,8 @@ describe("dashboard command", () => {
   });
 
   it("should not overwrite readConfig values if no CLI arguments provided", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
 
     await run(DashboardCommand, ["dashboard", "./allure-results"]);
 

--- a/packages/cli/test/commands/dashboard.test.ts
+++ b/packages/cli/test/commands/dashboard.test.ts
@@ -138,4 +138,20 @@ describe("dashboard command", () => {
       name: undefined,
     });
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(DashboardCommand, ["dashboard", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -1,5 +1,3 @@
-import { join } from "node:path";
-
 import { readConfig } from "@allurereport/core";
 import { serve } from "@allurereport/static-server";
 import { run } from "clipanion";
@@ -29,139 +27,77 @@ beforeEach(() => {
 
 describe("generate command", () => {
   it("should call generate with correct parameters when results directory is provided", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-      output: "allure-report",
-    };
-
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.output, open: false });
+    (readConfig as Mock).mockResolvedValue({ output: "allure-report", open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(GenerateCommand, ["generate", "--cwd", "foo", "bar"]);
 
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
-        config: { output: fixtures.output, open: false },
-        resultsDir: fixtures.resultsDir,
-        dump: expect.any(Object),
+        cwd: "foo",
+        config: { output: "allure-report", open: false },
+        resultsDir: ["bar"],
+        dump: undefined,
       }),
     );
     expect(serve).not.toHaveBeenCalled();
   });
 
-  it("should call generate with default results directory when not provided", async () => {
-    const fixtures = {
-      cwd: ".",
-      defaultResultsDir: "./**/allure-results",
-    };
-
+  it("should call generate with empty array when resultsDir not provided", async () => {
     (readConfig as Mock).mockResolvedValue({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = undefined;
-
-    await command.execute();
+    await run(GenerateCommand, ["generate"]);
 
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
-        config: { open: false },
-        resultsDir: fixtures.defaultResultsDir,
-        dump: expect.any(Object),
+        resultsDir: [],
       }),
     );
     expect(serve).not.toHaveBeenCalled();
   });
 
   it("should call generate with dump files when provided", async () => {
-    const fixtures = {
-      cwd: ".",
-      defaultResultsDir: "./**/allure-results",
-      dump: ["dump.zip", "dump.zip"],
-    };
-
     (readConfig as Mock).mockResolvedValue({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = undefined;
-    command.dump = fixtures.dump;
-
-    await command.execute();
+    await run(GenerateCommand, ["generate", "--dump", "dump.zip", "--dump", "dump.zip"]);
 
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
-        config: { open: false },
-        resultsDir: fixtures.defaultResultsDir,
-        dump: fixtures.dump,
+        dump: ["dump.zip", "dump.zip"],
       }),
     );
     expect(serve).not.toHaveBeenCalled();
   });
 
   it("should call generate with both state dump files and results directory", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-    };
-
     (readConfig as Mock).mockResolvedValue({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(GenerateCommand, ["generate", "--dump", "dump.zip", "--dump", "dump.zip", "./allure-results"]);
 
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
+        cwd: expect.any(String),
         config: { open: false },
-        resultsDir: fixtures.resultsDir,
-        dump: expect.any(Object),
+        resultsDir: ["./allure-results"],
+        dump: ["dump.zip", "dump.zip"],
       }),
     );
     expect(serve).not.toHaveBeenCalled();
   });
 
   it("should prefer CLI arguments over config and defaults", async () => {
-    const fixtures = {
-      resultsDir: join(".", "allure-results"),
-      output: "foo",
-      name: "bar",
-    };
-
     (readConfig as Mock).mockResolvedValueOnce({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    await run(GenerateCommand, [
-      "generate",
-      "--output",
-      fixtures.output,
-      "--report-name",
-      fixtures.name,
-      fixtures.resultsDir,
-    ]);
+    await run(GenerateCommand, ["generate", "--output", "foo", "--report-name", "bar", "baz"]);
 
     expect(readConfig).toHaveBeenCalledTimes(1);
     expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
-      output: fixtures.output,
-      name: fixtures.name,
+      output: "foo",
+      name: "bar",
       open: undefined,
       port: undefined,
       hideLabels: undefined,
@@ -171,7 +107,7 @@ describe("generate command", () => {
       expect.objectContaining({
         cwd: expect.any(String),
         config: { open: false },
-        resultsDir: fixtures.resultsDir,
+        resultsDir: ["baz"],
         dump: undefined,
       }),
     );
@@ -179,14 +115,10 @@ describe("generate command", () => {
   });
 
   it("should not overwrite readConfig values if no CLI arguments provided", async () => {
-    const fixtures = {
-      resultsDir: join(".", "allure-results"),
-    };
-
     (readConfig as Mock).mockResolvedValueOnce({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    await run(GenerateCommand, ["generate", fixtures.resultsDir]);
+    await run(GenerateCommand, ["generate", "foo"]);
 
     expect(readConfig).toHaveBeenCalledTimes(1);
     expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
@@ -201,7 +133,7 @@ describe("generate command", () => {
       expect.objectContaining({
         cwd: expect.any(String),
         config: { open: false },
-        resultsDir: fixtures.resultsDir,
+        resultsDir: ["foo"],
         dump: undefined,
       }),
     );
@@ -209,18 +141,12 @@ describe("generate command", () => {
   });
 
   it("should pass config to generate function", async () => {
-    const fixtures = {
-      resultsDir: join(".", "allure-results"),
-      configPath: join(".", "custom-config.js"),
-      output: "custom-output",
-    };
-
-    (readConfig as Mock).mockResolvedValueOnce({ output: fixtures.output, open: false });
+    (readConfig as Mock).mockResolvedValueOnce({ output: "foo", open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    await run(GenerateCommand, ["generate", "--config", fixtures.configPath, fixtures.resultsDir]);
+    await run(GenerateCommand, ["generate", "--config", "bar.js", "baz"]);
 
-    expect(readConfig).toHaveBeenCalledWith(expect.any(String), fixtures.configPath, {
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), "bar.js", {
       output: undefined,
       name: undefined,
       open: undefined,
@@ -231,8 +157,8 @@ describe("generate command", () => {
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: expect.any(String),
-        config: { output: fixtures.output, open: false },
-        resultsDir: fixtures.resultsDir,
+        config: { output: "foo", open: false },
+        resultsDir: ["baz"],
         dump: undefined,
       }),
     );
@@ -240,163 +166,116 @@ describe("generate command", () => {
   });
 
   it("should propagate errors from generate function", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-    };
-
     const error = new Error("Generate failed");
     (readConfig as Mock).mockResolvedValue({ open: false });
     (generate as Mock).mockRejectedValue(error);
 
-    const command = new GenerateCommand();
+    const code = await run(GenerateCommand, ["generate", "foo"]);
 
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-
-    await expect(command.execute()).rejects.toThrow("Generate failed");
+    expect(code).not.toBe(0);
     expect(serve).not.toHaveBeenCalled();
   });
 
   it("should call serve when open flag is true", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-      output: "allure-report",
-    };
-
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.output, open: true });
+    (readConfig as Mock).mockResolvedValue({ output: "foo", open: true });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
+    await run(GenerateCommand, ["generate", "--open", "bar"]);
 
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.open = true;
-
-    await command.execute();
-
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, expect.objectContaining({ open: true }));
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
-        config: { output: fixtures.output, open: true },
-        resultsDir: fixtures.resultsDir,
-        dump: expect.any(Object),
+        config: { output: "foo", open: true },
+        resultsDir: ["bar"],
       }),
     );
     expect(serve).toHaveBeenCalledWith(
       expect.objectContaining({
         port: undefined,
-        servePath: fixtures.output,
+        servePath: "foo",
         open: true,
       }),
     );
   });
 
   it("should pass port to serve when open flag is true and port is specified", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-      output: "allure-report",
-      port: "8080",
-    };
-
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.output, open: true, port: fixtures.port });
+    (readConfig as Mock).mockResolvedValue({
+      output: "foo",
+      open: true,
+      port: 10202,
+    });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
+    await run(GenerateCommand, ["generate", "--open", "--port", "10201", "bar"]);
 
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.open = true;
-    command.port = fixtures.port;
-
-    await command.execute();
-
+    expect(readConfig).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      expect.objectContaining({
+        open: true,
+        port: "10201",
+      }),
+    );
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
-        config: { output: fixtures.output, open: true, port: fixtures.port },
-        resultsDir: fixtures.resultsDir,
-        dump: expect.any(Object),
+        config: { output: "foo", open: true, port: 10202 },
+        resultsDir: ["bar"],
       }),
     );
     expect(serve).toHaveBeenCalledWith(
       expect.objectContaining({
-        port: 8080,
-        servePath: fixtures.output,
+        port: 10202,
+        servePath: "foo",
         open: true,
       }),
     );
   });
 
-  it("should not call serve when open flag is false", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-      output: "allure-report",
-    };
-
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.output, open: false });
+  it("should not call serve when not open flag is passed", async () => {
+    (readConfig as Mock).mockResolvedValue({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    const command = new GenerateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.open = false;
-
-    await command.execute();
+    await run(GenerateCommand, ["generate", "foo"]);
 
     expect(generate).toHaveBeenCalled();
     expect(serve).not.toHaveBeenCalled();
   });
 
   it("should handle errors from serve function when open is true", async () => {
-    const fixtures = {
-      cwd: ".",
-      resultsDir: join(".", "allure-results"),
-      output: "allure-report",
-    };
-
     const error = new Error("Serve failed");
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.output, open: true });
+    (readConfig as Mock).mockResolvedValue({ open: true });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockRejectedValue(error);
 
-    const command = new GenerateCommand();
+    const code = await run(GenerateCommand, ["generate", "--open", "foo"]);
 
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.open = true;
-
-    await expect(command.execute()).rejects.toThrow("Serve failed");
+    expect(code).not.toBe(0);
     expect(generate).toHaveBeenCalled();
   });
 
   it("should pass hideLabels override to readConfig and use normalized config", async () => {
     (readConfig as Mock).mockResolvedValue({
       open: false,
-      hideLabels: ["owner", "tag"],
+      hideLabels: ["foo", "bar"],
     });
     (generate as Mock).mockResolvedValue(undefined);
 
-    await run(GenerateCommand, ["generate", "--hide-labels", "owner", "--hide-labels", "tag", "./allure-results"]);
+    await run(GenerateCommand, ["generate", "--hide-labels", "baz", "--hide-labels", "qux", "qut"]);
 
     expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
       name: undefined,
       output: undefined,
       open: undefined,
       port: undefined,
-      hideLabels: ["owner", "tag"],
+      hideLabels: ["baz", "qux"],
       historyLimit: undefined,
     });
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
         config: expect.objectContaining({
-          hideLabels: ["owner", "tag"],
+          hideLabels: ["foo", "bar"],
         }),
       }),
     );

--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -280,4 +280,18 @@ describe("generate command", () => {
       }),
     );
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValue({});
+    (generate as Mock).mockResolvedValue(undefined);
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(GenerateCommand, ["generate", "foo", "bar"]);
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resultsDir: ["foo", "bar"],
+      }),
+    );
+  });
 });

--- a/packages/cli/test/commands/knownIssue.test.ts
+++ b/packages/cli/test/commands/knownIssue.test.ts
@@ -1,8 +1,9 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, resolveConfig, writeKnownIssues } from "@allurereport/core";
+import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { KnownIssueCommand } from "../../src/commands/knownIssue.js";
@@ -22,10 +23,6 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
 
@@ -35,6 +32,11 @@ vi.mock("@allurereport/core", async () => {
     AllureReport: AllureReportMock,
   };
 });
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
+  };
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -42,30 +44,21 @@ beforeEach(() => {
 
 describe("known-issue command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
-    const command = new KnownIssueCommand();
-
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(KnownIssueCommand, ["known-issue", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report and write known issues with default output path", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new KnownIssueCommand();
-
-    command.output = undefined;
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(KnownIssueCommand, ["known-issue", fixtures.resultsDir]);
 
     expect(resolveConfig).toHaveBeenCalledTimes(1);
     expect(resolveConfig).toHaveBeenCalledWith({
@@ -74,20 +67,15 @@ describe("known-issue command", () => {
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport.prototype.start).toHaveBeenCalledTimes(1);
     expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(1);
-    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledWith(fixtures.resultsDir);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledWith(`${fixtures.resultsDir}/`);
     expect(AllureReport.prototype.done).toHaveBeenCalledTimes(1);
     expect(writeKnownIssues).toHaveBeenCalledTimes(1);
   });
 
   it("should initialize allure report and write known issues with custom output path", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new KnownIssueCommand();
-
-    command.output = fixtures.output;
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(KnownIssueCommand, ["known-issue", "--output", fixtures.output, fixtures.resultsDir]);
 
     expect(resolveConfig).toHaveBeenCalledTimes(1);
     expect(resolveConfig).toHaveBeenCalledWith({
@@ -96,7 +84,7 @@ describe("known-issue command", () => {
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport.prototype.start).toHaveBeenCalledTimes(1);
     expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(1);
-    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledWith(fixtures.resultsDir);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledWith(`${fixtures.resultsDir}/`);
     expect(AllureReport.prototype.done).toHaveBeenCalledTimes(1);
     expect(writeKnownIssues).toHaveBeenCalledTimes(1);
   });

--- a/packages/cli/test/commands/knownIssue.test.ts
+++ b/packages/cli/test/commands/knownIssue.test.ts
@@ -88,4 +88,19 @@ describe("known-issue command", () => {
     expect(AllureReport.prototype.done).toHaveBeenCalledTimes(1);
     expect(writeKnownIssues).toHaveBeenCalledTimes(1);
   });
+
+  it("should support multiple resultsDir", async () => {
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(KnownIssueCommand, ["known-issue", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/log.test.ts
+++ b/packages/cli/test/commands/log.test.ts
@@ -110,4 +110,20 @@ describe("log command", () => {
       }),
     );
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(LogCommand, ["log", "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/log.test.ts
+++ b/packages/cli/test/commands/log.test.ts
@@ -1,9 +1,10 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, readConfig } from "@allurereport/core";
 import LogPlugin from "@allurereport/plugin-log";
+import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LogCommand } from "../../src/commands/log.js";
@@ -24,16 +25,17 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
 
   return {
     readConfig: vi.fn(),
     AllureReport: AllureReportMock,
+  };
+});
+vi.mock("glob", async () => {
+  return {
+    glob: vi.fn(),
   };
 });
 
@@ -43,34 +45,24 @@ beforeEach(() => {
 
 describe("log command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
-    const command = new LogCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(LogCommand, ["log", fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new LogCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(LogCommand, ["log", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith({
@@ -86,7 +78,6 @@ describe("log command", () => {
   });
 
   it("should initialize allure report with provided plugin options when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -103,13 +94,9 @@ describe("log command", () => {
         },
       ],
     });
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
 
-    const command = new LogCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(LogCommand, ["log", fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith(

--- a/packages/cli/test/commands/open.test.ts
+++ b/packages/cli/test/commands/open.test.ts
@@ -51,408 +51,369 @@ beforeEach(() => {
 });
 
 describe("open command", () => {
-  it("should generate report in temp directory and serve when no summary files found", async () => {
-    const fixtures = {
-      resultsDir: "allure-report",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
+  it("should open existing default dir when no input and config output are provided", async () => {
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
+    (glob as unknown as Mock).mockResolvedValue(["foo"]);
+    (readConfig as Mock).mockResolvedValue({ port: undefined });
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "--cwd", "bar"]);
+
+    expect(glob).toHaveBeenCalledWith(join("bar", "allure-report", "**", "summary.json"), {
+      nodir: true,
+      absolute: true,
+      dot: true,
+      windowsPathsNoEscape: true,
+      cwd: "bar",
+    });
+    expect(readConfig).toHaveBeenCalledWith("bar", undefined, {
+      port: undefined,
+    });
+    expect(generate).not.toHaveBeenCalled();
+    expect(serve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: undefined,
+        servePath: join("bar", "allure-report"),
+        open: true,
+      }),
+    );
+  });
+
+  it("should open existing configured dir when no input is provided", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    (glob as unknown as Mock).mockResolvedValue(["foo"]);
+    (readConfig as Mock).mockResolvedValueOnce({ output: "bar" });
+    (readConfig as Mock).mockResolvedValue({ port: undefined });
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "--cwd", "baz"]);
+
+    expect(glob).toHaveBeenCalledWith(join("baz", "bar", "**", "summary.json"), {
+      nodir: true,
+      absolute: true,
+      dot: true,
+      windowsPathsNoEscape: true,
+      cwd: "baz",
+    });
+    expect(readConfig).toHaveBeenCalledWith("baz", undefined, {
+      port: undefined,
+    });
+    expect(generate).not.toHaveBeenCalled();
+    expect(serve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: undefined,
+        servePath: join("baz", "bar"),
+        open: true,
+      }),
+    );
+  });
+
+  it("should generate report in temp directory and serve when no summary files found", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
     (glob as unknown as Mock).mockResolvedValue([]);
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "qux", "qut"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
-
-    expect(mkdtemp).toHaveBeenCalledWith(join("/tmp", "allure-report-"));
-    expect(readConfig).toHaveBeenCalledWith(".", expect.any(Object), {
-      port: expect.any(Object),
-      output: fixtures.tmpDir,
+    expect(mkdtemp).toHaveBeenCalledWith(join("foo", "allure-report-"));
+    expect(readConfig).toHaveBeenCalledWith("qux", undefined, {
+      port: undefined,
+      output: "bar",
       hideLabels: undefined,
     });
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: ".",
-        config: { output: fixtures.tmpDir },
-        resultsDir: join(".", fixtures.resultsDir),
+        cwd: "qux",
+        config: { output: "baz" },
+        resultsDir: ["qut"],
       }),
     );
     expect(serve).toHaveBeenCalledWith(
       expect.objectContaining({
         port: undefined,
-        servePath: fixtures.tmpDir,
+        servePath: "baz",
+        open: true,
+      }),
+    );
+  });
+
+  it("should generate and serve the default pattern when no input provided and output not exists", async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    (readConfig as Mock).mockResolvedValueOnce({ output: "foo" });
+    (readConfig as Mock).mockResolvedValueOnce({ output: "bar" });
+    (tmpdir as Mock).mockReturnValueOnce("baz");
+    (mkdtemp as Mock).mockResolvedValueOnce("qux");
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "--cwd", "qut"]);
+
+    expect(readConfig).toHaveBeenNthCalledWith(1, "qut", undefined, {
+      port: undefined,
+    });
+    expect(readConfig).toHaveBeenNthCalledWith(2, "qut", undefined, expect.objectContaining({ output: "qux" }));
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resultsDir: [],
+        cwd: "qut",
+        config: expect.objectContaining({
+          output: "bar",
+        }),
+      }),
+    );
+    expect(serve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: undefined,
+        servePath: "bar",
         open: true,
       }),
     );
   });
 
   it("should serve existing report when summary.json files are found", async () => {
-    const fixtures = {
-      resultsDir: "allure-report",
-    };
-
     (existsSync as Mock).mockReturnValue(true);
-    (glob as unknown as Mock).mockResolvedValue([join(".", fixtures.resultsDir, "summary.json")]);
+    (glob as unknown as Mock).mockResolvedValue(["foo"]);
     (readConfig as Mock).mockResolvedValue({ port: undefined });
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "bar", "baz"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
-
-    expect(glob).toHaveBeenCalledWith(join(".", fixtures.resultsDir, "**", "summary.json"), {
-      mark: true,
-      nodir: false,
+    expect(glob).toHaveBeenCalledWith(join("bar", "baz", "**", "summary.json"), {
+      nodir: true,
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: ".",
+      cwd: "bar",
     });
-    expect(readConfig).toHaveBeenCalledWith(".", expect.any(Object), {
-      port: expect.any(Object),
+    expect(readConfig).toHaveBeenCalledWith("bar", undefined, {
+      port: undefined,
     });
     expect(generate).not.toHaveBeenCalled();
     expect(serve).toHaveBeenCalledWith(
       expect.objectContaining({
         port: undefined,
-        servePath: join(".", fixtures.resultsDir),
+        servePath: join("bar", "baz"),
         open: true,
       }),
     );
   });
 
   it("should generate report when target directory does not exist", async () => {
-    const fixtures = {
-      resultsDir: "allure-report",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
     (existsSync as Mock).mockReturnValue(false);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
     (glob as unknown as Mock).mockResolvedValue([]);
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "qux", "qut"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
-
-    expect(existsSync).toHaveBeenCalledWith(join(".", fixtures.resultsDir));
     expect(glob).not.toHaveBeenCalled();
-    expect(generate).toHaveBeenCalled();
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resultsDir: ["qut"],
+        cwd: "qux",
+        config: expect.objectContaining({
+          output: "baz",
+        }),
+      }),
+    );
     expect(serve).toHaveBeenCalledWith(
       expect.objectContaining({
-        servePath: fixtures.tmpDir,
+        servePath: "baz",
         open: true,
       }),
     );
   });
 
   it("should serve with custom port when specified", async () => {
-    const fixtures = {
-      resultsDir: "report",
-      port: "8080",
-    };
-
     (existsSync as Mock).mockReturnValue(true);
-    (glob as unknown as Mock).mockResolvedValue([join(".", fixtures.resultsDir, "summary.json")]);
-    (readConfig as Mock).mockResolvedValue({ port: fixtures.port });
+    (glob as unknown as Mock).mockResolvedValue(["foo"]);
+    (readConfig as Mock).mockResolvedValue({ port: "10201" });
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "bar", "--port", "10202", "baz"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-    command.port = fixtures.port;
-
-    await command.execute();
-
-    expect(readConfig).toHaveBeenCalledWith(".", expect.any(Object), {
-      port: fixtures.port,
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      port: "10202",
     });
     expect(serve).toHaveBeenCalledWith(
       expect.objectContaining({
-        port: 8080,
-        servePath: join(".", fixtures.resultsDir),
+        port: 10201,
+        servePath: join("bar", "baz"),
         open: true,
       }),
     );
   });
 
   it("should use custom config file when provided", async () => {
-    const fixtures = {
-      resultsDir: "allure-report",
-      configPath: join(".", "custom", "allurerc.mjs"),
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
     (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "qux", "--config", "qut", "quc"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-    command.config = fixtures.configPath;
-
-    await command.execute();
-
-    expect(readConfig).toHaveBeenCalledWith(".", fixtures.configPath, {
-      port: expect.any(Object),
-      output: fixtures.tmpDir,
+    expect(readConfig).toHaveBeenCalledWith("qux", "qut", {
+      port: undefined,
+      output: "bar",
       hideLabels: undefined,
     });
   });
 
-  it("should prefer CLI arguments over config", async () => {
-    const fixtures = {
-      resultsDir: "allure-report",
-      port: "3000",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
+  it("should use process cwd if no --cwd provided", async () => {
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
     (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir, port: fixtures.port });
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    await run(OpenCommand, ["open", "--port", fixtures.port, fixtures.resultsDir]);
+    await run(OpenCommand, ["open", "qux"]);
 
-    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
-      port: fixtures.port,
-      output: fixtures.tmpDir,
-      hideLabels: undefined,
-    });
-    expect(serve).toHaveBeenCalledWith(
-      expect.objectContaining({
-        port: 3000,
-        servePath: fixtures.tmpDir,
-        open: true,
-      }),
-    );
-  });
-
-  it("should use cwd when provided", async () => {
-    const fixtures = {
-      cwd: join("/", "custom", "cwd"),
-      resultsDir: "allure-report",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
-    (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
-    (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
-    (generate as Mock).mockResolvedValue(undefined);
-    (serve as Mock).mockResolvedValue(undefined);
-
-    const command = new OpenCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
-
-    expect(readConfig).toHaveBeenCalledWith(fixtures.cwd, expect.any(Object), {
-      port: expect.any(Object),
-      output: fixtures.tmpDir,
-      hideLabels: undefined,
-    });
+    expect(readConfig).toHaveBeenCalledWith(process.cwd(), undefined, expect.any(Object));
     expect(glob).toHaveBeenCalledWith(
-      join(fixtures.cwd, fixtures.resultsDir, "**", "summary.json"),
+      join(process.cwd(), "qux", "**", "summary.json"),
       expect.objectContaining({
-        cwd: fixtures.cwd,
+        cwd: process.cwd(),
       }),
     );
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: fixtures.cwd,
-        resultsDir: join(fixtures.cwd, fixtures.resultsDir),
+        cwd: process.cwd(),
+        resultsDir: ["qux"],
       }),
     );
   });
 
   it("should check for summary.json in target directory", async () => {
-    const fixtures = {
-      resultsDir: "my-results",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
     (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "qux", "qut"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
-
-    expect(glob).toHaveBeenCalledWith(join(".", fixtures.resultsDir, "**", "summary.json"), {
-      mark: true,
-      nodir: false,
+    expect(glob).toHaveBeenCalledWith(join("qux", "qut", "**", "summary.json"), {
+      nodir: true,
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: ".",
+      cwd: "qux",
     });
   });
 
-  it("should use configured output when target is not provided", async () => {
-    const fixtures = {
-      configuredOutput: "/custom/allure-report",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
+  it("should pass empty resultsDir to generate when not provided and no summary in output", async () => {
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
     (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock)
-      .mockResolvedValueOnce({ output: fixtures.configuredOutput })
-      .mockResolvedValueOnce({ output: fixtures.tmpDir });
+    (readConfig as Mock).mockResolvedValue({ output: "bar" });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "qux"]);
 
-    command.cwd = ".";
-    command.resultsDir = undefined;
-
-    await command.execute();
-
-    expect(existsSync).toHaveBeenCalledWith(fixtures.configuredOutput);
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        resultsDir: fixtures.configuredOutput,
+        resultsDir: [],
       }),
     );
   });
 
-  it("should serve configured output when no target is provided", async () => {
-    const fixtures = {
-      configuredOutput: "/custom/allure-report",
-      port: "8080",
-    };
-
-    (existsSync as Mock).mockReturnValue(true);
-    (glob as unknown as Mock).mockResolvedValue([join(fixtures.configuredOutput, "summary.json")]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.configuredOutput, port: fixtures.port });
+  it("should pass empty resultsDir to generate when not provided and output not exists", async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
+    (glob as unknown as Mock).mockResolvedValue([]);
+    (readConfig as Mock).mockResolvedValue({ output: "bar" });
+    (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    await run(OpenCommand, ["serve", "--port", fixtures.port]);
+    await run(OpenCommand, ["open", "--cwd", "qux"]);
 
-    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
-      port: fixtures.port,
-    });
-    expect(glob).toHaveBeenCalledWith(join(fixtures.configuredOutput, "**", "summary.json"), {
-      mark: true,
-      nodir: false,
-      absolute: true,
-      dot: true,
-      windowsPathsNoEscape: true,
-      cwd: expect.any(String),
-    });
-    expect(mkdtemp).not.toHaveBeenCalled();
-    expect(generate).not.toHaveBeenCalled();
-    expect(serve).toHaveBeenCalledWith(
+    expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        port: 8080,
-        servePath: fixtures.configuredOutput,
-        open: true,
+        resultsDir: [],
       }),
     );
   });
 
   it("should create temp directory with mkdtemp pattern", async () => {
-    const fixtures = {
-      resultsDir: "allure-report",
-      tmpDir: "/tmp/allure-report-xyz789",
-    };
-
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
     (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    const command = new OpenCommand();
+    await run(OpenCommand, ["open", "--cwd", "qux", "qut"]);
 
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
-
-    expect(mkdtemp).toHaveBeenCalledWith(join("/tmp", "allure-report-"));
-    expect(readConfig).toHaveBeenCalledWith(".", expect.any(Object), {
-      port: expect.any(Object),
-      output: fixtures.tmpDir,
+    expect(mkdtemp).toHaveBeenCalledWith(join("foo", "allure-report-"));
+    expect(readConfig).toHaveBeenCalledWith("qux", undefined, {
+      port: undefined,
+      output: "bar",
       hideLabels: undefined,
     });
   });
 
   it("should pass hideLabels override when generating a temporary report", async () => {
-    const fixtures = {
-      resultsDir: "allure-results",
-      tmpDir: "/tmp/allure-report-abc123",
-    };
-
     (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("/tmp");
-    (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
     (glob as unknown as Mock).mockResolvedValue([]);
     (readConfig as Mock).mockResolvedValue({
-      output: fixtures.tmpDir,
-      hideLabels: ["owner", "tag"],
+      output: "baz",
+      hideLabels: ["qut", "quc"],
     });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
-    await run(OpenCommand, ["open", "--hide-labels", "owner", "--hide-labels", "tag", fixtures.resultsDir]);
+    await run(OpenCommand, ["open", "--hide-labels", "quz", "--hide-labels", "qur", "qre"]);
 
     expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
       port: undefined,
-      output: fixtures.tmpDir,
-      hideLabels: ["owner", "tag"],
+      output: "bar",
+      hideLabels: ["quz", "qur"],
     });
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
         config: expect.objectContaining({
-          hideLabels: ["owner", "tag"],
+          hideLabels: ["qut", "quc"],
         }),
       }),
     );
+  });
+
+  it("should generate if more than one resultsDir provided", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    (tmpdir as Mock).mockReturnValue("foo");
+    (mkdtemp as Mock).mockResolvedValue("bar");
+    (readConfig as Mock).mockResolvedValue({ output: "baz" });
+    (glob as unknown as Mock).mockResolvedValue([]);
+    (generate as Mock).mockResolvedValue(undefined);
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "foo", "bar"]);
+
+    expect(existsSync).toHaveBeenCalledTimes(0);
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resultsDir: ["foo", "bar"],
+      }),
+    );
+    expect(serve).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/test/commands/open.test.ts
+++ b/packages/cli/test/commands/open.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { exit } from "node:process";
 
 import { readConfig } from "@allurereport/core";
 import { serve } from "@allurereport/static-server";
@@ -28,6 +29,10 @@ vi.mock("node:os", async (importOriginal) => {
     tmpdir: vi.fn(),
   };
 });
+vi.mock("node:process", async (importOriginal) => ({
+  ...(await importOriginal()),
+  exit: vi.fn(),
+}));
 vi.mock("glob", () => ({
   glob: vi.fn(),
 }));
@@ -59,12 +64,12 @@ describe("open command", () => {
 
     await run(OpenCommand, ["open", "--cwd", "bar"]);
 
-    expect(glob).toHaveBeenCalledWith(join("bar", "allure-report", "**", "summary.json"), {
+    expect(glob).toHaveBeenCalledWith(join("**", "summary.json"), {
       nodir: true,
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "bar",
+      cwd: "bar/allure-report",
     });
     expect(readConfig).toHaveBeenCalledWith("bar", undefined, {
       port: undefined,
@@ -88,12 +93,12 @@ describe("open command", () => {
 
     await run(OpenCommand, ["open", "--cwd", "baz"]);
 
-    expect(glob).toHaveBeenCalledWith(join("baz", "bar", "**", "summary.json"), {
+    expect(glob).toHaveBeenCalledWith(join("**", "summary.json"), {
       nodir: true,
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "baz",
+      cwd: "baz/bar",
     });
     expect(readConfig).toHaveBeenCalledWith("baz", undefined, {
       port: undefined,
@@ -141,36 +146,62 @@ describe("open command", () => {
     );
   });
 
-  it("should generate and serve the default pattern when no input provided and output not exists", async () => {
+  it("should fail when no input provided and configured output not exists", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     (existsSync as Mock).mockReturnValue(false);
     (readConfig as Mock).mockResolvedValueOnce({ output: "foo" });
-    (readConfig as Mock).mockResolvedValueOnce({ output: "bar" });
-    (tmpdir as Mock).mockReturnValueOnce("baz");
-    (mkdtemp as Mock).mockResolvedValueOnce("qux");
     (serve as Mock).mockResolvedValue(undefined);
 
-    await run(OpenCommand, ["open", "--cwd", "qut"]);
+    await run(OpenCommand, ["open", "--cwd", "bar"]);
 
-    expect(readConfig).toHaveBeenNthCalledWith(1, "qut", undefined, {
-      port: undefined,
-    });
-    expect(readConfig).toHaveBeenNthCalledWith(2, "qut", undefined, expect.objectContaining({ output: "qux" }));
-    expect(generate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resultsDir: [],
-        cwd: "qut",
-        config: expect.objectContaining({
-          output: "bar",
-        }),
-      }),
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("A report doesn't exist in bar/foo and no input was provided to generate."),
     );
-    expect(serve).toHaveBeenCalledWith(
-      expect.objectContaining({
-        port: undefined,
-        servePath: "bar",
-        open: true,
-      }),
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should fail when no input provided and default output not exists", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    (existsSync as Mock).mockReturnValue(false);
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "--cwd", "foo"]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("A report doesn't exist in foo/allure-report and no input was provided to generate."),
     );
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should fail when no input provided and no report in configured output", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    (existsSync as Mock).mockReturnValue(true);
+    (glob as unknown as Mock).mockResolvedValue([]);
+    (readConfig as Mock).mockResolvedValueOnce({ output: "foo" });
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "--cwd", "bar"]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("A report doesn't exist in bar/foo and no input was provided to generate."),
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should fail when no input provided and no report in default output", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    (existsSync as Mock).mockReturnValue(true);
+    (glob as unknown as Mock).mockResolvedValue([]);
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["open", "--cwd", "foo"]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("A report doesn't exist in foo/allure-report and no input was provided to generate."),
+    );
+    expect(exit).toHaveBeenCalledWith(1);
   });
 
   it("should serve existing report when summary.json files are found", async () => {
@@ -181,12 +212,12 @@ describe("open command", () => {
 
     await run(OpenCommand, ["open", "--cwd", "bar", "baz"]);
 
-    expect(glob).toHaveBeenCalledWith(join("bar", "baz", "**", "summary.json"), {
+    expect(glob).toHaveBeenCalledWith(join("**", "summary.json"), {
       nodir: true,
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "bar",
+      cwd: "bar/baz",
     });
     expect(readConfig).toHaveBeenCalledWith("bar", undefined, {
       port: undefined,
@@ -281,9 +312,9 @@ describe("open command", () => {
 
     expect(readConfig).toHaveBeenCalledWith(process.cwd(), undefined, expect.any(Object));
     expect(glob).toHaveBeenCalledWith(
-      join(process.cwd(), "qux", "**", "summary.json"),
+      join("**", "summary.json"),
       expect.objectContaining({
-        cwd: process.cwd(),
+        cwd: join(process.cwd(), "qux"),
       }),
     );
     expect(generate).toHaveBeenCalledWith(
@@ -305,49 +336,13 @@ describe("open command", () => {
 
     await run(OpenCommand, ["open", "--cwd", "qux", "qut"]);
 
-    expect(glob).toHaveBeenCalledWith(join("qux", "qut", "**", "summary.json"), {
+    expect(glob).toHaveBeenCalledWith(join("**", "summary.json"), {
       nodir: true,
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "qux",
+      cwd: "qux/qut",
     });
-  });
-
-  it("should pass empty resultsDir to generate when not provided and no summary in output", async () => {
-    (existsSync as Mock).mockReturnValue(true);
-    (tmpdir as Mock).mockReturnValue("foo");
-    (mkdtemp as Mock).mockResolvedValue("bar");
-    (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: "bar" });
-    (generate as Mock).mockResolvedValue(undefined);
-    (serve as Mock).mockResolvedValue(undefined);
-
-    await run(OpenCommand, ["open", "--cwd", "qux"]);
-
-    expect(generate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resultsDir: [],
-      }),
-    );
-  });
-
-  it("should pass empty resultsDir to generate when not provided and output not exists", async () => {
-    (existsSync as Mock).mockReturnValue(false);
-    (tmpdir as Mock).mockReturnValue("foo");
-    (mkdtemp as Mock).mockResolvedValue("bar");
-    (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: "bar" });
-    (generate as Mock).mockResolvedValue(undefined);
-    (serve as Mock).mockResolvedValue(undefined);
-
-    await run(OpenCommand, ["open", "--cwd", "qux"]);
-
-    expect(generate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resultsDir: [],
-      }),
-    );
   });
 
   it("should create temp directory with mkdtemp pattern", async () => {

--- a/packages/cli/test/commands/open.test.ts
+++ b/packages/cli/test/commands/open.test.ts
@@ -69,7 +69,7 @@ describe("open command", () => {
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "bar/allure-report",
+      cwd: join("bar", "allure-report"),
     });
     expect(readConfig).toHaveBeenCalledWith("bar", undefined, {
       port: undefined,
@@ -98,7 +98,7 @@ describe("open command", () => {
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "baz/bar",
+      cwd: join("baz", "bar"),
     });
     expect(readConfig).toHaveBeenCalledWith("baz", undefined, {
       port: undefined,
@@ -155,7 +155,7 @@ describe("open command", () => {
     await run(OpenCommand, ["open", "--cwd", "bar"]);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("A report doesn't exist in bar/foo and no input was provided to generate."),
+      expect.stringContaining(`A report doesn't exist in ${join("bar", "foo")} and no input was provided to generate.`),
     );
     expect(exit).toHaveBeenCalledWith(1);
   });
@@ -169,7 +169,9 @@ describe("open command", () => {
     await run(OpenCommand, ["open", "--cwd", "foo"]);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("A report doesn't exist in foo/allure-report and no input was provided to generate."),
+      expect.stringContaining(
+        `A report doesn't exist in ${join("foo", "allure-report")} and no input was provided to generate.`,
+      ),
     );
     expect(exit).toHaveBeenCalledWith(1);
   });
@@ -184,7 +186,7 @@ describe("open command", () => {
     await run(OpenCommand, ["open", "--cwd", "bar"]);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("A report doesn't exist in bar/foo and no input was provided to generate."),
+      expect.stringContaining(`A report doesn't exist in ${join("bar", "foo")} and no input was provided to generate.`),
     );
     expect(exit).toHaveBeenCalledWith(1);
   });
@@ -199,7 +201,9 @@ describe("open command", () => {
     await run(OpenCommand, ["open", "--cwd", "foo"]);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("A report doesn't exist in foo/allure-report and no input was provided to generate."),
+      expect.stringContaining(
+        `A report doesn't exist in ${join("foo", "allure-report")} and no input was provided to generate.`,
+      ),
     );
     expect(exit).toHaveBeenCalledWith(1);
   });
@@ -217,7 +221,7 @@ describe("open command", () => {
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "bar/baz",
+      cwd: join("bar", "baz"),
     });
     expect(readConfig).toHaveBeenCalledWith("bar", undefined, {
       port: undefined,
@@ -341,7 +345,7 @@ describe("open command", () => {
       absolute: true,
       dot: true,
       windowsPathsNoEscape: true,
-      cwd: "qux/qut",
+      cwd: join("qux", "qut"),
     });
   });
 

--- a/packages/cli/test/commands/qualityGate.test.ts
+++ b/packages/cli/test/commands/qualityGate.test.ts
@@ -250,7 +250,6 @@ describe("quality-gate command", () => {
 
   it("should prefer CLI arguments over config and defaults", async () => {
     (readConfig as Mock).mockResolvedValueOnce({});
-    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
     await run(QualityGateCommand, ["quality-gate", "--known-issues", "foo"]);
 
@@ -262,7 +261,6 @@ describe("quality-gate command", () => {
 
   it("should not overwrite readConfig values if no CLI arguments provided", async () => {
     (readConfig as Mock).mockResolvedValueOnce({});
-    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
     await run(QualityGateCommand, ["quality-gate"]);
 

--- a/packages/cli/test/commands/qualityGate.test.ts
+++ b/packages/cli/test/commands/qualityGate.test.ts
@@ -301,4 +301,32 @@ describe("quality-gate command", () => {
       }),
     );
   });
+
+  it("should support multiple resultsDir", async () => {
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+    (readConfig as Mock).mockResolvedValueOnce({ plugins: [] });
+    AllureReportMock.prototype.hasQualityGate = true;
+    AllureReportMock.prototype.realtimeSubscriber = {
+      onTestResults: () => {},
+    };
+    AllureReportMock.prototype.store = {
+      allTestResults: vi.fn().mockResolvedValue([]),
+      testResultById: vi.fn(),
+      allKnownIssues: vi.fn().mockResolvedValue([]),
+    };
+    (AllureReportMock.prototype.validate as unknown as Mock).mockResolvedValueOnce({ results: [] });
+
+    await run(QualityGateCommand, ["quality-gate", "foo", "bar"]);
+
+    expect(exit).toHaveBeenCalledWith(0);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledWith("./foo/");
+    expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledWith("./bar/");
+  });
 });

--- a/packages/cli/test/commands/qualityGate.test.ts
+++ b/packages/cli/test/commands/qualityGate.test.ts
@@ -116,28 +116,29 @@ describe("quality-gate command", () => {
     };
     (AllureReportMock.prototype.validate as unknown as Mock).mockResolvedValueOnce({ results: [] });
 
-    const command = new QualityGateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.config = fixtures.config;
-
-    await command.execute();
+    await run(QualityGateCommand, [
+      "quality-gate",
+      "--cwd",
+      fixtures.cwd,
+      "--config",
+      fixtures.config,
+      fixtures.resultsDir,
+    ]);
 
     expect(exit).toHaveBeenCalledWith(0);
   });
 
   it("should exit with code 1 on fast-fail during realtime validation", async () => {
-    let onTestResultsCb: (ids: string[]) => void;
-
     (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
     (readConfig as Mock).mockResolvedValueOnce({ plugins: [] });
     AllureReportMock.prototype.hasQualityGate = true;
-    AllureReportMock.prototype.realtimeSubscriber = {
-      onTestResults: (cb: (ids: string[]) => void) => {
-        onTestResultsCb = cb;
-      },
-    };
+    const onTestResultPromise = new Promise<(ids: string[]) => void>((r) => {
+      AllureReportMock.prototype.realtimeSubscriber = {
+        onTestResults: (cb: (ids: string[]) => void) => {
+          r(cb);
+        },
+      };
+    });
     AllureReportMock.prototype.store = {
       allTestResults: vi.fn().mockResolvedValue([]),
       testResultById: vi.fn().mockResolvedValue({}),
@@ -150,20 +151,17 @@ describe("quality-gate command", () => {
     validateMock.mockResolvedValueOnce({ results: [{ success: false }], fastFailed: true });
     validateMock.mockResolvedValueOnce({ results: [{ success: false }] });
 
-    const command = new QualityGateCommand();
+    const commandPromise = run(QualityGateCommand, [
+      "quality-gate",
+      "--cwd",
+      fixtures.cwd,
+      "--config",
+      fixtures.config,
+      fixtures.resultsDir,
+    ]);
 
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.config = fixtures.config;
-
-    const commandPromise = command.execute();
-
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    onTestResultsCb!(["id-1"]);
+    const onTestResultCb = await onTestResultPromise;
+    onTestResultCb(["id-1"]);
 
     await commandPromise;
 
@@ -184,12 +182,7 @@ describe("quality-gate command", () => {
     };
     (AllureReportMock.prototype.validate as unknown as Mock).mockResolvedValueOnce({ results: [] });
 
-    const command = new QualityGateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = undefined;
-
-    await command.execute();
+    await run(QualityGateCommand, ["quality-gate", "--cwd", fixtures.cwd]);
 
     expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledWith("dir1/allure-results/");
     expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledWith("dir2/allure-results/");
@@ -202,12 +195,7 @@ describe("quality-gate command", () => {
     (AllureReportMock.prototype.validate as unknown as Mock).mockResolvedValueOnce({ results: [] });
     AllureReportMock.prototype.hasQualityGate = true;
 
-    const command = new QualityGateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = undefined;
-
-    await command.execute();
+    await run(QualityGateCommand, ["quality-gate", "--cwd", fixtures.cwd]);
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("No test results directories found matching pattern:"),
@@ -222,35 +210,37 @@ describe("quality-gate command", () => {
     };
     AllureReportMock.prototype.hasQualityGate = false;
 
-    const command = new QualityGateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.config = fixtures.config;
-    command.maxFailures = undefined;
-    command.minTestsCount = undefined;
-    command.successRate = undefined;
-
-    await command.execute();
+    await run(QualityGateCommand, [
+      "quality-gate",
+      "--cwd",
+      fixtures.cwd,
+      "--config",
+      fixtures.config,
+      fixtures.resultsDir,
+    ]);
 
     expect(exit).toHaveBeenCalledWith(-1);
   });
 
   it("should exit with code 1 when there is no test results found", async () => {
-    (readConfig as Mock).mockResolvedValueOnce({ plugins: [], qualityGate: fixtures.qualityGateConfig });
+    (readConfig as Mock).mockResolvedValueOnce({
+      plugins: [],
+      qualityGate: fixtures.qualityGateConfig,
+    });
     AllureReportMock.prototype.store = {
       allKnownIssues: vi.fn().mockResolvedValue([]),
     };
     (glob as unknown as Mock).mockResolvedValueOnce([]);
     AllureReportMock.prototype.hasQualityGate = true;
 
-    const command = new QualityGateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.config = fixtures.config;
-
-    await command.execute();
+    await run(QualityGateCommand, [
+      "quality-gate",
+      "--cwd",
+      fixtures.cwd,
+      "--config",
+      fixtures.config,
+      fixtures.resultsDir,
+    ]);
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("No test results directories found matching pattern:"),
@@ -303,13 +293,7 @@ describe("quality-gate command", () => {
     (glob as unknown as Mock).mockResolvedValueOnce([]);
     AllureReportMock.prototype.hasQualityGate = true;
 
-    const command = new QualityGateCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = undefined;
-    command.environmentName = "Production";
-
-    await command.execute();
+    await run(QualityGateCommand, ["quality-gate", "--cwd", fixtures.cwd, "--environment-name", "Production"]);
 
     expect(AllureReportMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/cli/test/commands/slack.test.ts
+++ b/packages/cli/test/commands/slack.test.ts
@@ -114,4 +114,20 @@ describe("slack command", () => {
       }),
     );
   });
+
+  it("should support multiple resultsDir", async () => {
+    (readConfig as Mock).mockResolvedValueOnce({});
+    (glob as unknown as Mock).mockResolvedValueOnce(["./foo/"]);
+    (glob as unknown as Mock).mockResolvedValueOnce(["./bar/"]);
+
+    await run(SlackCommand, ["slack", "--token", fixtures.token, "--channel", fixtures.channel, "foo", "bar"]);
+
+    expect(glob).toHaveBeenCalledTimes(2);
+    expect(glob).toHaveBeenNthCalledWith(1, "foo", expect.any(Object));
+    expect(glob).toHaveBeenNthCalledWith(2, "bar", expect.any(Object));
+
+    expect(AllureReport.prototype.readDirectory).toHaveBeenCalledTimes(2);
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(1, "./foo/");
+    expect(AllureReport.prototype.readDirectory).toHaveBeenNthCalledWith(2, "./bar/");
+  });
 });

--- a/packages/cli/test/commands/slack.test.ts
+++ b/packages/cli/test/commands/slack.test.ts
@@ -1,9 +1,10 @@
 import * as console from "node:console";
-import { existsSync } from "node:fs";
 import { exit } from "node:process";
 
 import { AllureReport, readConfig } from "@allurereport/core";
 import SlackPlugin from "@allurereport/plugin-slack";
+import { run } from "clipanion";
+import { glob } from "glob";
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SlackCommand } from "../../src/commands/slack.js";
@@ -24,15 +25,17 @@ vi.mock("node:process", async (importOriginal) => ({
   ...(await importOriginal()),
   exit: vi.fn(),
 }));
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal()),
-  existsSync: vi.fn(),
-}));
 vi.mock("@allurereport/core", async () => {
   const { AllureReportMock } = await import("../utils.js");
   return {
     readConfig: vi.fn(),
     AllureReport: AllureReportMock,
+  };
+});
+vi.mock("glob", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    glob: vi.fn(),
   };
 });
 
@@ -42,36 +45,24 @@ beforeEach(() => {
 
 describe("slack command", () => {
   it("should exit with code 1 when resultsDir doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(false);
+    (glob as unknown as Mock).mockResolvedValueOnce([]);
 
-    const command = new SlackCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-    command.token = fixtures.token;
-    command.channel = fixtures.channel;
-
-    await command.execute();
+    await run(SlackCommand, ["slack", "--token", fixtures.token, "--channel", fixtures.channel, fixtures.resultsDir]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(`The given test results directory doesn't exist: ${fixtures.resultsDir}`),
+      expect.stringContaining(`No test results directories found matching pattern: ${fixtures.resultsDir}`),
     );
     expect(exit).toHaveBeenCalledWith(1);
     expect(AllureReport).not.toHaveBeenCalled();
   });
 
   it("should initialize allure report with default plugin options when config doesn't exist", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [],
     });
 
-    const command = new SlackCommand();
-
-    command.cwd = ".";
-    command.resultsDir = fixtures.resultsDir;
-
-    await command.execute();
+    await run(SlackCommand, ["slack", "--token", fixtures.token, "--channel", fixtures.channel, fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith({
@@ -86,7 +77,7 @@ describe("slack command", () => {
   });
 
   it("should initialize allure report with provided plugin options when config exists", async () => {
-    (existsSync as Mock).mockReturnValueOnce(true);
+    (glob as unknown as Mock).mockResolvedValueOnce([`${fixtures.resultsDir}/`]);
     (readConfig as Mock).mockResolvedValueOnce({
       plugins: [
         {
@@ -104,14 +95,7 @@ describe("slack command", () => {
       ],
     });
 
-    const command = new SlackCommand();
-
-    command.cwd = fixtures.cwd;
-    command.resultsDir = fixtures.resultsDir;
-    command.token = fixtures.token;
-    command.channel = fixtures.channel;
-
-    await command.execute();
+    await run(SlackCommand, ["slack", "--token", fixtures.token, "--channel", fixtures.channel, fixtures.resultsDir]);
 
     expect(AllureReport).toHaveBeenCalledTimes(1);
     expect(AllureReport).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

This PR updates the CLI commands that read Allure results so they can accept multiple `resultsDir` inputs, including glob patterns, instead of forcing users to merge result files in a single directory.

## Why

This is mostly relevant for monorepos, where each module typically writes its own isolated `allure-results` directory instead of producing one shared output.

This feature is also important for `allure-gradle` and `allure-maven` to support multi-project builds.

Without this support, users often have to manually merge or copy result directories before running Allure commands. That extra copying is unnecessary and adds friction to CI scripts and local workflows.

Some commands (`generate`, `open`, `quality-gate`) already supported passing a single glob pattern as `resultsDir`. However, this made the experience of passing multiple directories awkward. Because these commands expected only one `resultsDir`, users had to wrap glob patterns in quotes to prevent shell expansion. If the glob was not quoted, the shell could expand it into multiple paths, causing Allure to throw an error.

## What Changed

- Affected commands now accept `resultsDir` as a rest argument instead of a single positional string.
- Users can now pass any combination of multiple explicit result directories, quoted globs, and unquoted glob (that some shells expand into multiple paths).
- Result directory resolution logic is centralized in `findAllureResultDirectories`.
- The existing default search behavior for `generate`, `open`, and `quality-gate` is preserved: when no `resultsDir` is provided, commands still search `./**/allure-results`. The PR extends this behavior to other commands that work with result files.
- `open`/`serve` keep the existing behavior of serving an already generated report when a single or default report directory is provided and contains a generated report. Otherwise, they fall back to generating a report from the matched result directories.

## Affected Commands

- `generate`
- `open` / `serve`
- `allure2`
- `awesome`
- `classic`
- `csv`
- `dashboard`
- `history`
- `known-issue`
- `log`
- `quality-gate`
- `slack`
- `testplan`
- `watch`

## Examples

Examples are provided given this repo's layout.

  - Multiple paths:

   ```sh
   npx allure generate ./packages/reader-api/out/allure-results ./packages/reader/out/allure-results
   ```

  - An unquoted glob:

   ```sh
   npx allure open ./packages/*/out/allure-results
   ```

   In a shell with globbing support, this is equivalent to:

   ```sh
   npx allure open ./packages/aql/out/allure-results ./packages/charts-api/out/allure-results ... /packages/web-summary/out/allure-results
   ```

  - A quoted glob:

   ```sh
   npx allure awesome "./packages/*/out/allure-results"
   ```

   This is equivalent to the previous example, but instead of the shell, the  `glob` module performs the expansion according to its syntax and rules (which may differ from the shell's). Previously, only `generate`, `open`, and `quality-gate` supported this syntax.

  - Multiple globs, expanded by Allure:

   ```sh
   npx allure awesome "./packages/*-api/out/allure-results" "./packages/core*/out/allure-results"
   ```

  - Multiple globs, depending on the shell, can be expanded by the shell as well as by Allure (via glob):

   ```sh
   npx allure watch ./packages/*-api/out/allure-results ./packages/core*/out/allure-results
   ```

## Extra changes

  - fix leaking mock implementations affecting neighbor tests
  - improve some help messages
  - `allure open` and `allure serve` now require explicit input to generate instead of silently trying to generate from the output directory.

Closes #560