### PR TITLE
624: Use standard trace.playwright.dev instance

### DIFF
--- a/packages/web-awesome/src/components/TestResult/TrPwTraces/openPwTraceInNewTab.ts
+++ b/packages/web-awesome/src/components/TestResult/TrPwTraces/openPwTraceInNewTab.ts
@@ -1,5 +1,5 @@
 const PLAYWRIGHT_TRACE_ORIGIN = "https://trace.playwright.dev";
-const PLAYWRIGHT_TRACE_URL = `${PLAYWRIGHT_TRACE_ORIGIN}/next/`;
+const PLAYWRIGHT_TRACE_VIEWER_URL = `${PLAYWRIGHT_TRACE_ORIGIN}/`;
 const RETRY_DELAY_MS = 300;
 
 export const openPlaywrightTraceInNewTab = (blob: Blob) => {
@@ -17,7 +17,7 @@ export const openPlaywrightTraceInNewTab = (blob: Blob) => {
     newWindow.postMessage(payload, PLAYWRIGHT_TRACE_ORIGIN);
   };
 
-  newWindow.location.href = PLAYWRIGHT_TRACE_URL;
+  newWindow.location.href = PLAYWRIGHT_TRACE_VIEWER_URL;
   newWindow.focus();
 
   sendTraceMessage();


### PR DESCRIPTION
Use non-next trace URL

Bugs:
https://github.com/allure-framework/allure3/issues/624
https://github.com/allure-framework/allure3/issues/566