### PR TITLE
New allure service config format

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -120,7 +120,7 @@ export class AllureReport {
     if (allureServiceConfig?.accessToken) {
       if (allureServiceConfig?.legacy) {
         this.#allureServiceClient = new AllureLegacyServiceClient(allureServiceConfig);
-      } else if (allureServiceConfig?.url) {
+      } else {
         this.#allureServiceClient = new AllureServiceClient(allureServiceConfig);
       }
     }

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -16,9 +16,9 @@ import { resolveConfig } from "../src/index.js";
 import { AllureReport } from "../src/report.js";
 import { AllureLegacyServiceClientMock, AllureServiceClientMock } from "./utils.js";
 
-// JWT payload: { "iss": "allure-service", "url": "https://service.allurereport.org", "projectId": "test-project-id" }
+// Token payload: { "accessToken": "ELzFh8...", "url": "http://localhost:3000" }
 const validAccessToken =
-  "header.eyJpc3MiOiJhbGx1cmUtc2VydmljZSIsInVybCI6Imh0dHBzOi8vc2VydmljZS5hbGx1cmVyZXBvcnQub3JnIiwicHJvamVjdElkIjoidGVzdC1wcm9qZWN0LWlkIn0.signature";
+  "ars1.eyJhY2Nlc3NUb2tlbiI6IkVMekZoOFZvaENXeXRrTFlGZ0U2QzVtTS1DWTlyWnd2ZXVYMkRlbmtkTm8iLCJ1cmwiOiJodHRwOi8vbG9jYWxob3N0OjMwMDAifQ.OEwujL5WsTP0TQ8nFxrUauKfRLslw-S2ZFnlgFPTwO8";
 
 vi.mock("@allurereport/service", async (importOriginal) => {
   const utils = await import("./utils.js");
@@ -290,7 +290,6 @@ describe("report", () => {
       allureReport = new AllureReport({
         ...config,
         allureService: {
-          url: "https://service.allurereport.org",
           accessToken: validAccessToken,
         },
       });
@@ -415,7 +414,6 @@ describe("report", () => {
         allureReport = new AllureReport({
           ...config,
           allureService: {
-            url: "https://service.allurereport.org",
             accessToken: validAccessToken,
           },
         });

--- a/packages/plugin-api/src/config.ts
+++ b/packages/plugin-api/src/config.ts
@@ -61,7 +61,6 @@ export interface Config {
   appendHistory?: boolean;
   qualityGate?: QualityGateConfig;
   allureService?: {
-    url?: string;
     accessToken?: string;
     legacy?: boolean;
   };

--- a/packages/service/src/legacyService.ts
+++ b/packages/service/src/legacyService.ts
@@ -6,6 +6,7 @@ import { type Config } from "@allurereport/plugin-api";
 
 import type { AllureServiceApiClient } from "./model.js";
 import { type HttpClient, createServiceHttpClient } from "./utils/http.js";
+import { parseServiceToken } from "./utils/token.js";
 
 const ASSET_MAX_FILE_SIZE = 200 * 1024 * 1024; // 200MB
 const UPLOAD_CONTENT_TYPE = "application/octet-stream";
@@ -38,10 +39,10 @@ export class AllureLegacyServiceClient implements AllureServiceApiClient {
       throw new Error("Allure service access token is required");
     }
 
-    const { url } = JSON.parse(atob(config.accessToken.split(".")[1])) as { url: string };
+    const { accessToken, url } = parseServiceToken(config.accessToken);
 
     this.#url = url.replace(/\/$/, "");
-    this.#client = createServiceHttpClient(this.#url, config.accessToken);
+    this.#client = createServiceHttpClient(this.#url, accessToken);
   }
 
   async downloadHistory(payload: { repo?: string; branch?: string; limit?: number }) {

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -6,6 +6,7 @@ import { type Config } from "@allurereport/plugin-api";
 
 import type { AllureServiceApiClient } from "./model.js";
 import { type HttpClient, createServiceHttpClient } from "./utils/http.js";
+import { parseServiceToken } from "./utils/token.js";
 
 const ASSET_MAX_FILE_SIZE = 200 * 1024 * 1024; // 200MB
 const UPLOAD_CONTENT_TYPE = "application/octet-stream";
@@ -20,15 +21,13 @@ export class AllureServiceClient implements AllureServiceApiClient {
   readonly #url: string;
 
   constructor(readonly config: Config["allureService"]) {
-    if (!config?.url) {
-      throw new Error("Allure service URL is required");
-    }
-
     if (!config?.accessToken) {
       throw new Error("Allure service access token is required");
     }
 
-    this.#url = config.url.replace(/\/$/, "");
+    const { url } = parseServiceToken(config.accessToken);
+
+    this.#url = url.replace(/\/$/, "");
     this.#client = createServiceHttpClient(this.#url, config.accessToken);
   }
 

--- a/packages/service/src/utils/token.ts
+++ b/packages/service/src/utils/token.ts
@@ -1,0 +1,31 @@
+interface ServiceTokenPayload {
+  accessToken?: string;
+  url?: string;
+}
+
+export const parseServiceToken = (token: string) => {
+  try {
+    const encodedPayload = token.split(".")[1];
+
+    if (!encodedPayload) {
+      throw new Error("missing payload");
+    }
+
+    const payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf-8")) as ServiceTokenPayload;
+
+    if (!payload.accessToken) {
+      throw new Error("missing access token");
+    }
+
+    if (!payload.url) {
+      throw new Error("missing url");
+    }
+
+    return {
+      accessToken: payload.accessToken,
+      url: payload.url,
+    };
+  } catch {
+    throw new Error("Allure service access token is invalid");
+  }
+};

--- a/packages/service/test/history.test.ts
+++ b/packages/service/test/history.test.ts
@@ -8,15 +8,16 @@ import { HttpClientMock } from "./utils.js";
 
 const { AllureServiceClient: AllureServiceClientClass } = await import("../src/service.js");
 
-// Static JWT token fixture
-// JWT payload: { "iss": "allure-service", "url": "https://service.allurereport.org", "projectId": "test-project-id" }
-const validAccessToken =
-  "header.eyJpc3MiOiJhbGx1cmUtc2VydmljZSIsInVybCI6Imh0dHBzOi8vc2VydmljZS5hbGx1cmVyZXBvcnQub3JnIiwicHJvamVjdElkIjoidGVzdC1wcm9qZWN0LWlkIn0.signature";
+const serviceAccessToken = "service-access-token";
+const serviceUrl = "https://service.allurereport.org";
+const createAccessToken = (payload: Record<string, string>) =>
+  `ars1.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+const validAccessToken = createAccessToken({ accessToken: serviceAccessToken, url: serviceUrl });
 
 const fixtures = {
   accessToken: validAccessToken,
   project: "test-project-id",
-  url: "https://service.allurereport.org",
+  url: serviceUrl,
   repo: "allure3",
   branch: "main",
   historyDataPoint: {
@@ -50,7 +51,7 @@ describe("AllureRemoteHistory", () => {
   let history: AllureRemoteHistory;
 
   beforeEach(() => {
-    serviceClient = new AllureServiceClientClass({ url: fixtures.url, accessToken: fixtures.accessToken });
+    serviceClient = new AllureServiceClientClass({ accessToken: fixtures.accessToken });
     history = new AllureRemoteHistory({
       allureServiceClient: serviceClient,
       repo: fixtures.repo,

--- a/packages/service/test/legacyService.test.ts
+++ b/packages/service/test/legacyService.test.ts
@@ -7,13 +7,16 @@ import { type MockedFunction, beforeEach, describe, expect, it, vi } from "vites
 import type { AllureLegacyServiceClient } from "../src/legacyService.js";
 import { HttpClientMock, createHttpClientMock } from "./utils.js";
 
-// JWT payload: { "iss": "allure-service", "url": "https://service.allurereport.org", "projectId": "test-project-id" }
-const validAccessToken =
-  "header.eyJpc3MiOiJhbGx1cmUtc2VydmljZSIsInVybCI6Imh0dHBzOi8vc2VydmljZS5hbGx1cmVyZXBvcnQub3JnIiwicHJvamVjdElkIjoidGVzdC1wcm9qZWN0LWlkIn0.signature";
+const serviceAccessToken = "service-access-token";
+const serviceUrl = "https://service.allurereport.org";
+const createAccessToken = (payload: Record<string, string>) =>
+  `ars1.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+const validAccessToken = createAccessToken({ accessToken: serviceAccessToken, url: serviceUrl });
 
 const fixtures = {
   accessToken: validAccessToken,
-  url: "https://service.allurereport.org",
+  serviceAccessToken,
+  url: serviceUrl,
   reportUrl: "https://service.allurereport.org/reports/report-uuid/",
   history: {
     uuid: "1",
@@ -92,7 +95,7 @@ describe("AllureLegacyServiceClient", () => {
     });
 
     it("should create the HTTP client from the service URL in the access token", () => {
-      expect(createHttpClientMock).toHaveBeenCalledWith(fixtures.url, fixtures.accessToken);
+      expect(createHttpClientMock).toHaveBeenCalledWith(fixtures.url, fixtures.serviceAccessToken);
     });
   });
 

--- a/packages/service/test/service.test.ts
+++ b/packages/service/test/service.test.ts
@@ -7,19 +7,18 @@ import { type MockedFunction, beforeEach, describe, expect, it, vi } from "vites
 import type { AllureServiceClient } from "../src/service.js";
 import { HttpClientMock, createHttpClientMock } from "./utils.js";
 
-// JWT payload: { "iss": "allure-service", "url": "https://service.allurereport.org", "projectId": "test-project-id" }
-const validAccessToken =
-  "header.eyJpc3MiOiJhbGx1cmUtc2VydmljZSIsInVybCI6Imh0dHBzOi8vc2VydmljZS5hbGx1cmVyZXBvcnQub3JnIiwicHJvamVjdElkIjoidGVzdC1wcm9qZWN0LWlkIn0.signature";
-
-// JWT payload: { "iss": "wrong-issuer", "url": "https://service.allurereport.org", "projectId": "test-project-id" }
-const invalidIssuerToken =
-  "header.eyJpc3MiOiJ3cm9uZy1pc3N1ZXIiLCJ1cmwiOiJodHRwczovL3NlcnZpY2UuYWxsdXJlcmVwb3J0Lm9yZyIsInByb2plY3RJZCI6InRlc3QtcHJvamVjdC1pZCJ9.signature";
+const serviceAccessToken = "service-access-token";
+const serviceUrl = "https://service.allurereport.org";
+const createAccessToken = (payload: Record<string, string>) =>
+  `ars1.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+const validAccessToken = createAccessToken({ accessToken: serviceAccessToken, url: serviceUrl });
 
 const fixtures = {
   accessToken: validAccessToken,
+  serviceAccessToken,
   newAccessToken: "new-access-token",
   project: "test-project-id",
-  url: "https://service.allurereport.org",
+  url: serviceUrl,
   email: "test@test.com",
   history: {
     uuid: "1",
@@ -88,28 +87,32 @@ describe("AllureServiceClient", () => {
     vi.clearAllMocks();
 
     serviceClient = new AllureServiceClientClass({
-      url: fixtures.url,
       accessToken: fixtures.accessToken,
     });
   });
 
   describe("constructor", () => {
     it("should throw an error if access token is not provided", () => {
-      expect(() => new AllureServiceClientClass({})).toThrow("Allure service URL is required");
+      expect(() => new AllureServiceClientClass({})).toThrow("Allure service access token is required");
     });
 
     it("should throw an error if access token is invalid", () => {
-      expect(() => new AllureServiceClientClass({ url: fixtures.url, accessToken: invalidIssuerToken })).not.toThrow();
-    });
-
-    it("should throw an error if URL is not provided", () => {
       expect(() => new AllureServiceClientClass({ accessToken: "invalid-token" })).toThrow(
-        "Allure service URL is required",
+        "Allure service access token is invalid",
       );
     });
 
+    it("should throw an error if token payload doesn't contain a URL", () => {
+      expect(
+        () => new AllureServiceClientClass({ accessToken: createAccessToken({ accessToken: serviceAccessToken }) }),
+      ).toThrow("Allure service access token is invalid");
+    });
+
     it("should successfully create client with valid config", () => {
-      expect(() => new AllureServiceClientClass({ url: fixtures.url, accessToken: validAccessToken })).not.toThrow();
+      vi.clearAllMocks();
+
+      expect(() => new AllureServiceClientClass({ accessToken: validAccessToken })).not.toThrow();
+      expect(createHttpClientMock).toHaveBeenCalledWith(fixtures.url, fixtures.accessToken);
     });
   });
 
@@ -399,8 +402,7 @@ describe("AllureServiceClient", () => {
 
     it("should preserve the URL protocol slashes in uploaded file hrefs", async () => {
       serviceClient = new AllureServiceClientClass({
-        url: "http://localhost:3000/",
-        accessToken: fixtures.accessToken,
+        accessToken: createAccessToken({ accessToken: fixtures.serviceAccessToken, url: "http://localhost:3000/" }),
       });
       HttpClientMock.prototype.post.mockResolvedValue({});
 


### PR DESCRIPTION
## Summary

- Simplify Allure Service runtime config to use only `allureService.accessToken`.
- Decode the new `ars1` token payload to derive the service `url`.
- Keep the non-legacy service client authenticating with the full configured token, while legacy service uses the parsed inner token.
- Update core service-client selection and tests to work without a separately configured service URL.

## Testing

- `yarn workspace @allurereport/plugin-api build`
- `yarn workspace @allurereport/service build`
- `yarn workspace @allurereport/core build`
- `yarn allure agent -- ... yarn workspace @allurereport/service test test/service.test.ts`
- Focused core report tests via `yarn allure agent`