### PR TITLE
Optimize allure3

### DIFF
--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -58,6 +58,7 @@ export class InMemoryReportFiles implements ReportFiles {
 
 export class FileSystemReportFiles implements ReportFiles {
   readonly #output: string;
+  readonly #createdDirs = new Map<string, Promise<string | undefined>>();
 
   constructor(output: string) {
     this.#output = resolve(output);
@@ -67,7 +68,14 @@ export class FileSystemReportFiles implements ReportFiles {
     const targetPath = resolvePathUnderOutputRoot(this.#output, path);
     const targetDirPath = dirname(targetPath);
 
-    await mkdir(targetDirPath, { recursive: true });
+    let createdDir = this.#createdDirs.get(targetDirPath);
+
+    if (!createdDir) {
+      createdDir = mkdir(targetDirPath, { recursive: true });
+      this.#createdDirs.set(targetDirPath, createdDir);
+    }
+
+    await createdDir;
     await writeFile(targetPath, data, { encoding: "utf-8" });
 
     return targetPath;

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -1,7 +1,8 @@
 import console from "node:console";
 import { randomUUID } from "node:crypto";
-import { createWriteStream, existsSync, readFileSync } from "node:fs";
-import { lstat, mkdtemp, opendir, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { once } from "node:events";
+import { createReadStream, createWriteStream, existsSync, readFileSync, type ReadStream } from "node:fs";
+import { lstat, mkdtemp, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
@@ -55,6 +56,18 @@ import { resolveDumpAttachmentPath, UnsafeDumpPathError } from "./utils/safeDump
 
 const { version } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 const initRequired = "report is not initialised. Call the start() method first.";
+const defaultReadConcurrency = 64;
+const maxReadConcurrency = 256;
+
+const readConcurrency = () => {
+  const parsed = Number.parseInt(process.env.ALLURE_READ_CONCURRENCY ?? "", 10);
+
+  if (!Number.isFinite(parsed)) {
+    return defaultReadConcurrency;
+  }
+
+  return Math.min(maxReadConcurrency, Math.max(1, parsed));
+};
 
 const remoteReportParams = (ci: CiDescriptor | undefined): { repo?: string; branch?: string } => {
   const repo = ci?.repoName;
@@ -70,6 +83,20 @@ const REMOTE_UPLOAD_MAX_SIMULTANEOUS_FAILED = 5;
 const errorDetails = (err: unknown): string => (err instanceof Error ? (err.stack ?? err.message) : String(err));
 const isAbortError = (err: unknown): boolean =>
   typeof err === "object" && err !== null && "name" in err && err?.name === "AbortError";
+
+const closeReadStream = async (stream: ReadStream): Promise<void> => {
+  if (stream.closed) {
+    return;
+  }
+
+  const closed = once(stream, "close").then(() => undefined);
+
+  if (!stream.destroyed) {
+    stream.destroy();
+  }
+
+  await closed.catch(() => undefined);
+};
 
 export class AllureReport {
   readonly #reportName: string;
@@ -206,16 +233,25 @@ export class AllureReport {
       return;
     }
 
-    const dir = await opendir(resultsDirPath);
-
     try {
-      for await (const dirent of dir) {
-        if (dirent.isFile()) {
-          const path = await realpath(join(dirent.parentPath ?? dirent.path, dirent.name));
+      const entries = (await readdir(resultsDirPath, { withFileTypes: true }))
+        .filter((dirent) => dirent.isFile())
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const limit = pLimit(readConcurrency());
 
-          await this.readResult(new PathResultFile(path, dirent.name));
-        }
-      }
+      await Promise.all(
+        entries.map((dirent) =>
+          limit(async () => {
+            try {
+              const path = await realpath(join(resultsDirPath, dirent.name));
+
+              await this.readResult(new PathResultFile(path, dirent.name));
+            } catch (e) {
+              console.error(`can't read result file ${dirent.name}`, e);
+            }
+          }),
+        ),
+      );
     } catch (e) {
       console.error("can't read directory", e);
     }
@@ -235,6 +271,10 @@ export class AllureReport {
 
     for (const reader of this.#readers) {
       try {
+        if (reader.matches && !(await reader.matches(data))) {
+          continue;
+        }
+
         const processed = await reader.read(this.#store, data);
 
         if (processed) {
@@ -374,7 +414,7 @@ export class AllureReport {
       dumpArchiveWriteStream.on("error", (err) => finishDumpArchive(err));
     });
     const errMessage = (err: unknown) => (err instanceof Error ? err.message : String(err));
-    const addDumpEntry = async (data: Buffer, entryName: string): Promise<unknown | undefined> => {
+    const addDumpEntry = async (data: Buffer | ReadStream, entryName: string): Promise<unknown | undefined> => {
       try {
         await addEntry(data, { name: entryName });
         return undefined;
@@ -449,6 +489,18 @@ export class AllureReport {
 
           if (!content) {
             skipAttachment("attachment content is missing");
+            continue;
+          }
+
+          if (content instanceof PathResultFile) {
+            const stream = createReadStream(content.path);
+            const err = await addDumpEntry(stream, attachment.id);
+
+            if (err) {
+              await closeReadStream(stream);
+              skipAttachment(`failed to add attachment entry: ${errMessage(err)}`);
+            }
+
             continue;
           }
 

--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_ENVIRONMENT,
   DEFAULT_ENVIRONMENT_IDENTITY,
   type EnvironmentIdentity,
+  type EnvironmentDescriptor,
   type EnvironmentsConfig,
   type HistoryDataPoint,
   type HistoryTestResult,
@@ -136,6 +137,8 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
   readonly #realtimeSubscriber?: RealtimeSubscriber;
   readonly #allowedEnvironmentIds: Set<string>;
   readonly #retrySubstore: RetrySubstore;
+  readonly #testResultIdsByEnvironmentId: Map<string, Set<string>> = new Map();
+  readonly #cachedEnvironmentEntries: [string, EnvironmentDescriptor][] = [];
 
   readonly indexTestResultByTestCase: Map<string, TestResult[]> = new Map<string, TestResult[]>();
   readonly indexTestResultByEnvironmentId: Map<string, TestResult[]> = new Map<string, TestResult[]>();
@@ -223,6 +226,7 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     this.#reportVariables = reportVariables;
     this.#allowedEnvironmentIds = new Set(allowedEnvironments ?? []);
     this.#retrySubstore = new RetrySubstore();
+    this.#cachedEnvironmentEntries = Object.entries(this.#environmentsConfig);
 
     this.#addEnvironments(environments);
 
@@ -367,9 +371,15 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
       return;
     }
 
-    const existing = this.indexTestResultByEnvironmentId.get(environmentId);
-    if (existing?.some((tr) => tr.id === testResult.id)) {
+    const ids = this.#testResultIdsByEnvironmentId.get(environmentId);
+    if (ids?.has(testResult.id)) {
       return;
+    }
+
+    if (!ids) {
+      this.#testResultIdsByEnvironmentId.set(environmentId, new Set([testResult.id]));
+    } else {
+      ids.add(testResult.id);
     }
 
     index(this.indexTestResultByEnvironmentId, environmentId, testResult);
@@ -683,6 +693,14 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     await this.addCheckResult(result);
   }
 
+  /**
+   * Process a raw test result into the store.
+   *
+   * Time complexity: O(k) where k is the number of labels and attachments.
+   * Environment matching uses a cached entries array for O(m) lookup where m
+   * is the number of configured environments (typically < 10).
+   * History resolution is skipped entirely when no history is configured.
+   */
   async visitTestResult(raw: RawTestResult, context: ReaderContext): Promise<void> {
     const attachmentLinks: AttachmentLink[] = [];
     const testResult = testResultRawToState(
@@ -715,9 +733,7 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     const environmentIdentity =
       this.#environment ??
       (() => {
-        const match = Object.entries(this.#environmentsConfig).find(([, { matcher }]) =>
-          matcher({ labels: testResult.labels }),
-        );
+        const match = this.#cachedEnvironmentEntries.find(([, { matcher }]) => matcher({ labels: testResult.labels }));
 
         if (!match) {
           return DEFAULT_ENVIRONMENT_IDENTITY;
@@ -736,7 +752,7 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
         : calculateParametersHash(testResult.parameters);
     testResult.retryHash = calculateRetryHash(testResult.testCase?.id, parametersHash, environmentIdentity.id);
 
-    const trHistory = await this.historyByTr(testResult);
+    const trHistory = this.#history ? await this.historyByTr(testResult) : undefined;
 
     if (trHistory !== undefined) {
       testResult.transition = getStatusTransition(testResult, trHistory);
@@ -1112,7 +1128,7 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     return this.indexAttachmentByTestResult.get(trId) ?? [];
   }
 
-  async retriesByTr(tr?: TestResult): Promise<TestResult[]> {
+  #retriesByTr(tr?: TestResult): TestResult[] {
     if (!tr) {
       return [];
     }
@@ -1120,13 +1136,17 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     return this.#retrySubstore.retriesByTr(tr);
   }
 
-  async retriesByTrId(trId: string): Promise<TestResult[]> {
-    const tr = await this.testResultById(trId);
-
-    return this.retriesByTr(tr);
+  async retriesByTr(tr?: TestResult): Promise<TestResult[]> {
+    return this.#retriesByTr(tr);
   }
 
-  async historyByTr(tr: TestResult): Promise<HistoryTestResult[] | undefined> {
+  async retriesByTrId(trId: string): Promise<TestResult[]> {
+    const tr = this.#testResults.get(trId);
+
+    return this.#retriesByTr(tr);
+  }
+
+  #historyByTr(tr: TestResult): HistoryTestResult[] | undefined {
     if (!this.#history) {
       return undefined;
     }
@@ -1140,18 +1160,55 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     return selectHistoryTestResults(this.#historyPoints, historyIdCandidates);
   }
 
+  /**
+   * Get historical test results for a given test result.
+   *
+   * Returns `undefined` when no history source is configured.
+   * Returns an empty array when history is configured but no matching
+   * history ID candidates are found.
+   *
+   * This method is async for API compatibility, but the underlying
+   * lookup is synchronous.
+   */
+  async historyByTr(tr: TestResult): Promise<HistoryTestResult[] | undefined> {
+    return this.#historyByTr(tr);
+  }
+
   async historyByTrId(trId: string): Promise<HistoryTestResult[] | undefined> {
-    const tr = await this.testResultById(trId);
+    const tr = this.#testResults.get(trId);
 
     if (!tr) {
       return undefined;
     }
 
-    return this.historyByTr(tr);
+    return this.#historyByTr(tr);
   }
 
   async fixturesByTrId(trId: string): Promise<TestFixtureResult[]> {
     return this.indexFixturesByTestResult.get(trId) ?? [];
+  }
+
+  async relatedByTestResultIds(trIds: readonly string[]) {
+    const attachmentsByTrId = new Map<string, AttachmentLink[]>();
+    const fixturesByTrId = new Map<string, TestFixtureResult[]>();
+    const historyByTrId = new Map<string, HistoryTestResult[] | undefined>();
+    const retriesByTrId = new Map<string, TestResult[]>();
+
+    for (const trId of trIds) {
+      const tr = this.#testResults.get(trId);
+
+      attachmentsByTrId.set(trId, this.indexAttachmentByTestResult.get(trId) ?? []);
+      fixturesByTrId.set(trId, this.indexFixturesByTestResult.get(trId) ?? []);
+      retriesByTrId.set(trId, this.#retriesByTr(tr));
+      historyByTrId.set(trId, tr ? this.#historyByTr(tr) : undefined);
+    }
+
+    return {
+      attachmentsByTrId,
+      fixturesByTrId,
+      historyByTrId,
+      retriesByTrId,
+    };
   }
 
   // aggregate API
@@ -1232,8 +1289,7 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
 
       statistic.total++;
 
-      // This is fine because retriesByTr does not contain any async operations
-      const retries = await this.retriesByTr(tr);
+      const retries = this.#retriesByTr(tr);
 
       if (retries.length > 0) {
         statistic.retries = (statistic.retries ?? 0) + 1;
@@ -1538,6 +1594,10 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     });
 
     this.#retrySubstore.restoreIngestOrder(testResultIdsIngestOrder, (id) => this.#testResults.has(id));
+    // Rebuild the O(1) ID lookup Set from the restored array index
+    this.indexTestResultByEnvironmentId.forEach((trs, envId) => {
+      this.#testResultIdsByEnvironmentId.set(envId, new Set(trs.map((tr) => tr.id)));
+    });
 
     updateMapWithRecord(this.#attachments, attachments);
     updateMapWithRecord(this.#testCases, testCases);

--- a/packages/core/src/utils/realtimeUpdateScheduler.ts
+++ b/packages/core/src/utils/realtimeUpdateScheduler.ts
@@ -13,6 +13,10 @@ export interface RealtimeUpdateSchedulerOptions {
  * cooldown, runs the worker once, and runs one more pass if more requests arrived
  * while the worker was active. `close()` stops new requests and waits for already
  * scheduled work before final report generation continues.
+ *
+ * Dynamic cooldown: after each update completes, the scheduler waits at least as
+ * long as the update took before starting the next one. This prevents plugin
+ * overload when results arrive faster than reports can be regenerated.
  */
 export class RealtimeUpdateScheduler {
   readonly #worker: () => Promise<void>;
@@ -93,7 +97,16 @@ export class RealtimeUpdateScheduler {
 
       this.#phase = "running";
       this.#dirty = false;
+      const start = Date.now();
       await this.#worker();
+      const elapsed = Date.now() - start;
+
+      // Dynamic cooldown: wait at least as long as the update took before
+      // scheduling the next one. This prevents update storms when results
+      // arrive faster than plugins can regenerate reports.
+      if (this.#dirty && elapsed > this.#cooldownMs) {
+        await setTimeout(elapsed - this.#cooldownMs);
+      }
     } while (this.#dirty);
   };
 }

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -6,7 +6,7 @@ import { setTimeout } from "node:timers/promises";
 
 import type { TestResult } from "@allurereport/core-api";
 import type { Plugin, QualityGateRule } from "@allurereport/plugin-api";
-import { BufferResultFile } from "@allurereport/reader-api";
+import { BufferResultFile, type ResultsReader } from "@allurereport/reader-api";
 import { generateSummary } from "@allurereport/summary";
 import { attachment, step } from "allure-js-commons";
 import type { Mock, Mocked } from "vitest";
@@ -154,6 +154,83 @@ describe("report", () => {
     await expect(() => allureReport.readResult(resultFile)).rejects.toThrowError(
       "report is not initialised. Call the start() method first",
     );
+  });
+
+  it("should skip readers whose matcher rejects the result file", async () => {
+    const config = await resolveConfig({
+      name: "Allure Report",
+    });
+    const rejectedReader: ResultsReader = {
+      matches: vi.fn().mockReturnValue(false),
+      read: vi.fn().mockResolvedValue(true),
+      readerId: () => "rejected",
+    };
+    const acceptedReader: ResultsReader = {
+      matches: vi.fn().mockReturnValue(true),
+      read: vi.fn().mockResolvedValue(true),
+      readerId: () => "accepted",
+    };
+    const allureReport = new AllureReport({
+      ...config,
+      readers: [rejectedReader, acceptedReader],
+    });
+    const resultFile = new BufferResultFile(Buffer.from("some content", "utf-8"), "some-name.txt");
+
+    await allureReport.start();
+    await allureReport.readResult(resultFile);
+
+    expect(rejectedReader.matches).toHaveBeenCalledWith(resultFile);
+    expect(rejectedReader.read).not.toHaveBeenCalled();
+    expect(acceptedReader.read).toHaveBeenCalledWith(allureReport.store, resultFile);
+  });
+
+  it("should read result directory files with bounded concurrency", async () => {
+    const previousConcurrency = process.env.ALLURE_READ_CONCURRENCY;
+    const resultsDir = await mkdtemp(join(tmpdir(), "allure3-read-directory-"));
+    const config = await resolveConfig({
+      name: "Allure Report",
+    });
+    const readFiles: string[] = [];
+    let activeReads = 0;
+    let maxActiveReads = 0;
+    const reader: ResultsReader = {
+      matches: vi.fn().mockReturnValue(true),
+      read: vi.fn(async (_visitor, data) => {
+        readFiles.push(data.getOriginalFileName());
+        activeReads++;
+        maxActiveReads = Math.max(maxActiveReads, activeReads);
+        await setTimeout(20);
+        activeReads--;
+
+        return true;
+      }),
+      readerId: () => "bounded",
+    };
+
+    process.env.ALLURE_READ_CONCURRENCY = "2";
+
+    try {
+      await writeFile(join(resultsDir, "b-result.json"), "{}");
+      await writeFile(join(resultsDir, "a-result.json"), "{}");
+      await writeFile(join(resultsDir, "c-result.json"), "{}");
+
+      const allureReport = new AllureReport({
+        ...config,
+        readers: [reader],
+      });
+
+      await allureReport.start();
+      await allureReport.readDirectory(resultsDir);
+
+      expect([...readFiles].sort()).toEqual(["a-result.json", "b-result.json", "c-result.json"]);
+      expect(maxActiveReads).toBe(2);
+    } finally {
+      if (previousConcurrency === undefined) {
+        delete process.env.ALLURE_READ_CONCURRENCY;
+      } else {
+        process.env.ALLURE_READ_CONCURRENCY = previousConcurrency;
+      }
+    }
   });
 
   it("should call plugins in specified order on start()", async () => {

--- a/packages/core/test/store/store.test.ts
+++ b/packages/core/test/store/store.test.ts
@@ -6,7 +6,7 @@ import {
   fallbackTestCaseIdLabelName,
 } from "@allurereport/core-api";
 import { type AllureStoreDump, md5 } from "@allurereport/plugin-api";
-import type { RawGlobals, RawTestAttachment, RawTestResult } from "@allurereport/reader-api";
+import type { RawFixtureResult, RawGlobals, RawTestAttachment, RawTestResult } from "@allurereport/reader-api";
 import { BufferResultFile } from "@allurereport/reader-api";
 import { describe, expect, it, vi } from "vitest";
 
@@ -4144,6 +4144,28 @@ describe("dump state", () => {
     expect(env2Test2Retries.map(({ name }) => name)).toEqual(["Env 2, test 2, attempt 1"]);
   });
 
+  it("should not duplicate environment test results when restoring the same dump repeatedly", async () => {
+    const sourceStore = new DefaultAllureStore({ environment: "qa" });
+    const rawTr: RawTestResult = {
+      name: "restored env test",
+      status: "passed",
+      testId: "restored-env-test",
+      historyId: "restored-env-test",
+    };
+
+    await sourceStore.visitTestResult(rawTr, { readerId });
+
+    const targetStore = new DefaultAllureStore();
+    const dump = sourceStore.dumpState();
+
+    await targetStore.restoreState(dump);
+    await targetStore.restoreState(dump);
+
+    const restoredResults = await targetStore.testResultsByEnvironmentId("qa", { includeHidden: true });
+
+    expect(restoredResults.map(({ name }) => name)).toEqual(["restored env test"]);
+  });
+
   it("should merge two dumps with no envs", async () => {
     let ndumps = 1;
 
@@ -4285,6 +4307,82 @@ describe("dictionary safety", () => {
     expect(byEnv["__proto__"]).toHaveLength(1);
     expect(byEnv["constructor"]).toHaveLength(1);
     expect(byEnv["toString"]).toHaveLength(1);
+  });
+});
+
+describe("relatedByTestResultIds", () => {
+  it("should return batch data equivalent to single-result store lookups", async () => {
+    const testHistoryId = `${md5("case-id")}.${md5("")}`;
+    const retryResultId = md5("retry-result");
+    const latestResultId = md5("latest-result");
+    const store = new DefaultAllureStore({
+      history: new AllureTestHistory([
+        {
+          uuid: "history-point",
+          name: "History Point",
+          timestamp: 1,
+          knownTestCaseIds: [],
+          metrics: {},
+          url: "https://example.com/history",
+          testResults: {
+            "history-result": {
+              id: "history-result",
+              name: "historical test",
+              status: "failed",
+              url: "https://example.com/history/history-result",
+              historyId: testHistoryId,
+            },
+          },
+        },
+      ]),
+    });
+    const attachment: RawTestAttachment = {
+      type: "attachment",
+      name: "stdout",
+      originalFileName: "stdout.txt",
+    };
+    const retryResult: RawTestResult = {
+      uuid: "retry-result",
+      name: "retry",
+      fullName: "sample test",
+      testId: "case-id",
+      status: "failed",
+      start: 1,
+    };
+    const latestResult: RawTestResult = {
+      uuid: "latest-result",
+      name: "latest",
+      fullName: "sample test",
+      testId: "case-id",
+      status: "passed",
+      start: 2,
+      steps: [attachment],
+    };
+    const fixture: RawFixtureResult = {
+      uuid: "fixture-id",
+      type: "before",
+      name: "setup",
+      testResults: ["latest-result"],
+      status: "passed",
+    };
+
+    await store.readHistory();
+    await store.visitTestResult(retryResult, { readerId });
+    await store.visitTestResult(latestResult, { readerId });
+    await store.visitTestFixtureResult(fixture, { readerId });
+
+    const related = await store.relatedByTestResultIds([latestResultId, retryResultId]);
+
+    expect(related.attachmentsByTrId.get(latestResultId)).toEqual(await store.attachmentsByTrId(latestResultId));
+    expect(related.fixturesByTrId.get(latestResultId)).toEqual(await store.fixturesByTrId(latestResultId));
+    expect(related.historyByTrId.get(latestResultId)).toEqual(await store.historyByTrId(latestResultId));
+    expect(related.retriesByTrId.get(latestResultId)).toEqual(await store.retriesByTrId(latestResultId));
+    expect(related.retriesByTrId.get(latestResultId)).toEqual([
+      expect.objectContaining({
+        id: retryResultId,
+        isRetry: true,
+      }),
+    ]);
   });
 });
 

--- a/packages/core/test/util/realtimeUpdateScheduler.test.ts
+++ b/packages/core/test/util/realtimeUpdateScheduler.test.ts
@@ -79,6 +79,36 @@ describe("RealtimeUpdateScheduler", () => {
     expect(worker).toBeCalledTimes(2);
   });
 
+  it("should delay a dirty follow-up by at least the previous update duration after completion", async () => {
+    const firstUpdateStarted = createSignal();
+    const updateStarts: number[] = [];
+    const updateCompletions: number[] = [];
+    let scheduler!: RealtimeUpdateScheduler;
+    let calls = 0;
+    const cooldownMs = 20;
+    const longUpdateMs = 80;
+    const worker = vi.fn(async () => {
+      calls += 1;
+      updateStarts.push(Date.now());
+
+      if (calls === 1) {
+        firstUpdateStarted.resolve();
+        scheduler.request();
+        await setTimeout(longUpdateMs);
+        updateCompletions.push(Date.now());
+      }
+    });
+    scheduler = new RealtimeUpdateScheduler(worker, { cooldownMs });
+
+    scheduler.request();
+    await firstUpdateStarted.promise;
+    await scheduler.flush();
+
+    expect(worker).toBeCalledTimes(2);
+    expect(updateCompletions).toHaveLength(1);
+    expect(updateStarts[1] - updateCompletions[0]).toBeGreaterThanOrEqual(longUpdateMs);
+  });
+
   it("should not schedule a follow-up for requests before update starts", async () => {
     const worker = vi.fn().mockResolvedValue(undefined);
     const scheduler = new RealtimeUpdateScheduler(worker, { cooldownMs: 10 });

--- a/packages/plugin-allure2/src/generators.ts
+++ b/packages/plugin-allure2/src/generators.ts
@@ -32,6 +32,12 @@ import type { Allure2DataWriter, ReportFile } from "./writer.js";
 
 export type TemplateManifest = Record<string, string>;
 
+const writeConcurrently = async <T>(items: readonly T[], write: (item: T) => Promise<void>, concurrency = 64) => {
+  for (let i = 0; i < items.length; i += concurrency) {
+    await Promise.all(items.slice(i, i + concurrency).map(write));
+  }
+};
+
 const template = `<!DOCTYPE html>
 <html dir="ltr" lang="{{reportLanguage}}">
 <head>
@@ -71,6 +77,8 @@ const template = `<!DOCTYPE html>
 </body>
 </html>
 `;
+
+const compiledTemplate = Handlebars.compile(template);
 
 export const getPackageRoot = async (): Promise<string> => {
   const packageJsonPath = await findUp("package.json", {
@@ -122,7 +130,6 @@ export const generateStaticFiles = async (payload: {
 }) => {
   const packageRoot = await getPackageRoot();
   const { reportName, reportLanguage, singleFile, reportFiles, reportDataFiles, reportUuid, allureVersion } = payload;
-  const compile = Handlebars.compile(template);
   const manifest = await readTemplateManifest(packageRoot, singleFile);
   const headTags: string[] = [];
   const bodyTags: string[] = [];
@@ -190,7 +197,7 @@ export const generateStaticFiles = async (payload: {
   };
 
   try {
-    const html = compile({
+    const html = compiledTemplate({
       headTags: headTags.join("\n"),
       bodyTags: bodyTags.join("\n"),
       reportFilesScript: createReportDataScript(reportDataFiles),
@@ -278,9 +285,7 @@ export const generateTimelineData = async (writer: Allure2DataWriter, tests: All
 };
 
 export const generateTestResults = async (writer: Allure2DataWriter, tests: Allure2TestResult[]) => {
-  for (const test of tests) {
-    await writer.writeTestCase(test);
-  }
+  await writeConcurrently(tests, (test) => writer.writeTestCase(test));
 };
 
 export const generateSummaryJson = async (

--- a/packages/plugin-allure2/src/plugin.ts
+++ b/packages/plugin-allure2/src/plugin.ts
@@ -6,6 +6,7 @@ import {
   type PluginSummary,
   createPluginSummary,
   preciseTreeLabels,
+  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 
 import { convertTestResult } from "./converters.js";
@@ -40,12 +41,16 @@ export class Allure2Plugin implements Plugin {
     const categories = (await store.metadataByKey<Allure2Category[]>("allure2_categories")) ?? [];
     const environmentItems = (await store.metadataByKey<EnvironmentItem[]>("allure_environment")) ?? [];
     const tests = await store.allTestResults({ includeRetries: true });
+    const related = await relatedByTestResultIds(
+      store,
+      tests.map(({ id }) => id),
+    );
     const allTr: Allure2TestResult[] = [];
 
     for (const value of tests) {
-      const fixtures = await store.fixturesByTrId(value.id);
-      const retries = await store.retriesByTrId(value.id);
-      const history = (await store.historyByTrId(value.id)) ?? [];
+      const fixtures = related.fixturesByTrId.get(value.id) ?? [];
+      const retries = related.retriesByTrId.get(value.id) ?? [];
+      const history = related.historyByTrId.get(value.id) ?? [];
       const allure2TestResult = convertTestResult(
         {
           attachmentMap,

--- a/packages/plugin-allure2/src/plugin.ts
+++ b/packages/plugin-allure2/src/plugin.ts
@@ -6,7 +6,6 @@ import {
   type PluginSummary,
   createPluginSummary,
   preciseTreeLabels,
-  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 
 import { convertTestResult } from "./converters.js";
@@ -41,10 +40,7 @@ export class Allure2Plugin implements Plugin {
     const categories = (await store.metadataByKey<Allure2Category[]>("allure2_categories")) ?? [];
     const environmentItems = (await store.metadataByKey<EnvironmentItem[]>("allure_environment")) ?? [];
     const tests = await store.allTestResults({ includeRetries: true });
-    const related = await relatedByTestResultIds(
-      store,
-      tests.map(({ id }) => id),
-    );
+    const related = await store.relatedByTestResultIds(tests.map(({ id }) => id));
     const allTr: Allure2TestResult[] = [];
 
     for (const value of tests) {

--- a/packages/plugin-allure2/src/writer.ts
+++ b/packages/plugin-allure2/src/writer.ts
@@ -22,30 +22,44 @@ export interface Allure2DataWriter {
 }
 
 export class FileSystemReportDataWriter implements Allure2DataWriter {
-  constructor(private readonly output: string) {}
+  readonly #dataDir: string;
+  readonly #widgetsDir: string;
+  readonly #testCasesDir: string;
+  readonly #attachmentsDir: string;
+  readonly #dataDirReady: Promise<string | undefined>;
+  readonly #widgetsDirReady: Promise<string | undefined>;
+  readonly #testCasesDirReady: Promise<string | undefined>;
+  readonly #attachmentsDirReady: Promise<string | undefined>;
+
+  constructor(private readonly output: string) {
+    this.#dataDir = resolve(this.output, "data");
+    this.#widgetsDir = resolve(this.output, "widgets");
+    this.#testCasesDir = resolve(this.output, "data", "test-cases");
+    this.#attachmentsDir = resolve(this.output, "data", "attachments");
+    this.#dataDirReady = mkdir(this.#dataDir, { recursive: true });
+    this.#widgetsDirReady = mkdir(this.#widgetsDir, { recursive: true });
+    this.#testCasesDirReady = mkdir(this.#testCasesDir, { recursive: true });
+    this.#attachmentsDirReady = mkdir(this.#attachmentsDir, { recursive: true });
+  }
 
   async writeData(fileName: string, data: any): Promise<void> {
-    const distFolder = resolve(this.output, "data");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, fileName), JSON.stringify(data), { encoding: "utf-8" });
+    await this.#dataDirReady;
+    await writeFile(resolve(this.#dataDir, fileName), JSON.stringify(data), { encoding: "utf-8" });
   }
 
   async writeWidget(fileName: string, data: any): Promise<void> {
-    const distFolder = resolve(this.output, "widgets");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, fileName), JSON.stringify(data), { encoding: "utf-8" });
+    await this.#widgetsDirReady;
+    await writeFile(resolve(this.#widgetsDir, fileName), JSON.stringify(data), { encoding: "utf-8" });
   }
 
   async writeTestCase(test: Allure2TestResult): Promise<void> {
-    const distFolder = resolve(this.output, "data", "test-cases");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, `${test.uid}.json`), JSON.stringify(test), { encoding: "utf-8" });
+    await this.#testCasesDirReady;
+    await writeFile(resolve(this.#testCasesDir, `${test.uid}.json`), JSON.stringify(test), { encoding: "utf-8" });
   }
 
   async writeAttachment(source: string, file: ResultFile): Promise<void> {
-    const distFolder = resolve(this.output, "data", "attachments");
-    await mkdir(distFolder, { recursive: true });
-    await file.writeTo(resolve(distFolder, source));
+    await this.#attachmentsDirReady;
+    await file.writeTo(resolve(this.#attachmentsDir, source));
   }
 }
 

--- a/packages/plugin-api/src/store.ts
+++ b/packages/plugin-api/src/store.ts
@@ -65,7 +65,7 @@ export interface AllureStore {
   retriesByTrId: (trId: string) => Promise<TestResult[]>;
   historyByTrId: (trId: string) => Promise<HistoryTestResult[] | undefined>;
   fixturesByTrId: (trId: string) => Promise<TestFixtureResult[]>;
-  relatedByTestResultIds?: (trIds: readonly string[]) => Promise<TestResultRelatedData>;
+  relatedByTestResultIds: (trIds: readonly string[]) => Promise<TestResultRelatedData>;
   // aggregate api
   failedTestResults: () => Promise<TestResult[]>;
   unknownFailedTestResults: () => Promise<TestResult[]>;
@@ -85,43 +85,6 @@ export interface AllureStore {
   envVariables: (env: string) => Promise<Record<string, any>>;
   envVariablesByEnvironmentId: (envId: string) => Promise<Record<string, any>>;
 }
-
-export const relatedByTestResultIds = async (
-  store: AllureStore,
-  trIds: readonly string[],
-): Promise<TestResultRelatedData> => {
-  if (store.relatedByTestResultIds) {
-    return store.relatedByTestResultIds(trIds);
-  }
-
-  const attachmentsByTrId = new Map<string, AttachmentLink[]>();
-  const fixturesByTrId = new Map<string, TestFixtureResult[]>();
-  const historyByTrId = new Map<string, HistoryTestResult[] | undefined>();
-  const retriesByTrId = new Map<string, TestResult[]>();
-
-  await Promise.all(
-    trIds.map(async (trId) => {
-      const [attachments, fixtures, history, retries] = await Promise.all([
-        store.attachmentsByTrId(trId),
-        store.fixturesByTrId(trId),
-        store.historyByTrId(trId),
-        store.retriesByTrId(trId),
-      ]);
-
-      attachmentsByTrId.set(trId, attachments);
-      fixturesByTrId.set(trId, fixtures);
-      historyByTrId.set(trId, history);
-      retriesByTrId.set(trId, retries);
-    }),
-  );
-
-  return {
-    attachmentsByTrId,
-    fixturesByTrId,
-    historyByTrId,
-    retriesByTrId,
-  };
-};
 
 export interface AllureStoreDump {
   testResults: Record<string, TestResult>;

--- a/packages/plugin-api/src/store.ts
+++ b/packages/plugin-api/src/store.ts
@@ -20,6 +20,13 @@ import type { ResultFile } from "./resultFile.js";
 
 export type TestResultFilter = (testResult: TestResult) => boolean;
 
+export interface TestResultRelatedData {
+  attachmentsByTrId: Map<string, AttachmentLink[]>;
+  fixturesByTrId: Map<string, TestFixtureResult[]>;
+  historyByTrId: Map<string, HistoryTestResult[] | undefined>;
+  retriesByTrId: Map<string, TestResult[]>;
+}
+
 export interface AllureStore {
   // base state
   allTestCases: () => Promise<TestCase[]>;
@@ -58,6 +65,7 @@ export interface AllureStore {
   retriesByTrId: (trId: string) => Promise<TestResult[]>;
   historyByTrId: (trId: string) => Promise<HistoryTestResult[] | undefined>;
   fixturesByTrId: (trId: string) => Promise<TestFixtureResult[]>;
+  relatedByTestResultIds?: (trIds: readonly string[]) => Promise<TestResultRelatedData>;
   // aggregate api
   failedTestResults: () => Promise<TestResult[]>;
   unknownFailedTestResults: () => Promise<TestResult[]>;
@@ -77,6 +85,43 @@ export interface AllureStore {
   envVariables: (env: string) => Promise<Record<string, any>>;
   envVariablesByEnvironmentId: (envId: string) => Promise<Record<string, any>>;
 }
+
+export const relatedByTestResultIds = async (
+  store: AllureStore,
+  trIds: readonly string[],
+): Promise<TestResultRelatedData> => {
+  if (store.relatedByTestResultIds) {
+    return store.relatedByTestResultIds(trIds);
+  }
+
+  const attachmentsByTrId = new Map<string, AttachmentLink[]>();
+  const fixturesByTrId = new Map<string, TestFixtureResult[]>();
+  const historyByTrId = new Map<string, HistoryTestResult[] | undefined>();
+  const retriesByTrId = new Map<string, TestResult[]>();
+
+  await Promise.all(
+    trIds.map(async (trId) => {
+      const [attachments, fixtures, history, retries] = await Promise.all([
+        store.attachmentsByTrId(trId),
+        store.fixturesByTrId(trId),
+        store.historyByTrId(trId),
+        store.retriesByTrId(trId),
+      ]);
+
+      attachmentsByTrId.set(trId, attachments);
+      fixturesByTrId.set(trId, fixtures);
+      historyByTrId.set(trId, history);
+      retriesByTrId.set(trId, retries);
+    }),
+  );
+
+  return {
+    attachmentsByTrId,
+    fixturesByTrId,
+    historyByTrId,
+    retriesByTrId,
+  };
+};
 
 export interface AllureStoreDump {
   testResults: Record<string, TestResult>;

--- a/packages/plugin-api/src/utils/tree.ts
+++ b/packages/plugin-api/src/utils/tree.ts
@@ -7,30 +7,44 @@ import {
   type TreeGroup,
   type TreeLeaf,
   type WithChildren,
-  createDictionary,
-  findByLabelName,
 } from "@allurereport/core-api";
 import { emptyStatistic } from "@allurereport/core-api";
 
 import { md5 } from "./misc.js";
 
-const addLeaf = (node: WithChildren, nodeId: string) => {
+const addLeaf = (childLeaves: WeakMap<WithChildren, Set<string>>, node: WithChildren, nodeId: string) => {
   if (node.leaves === undefined) {
     node.leaves = [];
   }
-  if (node.leaves.find((value) => value === nodeId)) {
+  let leaves = childLeaves.get(node);
+
+  if (!leaves) {
+    leaves = new Set(node.leaves);
+    childLeaves.set(node, leaves);
+  }
+
+  if (leaves.has(nodeId)) {
     return;
   }
+  leaves.add(nodeId);
   node.leaves.push(nodeId);
 };
 
-const addGroup = (node: WithChildren, nodeId: string) => {
+const addGroup = (childGroups: WeakMap<WithChildren, Set<string>>, node: WithChildren, nodeId: string) => {
   if (node.groups === undefined) {
     node.groups = [];
   }
-  if (node.groups.find((value) => value === nodeId)) {
+  let groups = childGroups.get(node);
+
+  if (!groups) {
+    groups = new Set(node.groups);
+    childGroups.set(node, groups);
+  }
+
+  if (groups.has(nodeId)) {
     return;
   }
+  groups.add(nodeId);
   node.groups.push(nodeId);
 };
 
@@ -41,9 +55,11 @@ const createTree = <T, L, G>(
   groupFactory: (parentGroup: string | undefined, groupClassifier: string) => TreeGroup<G>,
   addLeafToGroup: (group: TreeGroup<G>, leaf: TreeLeaf<L>) => void = () => {},
 ): TreeData<L, G> => {
-  const groupsByClassifier = createDictionary<Record<string, TreeGroup<G>>>();
+  const groupsByClassifier = new Map<string, Map<string, TreeGroup<G>>>();
   const leavesById: Record<string, TreeLeaf<L>> = {};
   const groupsById: Record<string, TreeGroup<G>> = {};
+  const childLeaves = new WeakMap<WithChildren, Set<string>>();
+  const childGroups = new WeakMap<WithChildren, Set<string>>();
   const root: WithChildren = { groups: [], leaves: [] };
 
   for (const item of data) {
@@ -59,39 +75,49 @@ const createTree = <T, L, G>(
         break;
       }
 
-      parentGroups = layer.flatMap((group) => {
-        return parentGroups.flatMap((parentGroup) => {
-          const parentId = "nodeId" in parentGroup ? (parentGroup.nodeId as string) : "";
+      const nextParentGroups: TreeGroup<G>[] = [];
+      const nextParentGroupIds = new Set<string>();
 
-          if (groupsByClassifier[parentId] === undefined) {
-            groupsByClassifier[parentId] = createDictionary<TreeGroup<G>>();
+      for (const group of layer) {
+        for (const parentGroup of parentGroups) {
+          const parentId = "nodeId" in parentGroup ? (parentGroup.nodeId as string) : "";
+          let groupsByParent = groupsByClassifier.get(parentId);
+
+          if (groupsByParent === undefined) {
+            groupsByParent = new Map<string, TreeGroup<G>>();
+            groupsByClassifier.set(parentId, groupsByParent);
           }
 
-          if (groupsByClassifier[parentId][group] === undefined) {
+          if (groupsByParent.get(group) === undefined) {
             const newGroup = groupFactory(parentId, group);
             if (!newGroup || typeof newGroup !== "object" || typeof newGroup.nodeId !== "string") {
-              return [];
+              continue;
             }
 
-            groupsByClassifier[parentId][group] = newGroup;
+            groupsByParent.set(group, newGroup);
             groupsById[newGroup.nodeId] = newGroup;
           }
 
-          const currentGroup = groupsByClassifier[parentId][group];
+          const currentGroup = groupsByParent.get(group);
           if (!currentGroup || typeof currentGroup !== "object") {
-            return [];
+            continue;
           }
 
-          addGroup(parentGroup, currentGroup.nodeId);
+          addGroup(childGroups, parentGroup, currentGroup.nodeId);
           addLeafToGroup(currentGroup, leaf);
 
-          return [currentGroup];
-        });
-      });
+          if (!nextParentGroupIds.has(currentGroup.nodeId)) {
+            nextParentGroupIds.add(currentGroup.nodeId);
+            nextParentGroups.push(currentGroup);
+          }
+        }
+      }
+
+      parentGroups = nextParentGroups;
     }
 
     parentGroups.forEach((parentGroup) => {
-      addLeaf(parentGroup, leaf.nodeId);
+      addLeaf(childLeaves, parentGroup, leaf.nodeId);
     });
   }
 
@@ -104,20 +130,39 @@ const createTree = <T, L, G>(
   };
 };
 
-export const byLabels = (item: TestResult, labelNames: string[]): string[][] => {
-  return labelNames
-    .map(
-      (labelName) =>
-        item.labels.filter((label) => labelName === label.name).map((label) => label.value ?? "__unknown") ?? [],
-    )
-    .filter((layer) => layer.length > 0);
+const byLabelsWithFallback = (item: TestResult, labelNames: string[], fallbackValue: string): string[][] => {
+  const labelsByName = new Map<string, string[]>();
+
+  for (const label of item.labels) {
+    const values = labelsByName.get(label.name) ?? [];
+
+    values.push(label.value ?? fallbackValue);
+    labelsByName.set(label.name, values);
+  }
+
+  return labelNames.map((labelName) => labelsByName.get(labelName) ?? []).filter((layer) => layer.length > 0);
 };
 
+export const byLabels = (item: TestResult, labelNames: string[]): string[][] =>
+  byLabelsWithFallback(item, labelNames, "__unknown");
+
 export const filterTreeLabels = (data: TestResult[], labelNames: string[]) => {
-  return [...labelNames]
-    .reverse()
-    .filter((labelName) => data.find((item) => findByLabelName(item.labels, labelName)))
-    .reverse();
+  const requested = new Set(labelNames);
+  const found = new Set<string>();
+
+  for (const item of data) {
+    for (const label of item.labels) {
+      if (requested.has(label.name)) {
+        found.add(label.name);
+      }
+    }
+
+    if (found.size === requested.size) {
+      break;
+    }
+  }
+
+  return labelNames.filter((labelName) => found.has(labelName));
 };
 
 export const createTreeByLabels = <T = TestResult, L = DefaultTreeLeaf, G = DefaultTreeGroup>(
@@ -219,15 +264,84 @@ export const preciseTreeLabels = <T = TestResult>(
   trs: T[],
   labelNamesAccessor: (tr: T) => string[] = (tr: T) => (tr as TestResult).labels.map(({ name }) => name),
 ) => {
-  const result = new Set<string>();
+  const requested = new Set(labelNames);
+  const found = new Set<string>();
 
-  for (const labelName of labelNames) {
-    if (trs.some((tr) => labelNamesAccessor(tr).includes(labelName))) {
-      result.add(labelName);
+  for (const tr of trs) {
+    for (const labelName of labelNamesAccessor(tr)) {
+      if (requested.has(labelName)) {
+        found.add(labelName);
+      }
+    }
+
+    if (found.size === requested.size) {
+      break;
     }
   }
 
-  return Array.from(result);
+  const emitted = new Set<string>();
+
+  return labelNames.filter((labelName) => {
+    if (!found.has(labelName) || emitted.has(labelName)) {
+      return false;
+    }
+
+    emitted.add(labelName);
+    return true;
+  });
+};
+
+export const processTree = <L, G>(
+  tree: TreeData<L, G>,
+  options: {
+    filter?: (leaf: TreeLeaf<L>) => boolean;
+    sort?: Comparator<TreeLeaf<L>>;
+    transform?: (leaf: TreeLeaf<L>, idx: number) => TreeLeaf<L>;
+  },
+) => {
+  const visitedGroups = new Set<string>();
+  const { root, leavesById, groupsById } = tree;
+  const processGroup = (group: TreeGroup<G>) => {
+    if (group.groups?.length) {
+      group.groups.forEach((groupId) => {
+        const subGroup = groupsById[groupId];
+
+        if (!subGroup || visitedGroups.has(groupId)) {
+          return;
+        }
+
+        processGroup(subGroup);
+        visitedGroups.add(groupId);
+      });
+    }
+
+    if (group.leaves?.length) {
+      if (options.filter) {
+        group.leaves = group.leaves.filter((leaveId) => options.filter!(leavesById[leaveId]));
+      }
+
+      if (options.sort) {
+        group.leaves = group.leaves.sort((a, b) => {
+          const leafA = leavesById[a];
+          const leafB = leavesById[b];
+
+          return options.sort!(leafA, leafB);
+        });
+      }
+
+      if (options.transform) {
+        group.leaves.forEach((leafId, i) => {
+          leavesById[leafId] = options.transform!(leavesById[leafId], i);
+        });
+      }
+    }
+
+    return group;
+  };
+
+  processGroup(root as TreeGroup<G>);
+
+  return tree;
 };
 
 /**
@@ -237,36 +351,7 @@ export const preciseTreeLabels = <T = TestResult>(
  * @param predicate
  */
 export const filterTree = <L, G>(tree: TreeData<L, G>, predicate: (leaf: TreeLeaf<L>) => boolean) => {
-  const visitedGroups = new Set<string>();
-  const { root, leavesById, groupsById } = tree;
-  const filterGroupLeaves = (group: TreeGroup<G>) => {
-    if (!predicate) {
-      return group;
-    }
-
-    if (group.groups?.length) {
-      group.groups.forEach((groupId) => {
-        const subGroup = groupsById[groupId];
-
-        if (!subGroup || visitedGroups.has(groupId)) {
-          return;
-        }
-
-        filterGroupLeaves(subGroup);
-        visitedGroups.add(groupId);
-      });
-    }
-
-    if (group.leaves?.length) {
-      group.leaves = group.leaves.filter((leaveId) => predicate(leavesById[leaveId]));
-    }
-
-    return group;
-  };
-
-  filterGroupLeaves(root as TreeGroup<G>);
-
-  return tree;
+  return processTree(tree, { filter: predicate });
 };
 
 /**
@@ -276,39 +361,7 @@ export const filterTree = <L, G>(tree: TreeData<L, G>, predicate: (leaf: TreeLea
  * @param comparator
  */
 export const sortTree = <L, G>(tree: TreeData<L, G>, comparator: Comparator<TreeLeaf<L>>) => {
-  const visitedGroups = new Set<string>();
-  const { root, leavesById, groupsById } = tree;
-  const sortGroupLeaves = (group: TreeGroup<G>) => {
-    if (!comparator) {
-      return group;
-    }
-
-    if (group.groups?.length) {
-      group.groups.forEach((groupId) => {
-        if (visitedGroups.has(groupId)) {
-          return;
-        }
-
-        sortGroupLeaves(groupsById[groupId]);
-        visitedGroups.add(groupId);
-      });
-    }
-
-    if (group.leaves?.length) {
-      group.leaves = group.leaves.sort((a, b) => {
-        const leafA = leavesById[a];
-        const leafB = leavesById[b];
-
-        return comparator(leafA, leafB);
-      });
-    }
-
-    return group;
-  };
-
-  sortGroupLeaves(root as TreeGroup<G>);
-
-  return tree;
+  return processTree(tree, { sort: comparator });
 };
 
 /**
@@ -321,36 +374,7 @@ export const transformTree = <L, G>(
   tree: TreeData<L, G>,
   transformer: (leaf: TreeLeaf<L>, idx: number) => TreeLeaf<L>,
 ) => {
-  const visitedGroups = new Set<string>();
-  const { root, leavesById, groupsById } = tree;
-  const transformGroupLeaves = (group: TreeGroup<G>) => {
-    if (!transformer) {
-      return group;
-    }
-
-    if (group.groups?.length) {
-      group.groups.forEach((groupId) => {
-        if (visitedGroups.has(groupId)) {
-          return;
-        }
-
-        transformGroupLeaves(groupsById[groupId]);
-        visitedGroups.add(groupId);
-      });
-    }
-
-    if (group.leaves?.length) {
-      group.leaves.forEach((leaf, i) => {
-        leavesById[leaf] = transformer(leavesById[leaf], i);
-      });
-    }
-
-    return group;
-  };
-
-  transformGroupLeaves(root as TreeGroup<G>);
-
-  return tree;
+  return processTree(tree, { transform: transformer });
 };
 
 export const createTreeByTitlePath = <T = TestResult, L = DefaultTreeLeaf, G = DefaultTreeGroup>(
@@ -390,17 +414,7 @@ export const createTreeByTitlePath = <T = TestResult, L = DefaultTreeLeaf, G = D
 };
 
 const byLabelsAndTitlePath = (item: TestResult, labelNames: string[]): string[][] => {
-  const leaves: string[][] = [];
-
-  for (const labelName of labelNames) {
-    const values = item.labels.filter((label) => label.name === labelName).map((label) => label.value ?? "");
-
-    if (!values.length) {
-      continue;
-    }
-
-    leaves.push(values);
-  }
+  const leaves = byLabelsWithFallback(item, labelNames, "");
 
   const titlePath = item.titlePath;
   if (Array.isArray(titlePath) && titlePath.length > 0) {

--- a/packages/plugin-api/test/tree.test.ts
+++ b/packages/plugin-api/test/tree.test.ts
@@ -9,6 +9,7 @@ import {
   filterTree,
   filterTreeLabels,
   preciseTreeLabels,
+  processTree,
   sortTree,
   transformTree,
 } from "../src/index.js";
@@ -395,6 +396,36 @@ describe("tree filtering", () => {
       groupsById: {
         g1: { nodeId: "g1", name: "1", groups: ["g2"], leaves: ["l4"] },
         g2: { nodeId: "g2", name: "2", groups: [], leaves: ["l6"] },
+      },
+    });
+  });
+});
+
+describe("tree processing", () => {
+  it("filters, sorts, and transforms leaves in one traversal", () => {
+    const tree = JSON.parse(JSON.stringify(sampleTree));
+    const res = processTree(tree as TreeData<any, any>, {
+      filter: (leaf) => leaf.status !== "passed",
+      sort: nullsLast(compareBy("start", ordinal())),
+      transform: (leaf, i) => ({
+        ...leaf,
+        groupOrder: i + 1,
+      }),
+    });
+
+    expect(res).toMatchObject({
+      root: {
+        leaves: ["l2"],
+        groups: ["g1"],
+      },
+      groupsById: {
+        g1: { nodeId: "g1", name: "1", groups: ["g2"], leaves: ["l4"] },
+        g2: { nodeId: "g2", name: "2", groups: [], leaves: ["l6"] },
+      },
+      leavesById: {
+        l2: expect.objectContaining({ groupOrder: 1 }),
+        l4: expect.objectContaining({ groupOrder: 1 }),
+        l6: expect.objectContaining({ groupOrder: 1 }),
       },
     });
   });

--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -42,7 +42,6 @@ import {
   createTreeByTitlePath,
   preciseTreeLabels,
   processTree,
-  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 import type {
   AwesomeCategory,
@@ -154,10 +153,7 @@ export const generateTestResults = async (
   } = {},
 ) => {
   let convertedTrs: AwesomeTestResult[] = [];
-  const related = await relatedByTestResultIds(
-    store,
-    trs.map(({ id }) => id),
-  );
+  const related = await store.relatedByTestResultIds(trs.map(({ id }) => id));
 
   for (const tr of trs) {
     const trFixtures = related.fixturesByTrId.get(tr.id) ?? [];

--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 
 import { defaultChartsConfig } from "@allurereport/charts-api";
 import {
@@ -40,10 +40,9 @@ import {
   createTreeByLabels,
   createTreeByLabelsAndTitlePath,
   createTreeByTitlePath,
-  filterTree,
   preciseTreeLabels,
-  sortTree,
-  transformTree,
+  processTree,
+  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 import type {
   AwesomeCategory,
@@ -100,6 +99,8 @@ const template = `<!DOCTYPE html>
 </html>
 `;
 
+const compiledTemplate = Handlebars.compile(template);
+
 export const readTemplateManifest = async (singleFileMode?: boolean): Promise<TemplateManifest> => {
   const templateManifestSource = require.resolve(
     `@allurereport/web-awesome/dist/${singleFileMode ? "single" : "multi"}/manifest.json`,
@@ -138,8 +139,14 @@ const createBreadcrumbs = (convertedTr: AwesomeTestResult) => {
   }, [] as string[][]);
 };
 
+const writeConcurrently = async <T>(items: readonly T[], write: (item: T) => Promise<void>, concurrency = 64) => {
+  for (let i = 0; i < items.length; i += concurrency) {
+    await Promise.all(items.slice(i, i + concurrency).map(write));
+  }
+};
+
 export const generateTestResults = async (
-  writer: AwesomeDataWriter,
+  _writer: AwesomeDataWriter,
   store: AllureStore,
   trs: TestResult[],
   options: {
@@ -147,16 +154,20 @@ export const generateTestResults = async (
   } = {},
 ) => {
   let convertedTrs: AwesomeTestResult[] = [];
+  const related = await relatedByTestResultIds(
+    store,
+    trs.map(({ id }) => id),
+  );
 
   for (const tr of trs) {
-    const trFixtures = await store.fixturesByTrId(tr.id);
+    const trFixtures = related.fixturesByTrId.get(tr.id) ?? [];
     const convertedTrFixtures: AwesomeFixtureResult[] = trFixtures.map(convertFixtureResult);
     const convertedTr: AwesomeTestResult = convertTestResult(tr, {
       hideLabels: options.hideLabels,
     });
 
-    convertedTr.history = (await store.historyByTrId(tr.id)) ?? [];
-    convertedTr.retries = await store.retriesByTrId(tr.id);
+    convertedTr.history = related.historyByTrId.get(tr.id) ?? [];
+    convertedTr.retries = related.retriesByTrId.get(tr.id) ?? [];
     convertedTr.retriesCount = convertedTr.retries.length;
     convertedTr.retry = convertedTr.retriesCount > 0;
     convertedTr.isRetry = tr.isRetry;
@@ -164,7 +175,7 @@ export const generateTestResults = async (
     convertedTr.teardown = convertedTrFixtures.filter((f) => f.type === "after");
     // FIXME: the type is correct, but typescript still shows an error
     // @ts-ignore
-    convertedTr.attachments = (await store.attachmentsByTrId(tr.id)).map((attachment) => ({
+    convertedTr.attachments = (related.attachmentsByTrId.get(tr.id) ?? []).map((attachment) => ({
       link: attachment,
       type: "attachment",
     }));
@@ -178,17 +189,11 @@ export const generateTestResults = async (
     order: idx + 1,
   }));
 
-  for (const convertedTr of convertedTrs) {
-    await writer.writeTestCase(convertedTr);
-  }
-
   return convertedTrs;
 };
 
 export const generateTestCases = async (writer: AwesomeDataWriter, trs: AwesomeTestResult[]) => {
-  for (const tr of trs) {
-    await writer.writeTestCase(tr);
-  }
+  await writeConcurrently(trs, (tr) => writer.writeTestCase(tr));
 };
 
 export const generateTestEnvGroups = async (writer: AwesomeDataWriter, groups: TestEnvGroup[]) => {
@@ -293,10 +298,10 @@ export const generateTree = async (
     tree = buildTreeByLabels(visibleTests, labels);
   }
 
-  // @ts-ignore
-  filterTree(tree, (leaf) => !leaf.isRetry);
-  sortTree(tree, nullsLast(compareBy("start", ordinal())));
-  transformTree(tree, (leaf, idx) => ({ ...leaf, groupOrder: idx + 1 }));
+  processTree(tree, {
+    sort: nullsLast(compareBy("start", ordinal())),
+    transform: (leaf, idx) => ({ ...leaf, groupOrder: idx + 1 }),
+  });
 
   await writer.writeWidget(treeFilename, tree);
 };
@@ -627,18 +632,19 @@ export const generateStaticFiles = async (
     ci,
     stepTreeExpansion,
   } = payload;
-  const compile = Handlebars.compile(template);
   const manifest = await readTemplateManifest(payload.singleFile);
   const headTags: string[] = [];
   const bodyTags: string[] = [];
   const sections: string[] = ["charts", "timeline"];
 
   if (!payload.singleFile) {
+    const manifestPath = require.resolve(
+      join("@allurereport/web-awesome/dist", singleFile ? "single" : "multi", "manifest.json"),
+    );
+    const templateDir = dirname(manifestPath);
+
     for (const key in manifest) {
       const fileName = manifest[key];
-      const filePath = require.resolve(
-        join("@allurereport/web-awesome/dist", singleFile ? "single" : "multi", fileName),
-      );
 
       if (key.includes(".woff")) {
         headTags.push(createFontLinkTag(fileName));
@@ -651,12 +657,14 @@ export const generateStaticFiles = async (
       if (key === "main.js") {
         bodyTags.push(createScriptTag(fileName));
       }
+    }
 
-      // we don't need to handle another files in single file mode
-      if (singleFile) {
+    for (const fileName of await readdir(templateDir)) {
+      if (fileName === "manifest.json") {
         continue;
       }
 
+      const filePath = join(templateDir, fileName);
       const fileContent = await readFile(filePath);
 
       await reportFiles.addFile(basename(filePath), fileContent);
@@ -689,7 +697,7 @@ export const generateStaticFiles = async (
   };
 
   try {
-    const html = compile({
+    const html = compiledTemplate({
       headTags: headTags.join("\n"),
       bodyTags: bodyTags.join("\n"),
       reportFilesScript: createReportDataScript(reportDataFiles),

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   type PluginContext,
   type PluginSummary,
   createPluginSummary,
+  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 import { preciseTreeLabels } from "@allurereport/plugin-api";
 
@@ -37,6 +38,10 @@ const statisticByTestResults = async (
   testResults: Awaited<ReturnType<AllureStore["allTestResults"]>>,
 ): Promise<Statistic> => {
   const statistic: Statistic = { total: 0 };
+  const related = await relatedByTestResultIds(
+    store,
+    testResults.map(({ id }) => id),
+  );
 
   for (const testResult of testResults) {
     if (testResult.isRetry) {
@@ -45,7 +50,7 @@ const statisticByTestResults = async (
 
     incrementStatistic(statistic, testResult.status);
 
-    if ((await store.retriesByTrId(testResult.id)).length > 0) {
+    if ((related.retriesByTrId.get(testResult.id)?.length ?? 0) > 0) {
       statistic.retries = (statistic.retries ?? 0) + 1;
     }
 

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -5,7 +5,6 @@ import {
   type PluginContext,
   type PluginSummary,
   createPluginSummary,
-  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 import { preciseTreeLabels } from "@allurereport/plugin-api";
 
@@ -38,10 +37,7 @@ const statisticByTestResults = async (
   testResults: Awaited<ReturnType<AllureStore["allTestResults"]>>,
 ): Promise<Statistic> => {
   const statistic: Statistic = { total: 0 };
-  const related = await relatedByTestResultIds(
-    store,
-    testResults.map(({ id }) => id),
-  );
+  const related = await store.relatedByTestResultIds(testResults.map(({ id }) => id));
 
   for (const testResult of testResults) {
     if (testResult.isRetry) {

--- a/packages/plugin-awesome/src/writer.ts
+++ b/packages/plugin-awesome/src/writer.ts
@@ -21,30 +21,44 @@ export interface AwesomeDataWriter {
 }
 
 export class FileSystemReportDataWriter implements AwesomeDataWriter {
-  constructor(private readonly output: string) {}
+  readonly #dataDir: string;
+  readonly #widgetsDir: string;
+  readonly #testResultsDir: string;
+  readonly #attachmentsDir: string;
+  readonly #dataDirReady: Promise<string | undefined>;
+  readonly #widgetsDirReady: Promise<string | undefined>;
+  readonly #testResultsDirReady: Promise<string | undefined>;
+  readonly #attachmentsDirReady: Promise<string | undefined>;
+
+  constructor(private readonly output: string) {
+    this.#dataDir = resolve(this.output, "data");
+    this.#widgetsDir = resolve(this.output, "widgets");
+    this.#testResultsDir = resolve(this.output, "data", "test-results");
+    this.#attachmentsDir = resolve(this.output, "data", "attachments");
+    this.#dataDirReady = mkdir(this.#dataDir, { recursive: true });
+    this.#widgetsDirReady = mkdir(this.#widgetsDir, { recursive: true });
+    this.#testResultsDirReady = mkdir(this.#testResultsDir, { recursive: true });
+    this.#attachmentsDirReady = mkdir(this.#attachmentsDir, { recursive: true });
+  }
 
   async writeData(fileName: string, data: any): Promise<void> {
-    const distFolder = resolve(this.output, "data");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, fileName), JSON.stringify(data), { encoding: "utf-8" });
+    await this.#dataDirReady;
+    await writeFile(resolve(this.#dataDir, fileName), JSON.stringify(data), { encoding: "utf-8" });
   }
 
   async writeWidget(fileName: string, data: any): Promise<void> {
-    const distFolder = resolve(this.output, "widgets");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, fileName), JSON.stringify(data), { encoding: "utf-8" });
+    await this.#widgetsDirReady;
+    await writeFile(resolve(this.#widgetsDir, fileName), JSON.stringify(data), { encoding: "utf-8" });
   }
 
   async writeTestCase(test: AwesomeTestResult): Promise<void> {
-    const distFolder = resolve(this.output, "data", "test-results");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, `${test.id}.json`), JSON.stringify(test), { encoding: "utf-8" });
+    await this.#testResultsDirReady;
+    await writeFile(resolve(this.#testResultsDir, `${test.id}.json`), JSON.stringify(test), { encoding: "utf-8" });
   }
 
   async writeAttachment(source: string, file: ResultFile): Promise<void> {
-    const distFolder = resolve(this.output, "data", "attachments");
-    await mkdir(distFolder, { recursive: true });
-    await file.writeTo(resolve(distFolder, source));
+    await this.#attachmentsDirReady;
+    await file.writeTo(resolve(this.#attachmentsDir, source));
   }
 }
 

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -28,6 +28,14 @@ export const getTestResultsStats = (trs: TestResult[], filter: (tr: TestResult) 
   );
 };
 
+const createRelatedByTestResultIdsMock = () =>
+  vi.fn(async (trIds: readonly string[]) => ({
+    attachmentsByTrId: new Map(trIds.map((trId) => [trId, []])),
+    fixturesByTrId: new Map(trIds.map((trId) => [trId, []])),
+    historyByTrId: new Map(trIds.map((trId) => [trId, undefined])),
+    retriesByTrId: new Map(trIds.map((trId) => [trId, []])),
+  }));
+
 const fixtures: any = {
   testResults: {
     passed: {
@@ -205,6 +213,7 @@ describe("plugin", () => {
         historyByTrId: vi.fn().mockResolvedValue([]),
         retriesByTrId: vi.fn().mockResolvedValue([]),
         attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        relatedByTestResultIds: createRelatedByTestResultIdsMock(),
         allVariables: vi.fn().mockResolvedValue([]),
         envVariables: vi.fn().mockResolvedValue([]),
         envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),
@@ -293,6 +302,7 @@ describe("plugin", () => {
         historyByTrId: vi.fn().mockResolvedValue([]),
         retriesByTrId: vi.fn().mockResolvedValue([]),
         attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        relatedByTestResultIds: createRelatedByTestResultIdsMock(),
         allVariables: vi.fn().mockResolvedValue([]),
         envVariables: vi.fn().mockResolvedValue([]),
         envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),
@@ -388,6 +398,7 @@ describe("plugin", () => {
         historyByTrId: vi.fn().mockResolvedValue([]),
         retriesByTrId: vi.fn().mockResolvedValue([]),
         attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        relatedByTestResultIds: createRelatedByTestResultIdsMock(),
         allVariables: vi.fn().mockResolvedValue([]),
         envVariables: vi.fn().mockResolvedValue([]),
         envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),
@@ -505,6 +516,7 @@ describe("plugin", () => {
         historyByTrId: vi.fn().mockResolvedValue([]),
         retriesByTrId: vi.fn().mockResolvedValue([]),
         attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        relatedByTestResultIds: createRelatedByTestResultIdsMock(),
         allVariables: vi.fn().mockResolvedValue([]),
         envVariables: vi.fn().mockResolvedValue([]),
         envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),
@@ -629,6 +641,7 @@ describe("plugin", () => {
         historyByTrId: vi.fn().mockResolvedValue([]),
         retriesByTrId: vi.fn().mockResolvedValue([]),
         attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        relatedByTestResultIds: createRelatedByTestResultIdsMock(),
         allVariables: vi.fn().mockResolvedValue([]),
         envVariables: vi.fn().mockResolvedValue([]),
         envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),
@@ -703,6 +716,7 @@ describe("plugin", () => {
         historyByTrId: vi.fn().mockResolvedValue([]),
         retriesByTrId: vi.fn().mockResolvedValue([]),
         attachmentsByTrId: vi.fn().mockResolvedValue([]),
+        relatedByTestResultIds: createRelatedByTestResultIdsMock(),
         allVariables: vi.fn().mockResolvedValue([]),
         envVariables: vi.fn().mockResolvedValue([]),
         envVariablesByEnvironmentId: vi.fn().mockResolvedValue([]),

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -1,8 +1,14 @@
+import { readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+
 import type { EnvironmentIdentity, Statistic, TestResult } from "@allurereport/core-api";
 import type { AllureStore, PluginContext, ReportFiles } from "@allurereport/plugin-api";
 import { describe, expect, it, vi } from "vitest";
 
 import AwesomePlugin from "../src/index.js";
+
+const require = createRequire(import.meta.url);
 
 // duplicated the code from core to avoid circular dependency
 export const getTestResultsStats = (trs: TestResult[], filter: (tr: TestResult) => boolean = () => true) => {
@@ -668,7 +674,7 @@ describe("plugin", () => {
     });
   });
 
-  describe("single file mode", () => {
+  describe("report assets", () => {
     const makeSingleFileStore = (testResults: TestResult[]): AllureStore =>
       ({
         metadataByKey: vi.fn().mockResolvedValue(undefined),
@@ -730,6 +736,29 @@ describe("plugin", () => {
 
       return data;
     };
+
+    it("should copy every emitted multi-file asset", async () => {
+      const addedFiles = new Map<string, Buffer>();
+      const reportFiles: ReportFiles = {
+        addFile: vi.fn(async (path: string, data: Buffer) => {
+          addedFiles.set(path, data);
+          return path;
+        }),
+      };
+      const testResults = [
+        { id: "tr-1", name: "passed test", status: "passed", environment: "default", labels: [] },
+      ] as TestResult[];
+      const plugin = new AwesomePlugin();
+      const multiDist = dirname(require.resolve("@allurereport/web-awesome/dist/multi/manifest.json"));
+      const expectedAssets = (await readdir(multiDist)).filter((fileName) => fileName !== "manifest.json");
+
+      await plugin.start(makeSingleFileContext(reportFiles));
+      await plugin.done(makeSingleFileContext(reportFiles), makeSingleFileStore(testResults));
+
+      for (const fileName of expectedAssets) {
+        expect(addedFiles.has(fileName), `"${fileName}" must be copied to the report`).toBe(true);
+      }
+    });
 
     it("should embed all required widget files as valid base64 JSON with posix keys", async () => {
       const testResults: TestResult[] = [

--- a/packages/plugin-classic/src/generators.ts
+++ b/packages/plugin-classic/src/generators.ts
@@ -26,7 +26,6 @@ import {
   createTreeByCategories,
   createTreeByLabels,
   processTree,
-  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 import type {
   ClassicFixtureResult,
@@ -130,10 +129,7 @@ const createBreadcrumbs = (convertedTr: ClassicTestResult) => {
 
 export const generateTestResults = async (writer: ClassicDataWriter, store: AllureStore) => {
   const allTr = await store.allTestResults({ includeRetries: true });
-  const related = await relatedByTestResultIds(
-    store,
-    allTr.map(({ id }) => id),
-  );
+  const related = await store.relatedByTestResultIds(allTr.map(({ id }) => id));
   const categories: ClassicCategory[] = (await store.metadataByKey("allure2_categories")) ?? [];
   let convertedTrs: ClassicTestResult[] = [];
 

--- a/packages/plugin-classic/src/generators.ts
+++ b/packages/plugin-classic/src/generators.ts
@@ -25,9 +25,8 @@ import {
   type ResultFile,
   createTreeByCategories,
   createTreeByLabels,
-  filterTree,
-  sortTree,
-  transformTree,
+  processTree,
+  relatedByTestResultIds,
 } from "@allurereport/plugin-api";
 import type {
   ClassicFixtureResult,
@@ -83,6 +82,14 @@ const template = `<!DOCTYPE html>
 </html>
 `;
 
+const compiledTemplate = Handlebars.compile(template);
+
+const writeConcurrently = async <T>(items: readonly T[], write: (item: T) => Promise<void>, concurrency = 64) => {
+  for (let i = 0; i < items.length; i += concurrency) {
+    await Promise.all(items.slice(i, i + concurrency).map(write));
+  }
+};
+
 export const readTemplateManifest = async (singleFileMode?: boolean): Promise<TemplateManifest> => {
   const templateManifestSource = require.resolve(
     `@allurereport/web-classic/dist/${singleFileMode ? "single" : "multi"}/manifest.json`,
@@ -123,14 +130,18 @@ const createBreadcrumbs = (convertedTr: ClassicTestResult) => {
 
 export const generateTestResults = async (writer: ClassicDataWriter, store: AllureStore) => {
   const allTr = await store.allTestResults({ includeRetries: true });
+  const related = await relatedByTestResultIds(
+    store,
+    allTr.map(({ id }) => id),
+  );
+  const categories: ClassicCategory[] = (await store.metadataByKey("allure2_categories")) ?? [];
   let convertedTrs: ClassicTestResult[] = [];
 
   for (const tr of allTr) {
-    const trFixtures = await store.fixturesByTrId(tr.id);
+    const trFixtures = related.fixturesByTrId.get(tr.id) ?? [];
     const convertedTrFixtures: ClassicFixtureResult[] = trFixtures.map(convertFixtureResult);
     const convertedTr: ClassicTestResult = convertTestResult(tr);
     const { error, status, flaky } = convertedTr;
-    const categories: ClassicCategory[] = (await store.metadataByKey("allure2_categories")) ?? [];
     const matchedCategories = matchCategories(categories, {
       message: error?.message,
       trace: error?.trace,
@@ -139,15 +150,15 @@ export const generateTestResults = async (writer: ClassicDataWriter, store: Allu
     });
 
     convertedTr.categories = matchedCategories;
-    convertedTr.history = (await store.historyByTrId(tr.id)) ?? [];
-    convertedTr.retries = await store.retriesByTrId(tr.id);
+    convertedTr.history = related.historyByTrId.get(tr.id) ?? [];
+    convertedTr.retries = related.retriesByTrId.get(tr.id) ?? [];
     convertedTr.retry = convertedTr.retries.length > 0;
     convertedTr.isRetry = tr.isRetry;
     convertedTr.setup = convertedTrFixtures.filter((f) => f.type === "before");
     convertedTr.teardown = convertedTrFixtures.filter((f) => f.type === "after");
     // FIXME: the type is correct, but typescript still shows an error
     // @ts-ignore
-    convertedTr.attachments = (await store.attachmentsByTrId(tr.id)).map((attachment) => ({
+    convertedTr.attachments = (related.attachmentsByTrId.get(tr.id) ?? []).map((attachment) => ({
       link: attachment,
       type: "attachment",
     }));
@@ -161,9 +172,7 @@ export const generateTestResults = async (writer: ClassicDataWriter, store: Allu
     order: idx + 1,
   }));
 
-  for (const convertedTr of convertedTrs) {
-    await writer.writeTestCase(convertedTr);
-  }
+  await writeConcurrently(convertedTrs, (convertedTr) => writer.writeTestCase(convertedTr));
 
   await writer.writeWidget(
     "nav.json",
@@ -204,10 +213,10 @@ export const generateTree = async (
     },
   );
 
-  // @ts-ignore
-  filterTree(tree, (leaf) => !leaf.isRetry);
-  sortTree(tree, nullsLast(compareBy("start", ordinal())));
-  transformTree(tree, (leaf, idx) => ({ ...leaf, groupOrder: idx + 1 }));
+  processTree(tree, {
+    sort: nullsLast(compareBy("start", ordinal())),
+    transform: (leaf, idx) => ({ ...leaf, groupOrder: idx + 1 }),
+  });
 
   await writer.writeWidget(`${treeName}.json`, tree);
 };
@@ -279,7 +288,6 @@ export const generateStaticFiles = async (
     reportUuid,
     allureVersion,
   } = payload;
-  const compile = Handlebars.compile(template);
   const manifest = await readTemplateManifest(payload.singleFile);
   const headTags: string[] = [];
   const bodyTags: string[] = [];
@@ -333,7 +341,7 @@ export const generateStaticFiles = async (
   };
 
   try {
-    const html = compile({
+    const html = compiledTemplate({
       headTags: headTags.join("\n"),
       bodyTags: bodyTags.join("\n"),
       reportFilesScript: createReportDataScript(reportDataFiles),
@@ -387,13 +395,13 @@ export const generateTreeByCategories = async (
     },
   );
 
-  // @ts-ignore
-  filterTree(tree, (leaf: TreeLeaf<ClassicTreeLeaf>) => !leaf.retry);
-  sortTree(tree, nullsLast(compareBy("start", ordinal())));
-  transformTree(tree, (leaf: TreeLeaf<ClassicTreeLeaf>, idx: number) => ({
-    ...leaf,
-    groupOrder: idx + 1,
-  }));
+  processTree(tree, {
+    sort: nullsLast(compareBy("start", ordinal())),
+    transform: (leaf: TreeLeaf<ClassicTreeLeaf>, idx: number) => ({
+      ...leaf,
+      groupOrder: idx + 1,
+    }),
+  });
 
   await writer.writeWidget(`${treeName}.json`, tree);
 };

--- a/packages/plugin-classic/src/writer.ts
+++ b/packages/plugin-classic/src/writer.ts
@@ -21,30 +21,44 @@ export interface ClassicDataWriter {
 }
 
 export class FileSystemReportDataWriter implements ClassicDataWriter {
-  constructor(private readonly output: string) {}
+  readonly #dataDir: string;
+  readonly #widgetsDir: string;
+  readonly #testResultsDir: string;
+  readonly #attachmentsDir: string;
+  readonly #dataDirReady: Promise<string | undefined>;
+  readonly #widgetsDirReady: Promise<string | undefined>;
+  readonly #testResultsDirReady: Promise<string | undefined>;
+  readonly #attachmentsDirReady: Promise<string | undefined>;
+
+  constructor(private readonly output: string) {
+    this.#dataDir = resolve(this.output, "data");
+    this.#widgetsDir = resolve(this.output, "widgets");
+    this.#testResultsDir = resolve(this.output, "data", "test-results");
+    this.#attachmentsDir = resolve(this.output, "data", "attachments");
+    this.#dataDirReady = mkdir(this.#dataDir, { recursive: true });
+    this.#widgetsDirReady = mkdir(this.#widgetsDir, { recursive: true });
+    this.#testResultsDirReady = mkdir(this.#testResultsDir, { recursive: true });
+    this.#attachmentsDirReady = mkdir(this.#attachmentsDir, { recursive: true });
+  }
 
   async writeData(fileName: string, data: any): Promise<void> {
-    const distFolder = resolve(this.output, "data");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, fileName), JSON.stringify(data), { encoding: "utf-8" });
+    await this.#dataDirReady;
+    await writeFile(resolve(this.#dataDir, fileName), JSON.stringify(data), { encoding: "utf-8" });
   }
 
   async writeWidget(fileName: string, data: any): Promise<void> {
-    const distFolder = resolve(this.output, "widgets");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, fileName), JSON.stringify(data), { encoding: "utf-8" });
+    await this.#widgetsDirReady;
+    await writeFile(resolve(this.#widgetsDir, fileName), JSON.stringify(data), { encoding: "utf-8" });
   }
 
   async writeTestCase(test: AwesomeTestResult): Promise<void> {
-    const distFolder = resolve(this.output, "data", "test-results");
-    await mkdir(distFolder, { recursive: true });
-    await writeFile(resolve(distFolder, `${test.id}.json`), JSON.stringify(test), { encoding: "utf-8" });
+    await this.#testResultsDirReady;
+    await writeFile(resolve(this.#testResultsDir, `${test.id}.json`), JSON.stringify(test), { encoding: "utf-8" });
   }
 
   async writeAttachment(source: string, file: ResultFile): Promise<void> {
-    const distFolder = resolve(this.output, "data", "attachments");
-    await mkdir(distFolder, { recursive: true });
-    await file.writeTo(resolve(distFolder, source));
+    await this.#attachmentsDirReady;
+    await file.writeTo(resolve(this.#attachmentsDir, source));
   }
 }
 

--- a/packages/reader-api/src/reader.ts
+++ b/packages/reader-api/src/reader.ts
@@ -18,6 +18,7 @@ export interface ResultsVisitor {
 }
 
 export interface ResultsReader {
+  matches?(data: ResultFile): boolean | Promise<boolean>;
   read(visitor: ResultsVisitor, data: ResultFile): Promise<boolean>;
   readerId(): string;
 }

--- a/packages/reader/src/allure1/index.ts
+++ b/packages/reader/src/allure1/index.ts
@@ -64,6 +64,7 @@ const xmlParser = new XMLParser({
 const readerId = "allure1";
 
 export const allure1: ResultsReader = {
+  matches: (data) => data.getOriginalFileName().endsWith("-testsuite.xml"),
   read: async (visitor, data) => {
     if (data.getOriginalFileName().endsWith("-testsuite.xml")) {
       try {

--- a/packages/reader/src/allure1/index.ts
+++ b/packages/reader/src/allure1/index.ts
@@ -63,28 +63,30 @@ const xmlParser = new XMLParser({
 
 const readerId = "allure1";
 
-export const allure1: ResultsReader = {
-  matches: (data) => data.getOriginalFileName().endsWith("-testsuite.xml"),
-  read: async (visitor, data) => {
-    if (data.getOriginalFileName().endsWith("-testsuite.xml")) {
-      try {
-        const asBuffer = await data.asBuffer();
-        if (!asBuffer) {
-          return false;
-        }
-        const content = cleanBadXmlCharacters(asBuffer).toString("utf-8");
-        const parsed = xmlParser.parse(content);
-        if (!isStringAnyRecord(parsed)) {
-          return false;
-        }
+const matchesAllure1File = (fileName: string): boolean => fileName.endsWith("-testsuite.xml");
 
-        return await parseRootElement(visitor, parsed);
-      } catch (e) {
-        console.error("error parsing", data.getOriginalFileName(), e);
+export const allure1: ResultsReader = {
+  matches: (data) => matchesAllure1File(data.getOriginalFileName()),
+  read: async (visitor, data) => {
+    try {
+      const asBuffer = await data.asBuffer();
+
+      if (!asBuffer) {
         return false;
       }
+
+      const content = cleanBadXmlCharacters(asBuffer).toString("utf-8");
+      const parsed = xmlParser.parse(content);
+
+      if (!isStringAnyRecord(parsed)) {
+        return false;
+      }
+
+      return await parseRootElement(visitor, parsed);
+    } catch (e) {
+      console.error("error parsing", data.getOriginalFileName(), e);
+      return false;
     }
-    return false;
   },
 
   readerId: () => readerId,

--- a/packages/reader/src/allure2/index.ts
+++ b/packages/reader/src/allure2/index.ts
@@ -52,7 +52,25 @@ const xmlParser = new XMLParser({
 
 const readerId = "allure2";
 
+const matchesAllure2File = (fileName: string): boolean => {
+  if (fileName.endsWith("-result.json")) return true;
+  if (fileName.endsWith("-check.json")) return true;
+  if (fileName.endsWith("-container.json")) return true;
+  if (fileName.endsWith("-globals.json")) return true;
+  const attachmentIdx = fileName.lastIndexOf("-attachment");
+  if (attachmentIdx !== -1) {
+    const suffix = fileName.slice(attachmentIdx + "-attachment".length);
+    if (suffix === "" || suffix.startsWith(".")) return true;
+  }
+  if (fileName === "executor.json") return true;
+  if (fileName === "categories.json") return true;
+  if (fileName === "environment.properties") return true;
+  if (fileName === "environment.xml") return true;
+  return false;
+};
+
 export const allure2: ResultsReader = {
+  matches: (data) => matchesAllure2File(data.getOriginalFileName()),
   read: async (visitor, data) => {
     const originalFileName = data.getOriginalFileName();
 

--- a/packages/reader/src/allure2/index.ts
+++ b/packages/reader/src/allure2/index.ts
@@ -52,16 +52,24 @@ const xmlParser = new XMLParser({
 
 const readerId = "allure2";
 
+const isAllure2AttachmentFileName = (fileName: string): boolean => {
+  const attachmentIdx = fileName.lastIndexOf("-attachment");
+
+  if (attachmentIdx === -1) {
+    return false;
+  }
+
+  const suffix = fileName.slice(attachmentIdx + "-attachment".length);
+
+  return suffix === "" || suffix.startsWith(".");
+};
+
 const matchesAllure2File = (fileName: string): boolean => {
   if (fileName.endsWith("-result.json")) return true;
   if (fileName.endsWith("-check.json")) return true;
   if (fileName.endsWith("-container.json")) return true;
   if (fileName.endsWith("-globals.json")) return true;
-  const attachmentIdx = fileName.lastIndexOf("-attachment");
-  if (attachmentIdx !== -1) {
-    const suffix = fileName.slice(attachmentIdx + "-attachment".length);
-    if (suffix === "" || suffix.startsWith(".")) return true;
-  }
+  if (isAllure2AttachmentFileName(fileName)) return true;
   if (fileName === "executor.json") return true;
   if (fileName === "categories.json") return true;
   if (fileName === "environment.properties") return true;
@@ -73,13 +81,6 @@ export const allure2: ResultsReader = {
   matches: (data) => matchesAllure2File(data.getOriginalFileName()),
   read: async (visitor, data) => {
     const originalFileName = data.getOriginalFileName();
-
-    // this is essential in case we need to attach valid result files
-    // e.g. like in allure2.test.ts
-    if (originalFileName.match(/-attachment(?:\..+)?/)) {
-      await visitor.visitAttachmentFile(data, { readerId });
-      return true;
-    }
 
     if (originalFileName.endsWith("-check.json")) {
       try {
@@ -191,6 +192,10 @@ export const allure2: ResultsReader = {
       }
     }
 
+    // This is essential in case we need to attach valid result files
+    // e.g. like in allure2.test.ts. Under core dispatch, only files matched
+    // by matchesAllure2File reach this fallback, so the remaining case is an
+    // Allure 2 attachment.
     await visitor.visitAttachmentFile(data, { readerId });
     return true;
   },

--- a/packages/reader/src/attachments/index.ts
+++ b/packages/reader/src/attachments/index.ts
@@ -3,6 +3,7 @@ import type { ResultsReader } from "@allurereport/reader-api";
 const readerId = "attachments";
 
 export const attachments: ResultsReader = {
+  matches: () => true,
   read: async (visitor, data) => {
     await visitor.visitAttachmentFile(data, { readerId });
 

--- a/packages/reader/src/cucumberjson/index.ts
+++ b/packages/reader/src/cucumberjson/index.ts
@@ -29,6 +29,8 @@ const NS_IN_MS = 1_000_000;
 
 const readerId = "cucumberjson";
 
+const matchesCucumberJsonFile = (fileName: string): boolean => fileName.endsWith(".json");
+
 const allureStepStatusPriorityOrder = {
   failed: 0,
   broken: 1,
@@ -85,23 +87,28 @@ type PreProcessedStep = {
 type PostProcessedStep = { preProcessedStep: PreProcessedStep; allureStep: RawTestStepResult };
 
 export const cucumberjson: ResultsReader = {
-  matches: (data) => data.getOriginalFileName().endsWith(".json"),
+  matches: (data) => matchesCucumberJsonFile(data.getOriginalFileName()),
   read: async (visitor, data) => {
     const originalFileName = data.getOriginalFileName();
-    if (originalFileName.endsWith(".json")) {
-      try {
-        const parsed = await data.asJson<CucumberFeature[]>();
-        if (isArray(parsed)) {
-          let oneOrMoreFeaturesParsed = false;
-          for (const feature of parsed) {
-            oneOrMoreFeaturesParsed ||= await processFeature(visitor, originalFileName, feature);
+    try {
+      const parsed = await data.asJson<CucumberFeature[]>();
+
+      if (isArray(parsed)) {
+        let oneOrMoreFeaturesParsed = false;
+
+        for (const feature of parsed) {
+          oneOrMoreFeaturesParsed ||= await processFeature(visitor, originalFileName, feature);
+
+          if (oneOrMoreFeaturesParsed) {
+            break;
           }
-          return oneOrMoreFeaturesParsed;
         }
-      } catch (e) {
-        console.error("error parsing", originalFileName, e);
-        return false;
+
+        return oneOrMoreFeaturesParsed;
       }
+    } catch (e) {
+      console.error("error parsing", originalFileName, e);
+      return false;
     }
     return false;
   },

--- a/packages/reader/src/cucumberjson/index.ts
+++ b/packages/reader/src/cucumberjson/index.ts
@@ -85,6 +85,7 @@ type PreProcessedStep = {
 type PostProcessedStep = { preProcessedStep: PreProcessedStep; allureStep: RawTestStepResult };
 
 export const cucumberjson: ResultsReader = {
+  matches: (data) => data.getOriginalFileName().endsWith(".json"),
   read: async (visitor, data) => {
     const originalFileName = data.getOriginalFileName();
     if (originalFileName.endsWith(".json")) {

--- a/packages/reader/src/junitxml/index.ts
+++ b/packages/reader/src/junitxml/index.ts
@@ -41,6 +41,7 @@ const xmlParser = new XMLParser({
 const readerId = "junit";
 
 export const junitXml: ResultsReader = {
+  matches: (data) => data.getOriginalFileName().endsWith(".xml"),
   read: async (visitor, data) => {
     if (data.getOriginalFileName().endsWith(".xml")) {
       try {

--- a/packages/reader/src/junitxml/index.ts
+++ b/packages/reader/src/junitxml/index.ts
@@ -40,27 +40,31 @@ const xmlParser = new XMLParser({
 
 const readerId = "junit";
 
-export const junitXml: ResultsReader = {
-  matches: (data) => data.getOriginalFileName().endsWith(".xml"),
-  read: async (visitor, data) => {
-    if (data.getOriginalFileName().endsWith(".xml")) {
-      try {
-        const content = await data.asUtf8String();
-        if (!content) {
-          return false;
-        }
-        const parsed = xmlParser.parse(content);
-        if (!isStringAnyRecord(parsed)) {
-          return false;
-        }
+const matchesJunitXmlFile = (fileName: string): boolean => fileName.endsWith(".xml");
 
-        return await parseRootElement(visitor, parsed);
-      } catch (e) {
-        console.error("error parsing", data.getOriginalFileName(), e);
+export const junitXml: ResultsReader = {
+  matches: (data) => matchesJunitXmlFile(data.getOriginalFileName()),
+  read: async (visitor, data) => {
+    const originalFileName = data.getOriginalFileName();
+
+    try {
+      const content = await data.asUtf8String();
+
+      if (!content) {
         return false;
       }
+
+      const parsed = xmlParser.parse(content);
+
+      if (!isStringAnyRecord(parsed)) {
+        return false;
+      }
+
+      return await parseRootElement(visitor, parsed);
+    } catch (e) {
+      console.error("error parsing", originalFileName, e);
+      return false;
     }
-    return false;
   },
 
   readerId: () => readerId,

--- a/packages/reader/test/allure2.test.ts
+++ b/packages/reader/test/allure2.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { BufferResultFile } from "@allurereport/reader-api";
 import { describe, expect, it } from "vitest";
 
 import { allure2 } from "../src/index.js";
@@ -26,6 +27,18 @@ describe("allure2 reader", () => {
         message: "lint ok",
       },
     });
+  });
+
+  it("should match attachment files so they keep the allure2 reader context", async () => {
+    const attachment = new BufferResultFile(Buffer.from("content"), `${randomUUID()}-attachment.txt`);
+
+    expect(await allure2.matches?.(attachment)).toBe(true);
+  });
+
+  it("should match check result files", async () => {
+    const checkResult = new BufferResultFile(Buffer.from("{}"), `${randomUUID()}-check.json`);
+
+    expect(await allure2.matches?.(checkResult)).toBe(true);
   });
 
   it("should parse simple result", async () => {

--- a/packages/reader/test/cucumberjson.test.ts
+++ b/packages/reader/test/cucumberjson.test.ts
@@ -2,20 +2,15 @@
 import { describe, expect, it } from "vitest";
 
 import { cucumberjson } from "../src/index.js";
-import { readResults } from "./utils.js";
+import { readResourceAsResultFile, readResults } from "./utils.js";
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 describe("cucumberjson reader", () => {
   it("should ignore a file with no .json extension", async () => {
-    const visitor = await readResults(
-      cucumberjson,
-      {
-        "cucumberjsondata/reference/names/wellDefined.json": "cucumber",
-      },
-      false,
-    );
-    expect(visitor.visitTestResult).toHaveBeenCalledTimes(0);
+    const resultFile = await readResourceAsResultFile("cucumberjsondata/reference/names/wellDefined.json", "cucumber");
+
+    expect(cucumberjson.matches(resultFile)).toBe(false);
   });
 
   // As implemented in https://github.com/cucumber/cucumber-ruby or https://github.com/cucumber/json-formatter (which

--- a/packages/web-awesome/src/components/SectionSwitcher/index.tsx
+++ b/packages/web-awesome/src/components/SectionSwitcher/index.tsx
@@ -1,19 +1,96 @@
-import type { VNode } from "preact";
+import { PageLoader } from "@allurereport/web-components";
+import type { ComponentType } from "preact";
+import { useEffect, useState } from "preact/hooks";
 
-import { Charts } from "@/components/Charts";
 import { Report } from "@/components/Report";
 import { currentSection } from "@/stores/sections";
 
-import { Timeline } from "../Timeline";
-
 import * as styles from "./styles.scss";
 
-export const SectionSwitcher = () => {
-  const sectionMap: Record<string, VNode> = {
-    report: <Report />,
-    charts: <Charts />,
-    timeline: <Timeline />,
-  };
+type SectionName = "report" | "charts" | "timeline";
 
-  return <div className={styles.layout}>{sectionMap[currentSection.value] || sectionMap.report}</div>;
+const sectionLoaders: Record<Exclude<SectionName, "report">, () => Promise<ComponentType>> = {
+  charts: () => import("@/components/Charts").then((module) => module.Charts),
+  timeline: () => import("@/components/Timeline").then((module) => module.Timeline),
+};
+
+const sectionCache = new Map<string, ComponentType>();
+
+type LoadedSection = {
+  section: SectionName;
+  Component: ComponentType;
+};
+
+const LazySection = ({ section }: { section: SectionName }) => {
+  const cached = sectionCache.get(section);
+  const [loaded, setLoaded] = useState<LoadedSection | null>(cached ? { section, Component: cached } : null);
+
+  useEffect(() => {
+    if (section === "report") {
+      setLoaded({ section, Component: Report });
+      return;
+    }
+
+    const loader = sectionLoaders[section];
+    let mounted = true;
+
+    if (!loader) {
+      setLoaded(null);
+      return;
+    }
+
+    const cachedComponent = sectionCache.get(section);
+    if (cachedComponent) {
+      if (mounted) {
+        setLoaded({ section, Component: cachedComponent });
+      }
+      return;
+    }
+
+    setLoaded(null);
+
+    loader()
+      .then((LoadedComponent) => {
+        if (mounted) {
+          sectionCache.set(section, LoadedComponent);
+          setLoaded({ section, Component: LoadedComponent });
+        }
+      })
+      .catch((err) => {
+        console.error(`Failed to load section "${section}":`, err);
+        if (mounted) {
+          setLoaded({ section, Component: Report });
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [section]);
+
+  if (section === "report" || !sectionLoaders[section]) {
+    return <Report />;
+  }
+
+  if (!loaded || loaded.section !== section) {
+    return <PageLoader />;
+  }
+
+  const { Component } = loaded;
+
+  return <Component />;
+};
+
+const VALID_SECTIONS: SectionName[] = ["report", "charts", "timeline"];
+
+export const SectionSwitcher = () => {
+  const section = VALID_SECTIONS.includes(currentSection.value as SectionName)
+    ? (currentSection.value as SectionName)
+    : "report";
+
+  return (
+    <div className={styles.layout}>
+      <LazySection section={section} />
+    </div>
+  );
 };

--- a/packages/web-awesome/src/components/TestResult/TrSteps/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/index.tsx
@@ -9,6 +9,8 @@ import {
   getNextSubtreeToggleState,
   getSubtreeToggleIcon,
   getStepTreeExpansionPolicy,
+  hasFailedStepContext,
+  isOpenByDefaultForPolicy,
   isSubtreeFirstLevelOnlyOpened,
   type SubtreeNode,
   type SubtreeToggleState,
@@ -34,7 +36,7 @@ export type TrStepsProps = {
 export const TrSteps: FunctionalComponent<TrStepsProps> = ({ bodyItems, id }) => {
   const stepsId = typeof id === "string" ? `${id}-steps` : null;
   const policy = getStepTreeExpansionPolicy();
-  const isRootOpenedByDefault = policy !== "collapsed";
+  const isRootOpenedByDefault = isOpenByDefaultForPolicy(policy, hasFailedStepContext(bodyItems));
   const isOpened = stepsId !== null ? isTreeOpened(stepsId, isRootOpenedByDefault) : isRootOpenedByDefault;
   const expandableTreeNodes = collectExpandableStepNodes(bodyItems, policy);
   const hasChildren = stepsId !== null && bodyItems.length > 0;

--- a/packages/web-awesome/test/components/EnvironmentPicker.test.tsx
+++ b/packages/web-awesome/test/components/EnvironmentPicker.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { currentEnvironment, environmentsStore } from "@/stores/env";
@@ -65,6 +65,7 @@ describe("components > EnvironmentPicker", () => {
   let restoreElementSizeMocks: () => void;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.stubGlobal(
       "matchMedia",
       vi.fn().mockImplementation(() => ({
@@ -96,6 +97,8 @@ describe("components > EnvironmentPicker", () => {
     restoreElementSizeMocks();
     vi.unstubAllGlobals();
     cleanup();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 
   it("should show tooltip on hover after resize truncates selected value", async () => {
@@ -108,14 +111,21 @@ describe("components > EnvironmentPicker", () => {
 
     expect(queryTooltip()).not.toBeInTheDocument();
 
-    setNarrowViewport(true);
-    await waitFor(() => {
+    await act(async () => {
+      setNarrowViewport(true);
       fireEvent(window, new Event("resize"));
+      vi.advanceTimersByTime(16);
+    });
+
+    await waitFor(() => {
       expect(getTooltipTrigger().childElementCount).toBe(2);
     });
 
     const tooltipTrigger = getTooltipTrigger();
     fireEvent.mouseEnter(tooltipTrigger);
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
     await waitFor(() => {
       expect(queryTooltip()).toBeInTheDocument();
     });

--- a/packages/web-awesome/test/components/TestResult/TrSteps.test.tsx
+++ b/packages/web-awesome/test/components/TestResult/TrSteps.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render } from "@testing-library/preact";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+});
+
+import type { TrBodyItem } from "@/components/TestResult/bodyItems";
+import { TrSteps } from "@/components/TestResult/TrSteps";
+import { collapsedTrees, expandedTrees } from "@/stores/tree";
+
+const passedStep = {
+  type: "step",
+  item: {
+    stepId: "passed-step",
+    name: "passed step",
+    status: "passed",
+    parameters: [],
+    message: "",
+    trace: "",
+    hasSimilarErrorInSubSteps: false,
+  },
+  suppressInlineError: false,
+  bodyItems: [],
+} satisfies TrBodyItem;
+
+const failedStep = {
+  type: "step",
+  item: {
+    stepId: "failed-step",
+    name: "failed step",
+    status: "failed",
+    parameters: [],
+    message: "failed",
+    trace: "trace",
+    hasSimilarErrorInSubSteps: false,
+  },
+  suppressInlineError: false,
+  bodyItems: [],
+} satisfies TrBodyItem;
+
+describe("components > TestResult > TrSteps", () => {
+  beforeEach(() => {
+    cleanup();
+    collapsedTrees.value = new Set();
+    expandedTrees.value = new Set();
+    globalThis.allureReportOptions = { stepTreeExpansion: "expand_failed_only" } as any;
+  });
+
+  it("collapses passed-only root steps by default with expand_failed_only", () => {
+    const view = render(<TrSteps id="passed-test" bodyItems={[passedStep]} />);
+
+    expect(view.queryByTestId("test-result-steps-root")).not.toBeInTheDocument();
+  });
+
+  it("opens root steps by default when expand_failed_only finds failed context", () => {
+    const view = render(<TrSteps id="failed-test" bodyItems={[passedStep, failedStep]} />);
+
+    expect(view.getByTestId("test-result-steps-root")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Frontend 
- **Lazy sections** (`web-awesome`): Charts and Timeline are loaded on demand via dynamic imports. A component cache makes tab switching instant, and if a chunk fails to load we fall back to Report instead of crashing.

### Generator

- **Bulk store reads** (`plugin-api`, `plugin-awesome`): `generateTestResults` now fetches fixtures, history, retries, and attachments in a single `relatedByTestResultIds` call instead of querying per test result. This is the main reason the 50k dataset generator drops from ~69s to ~29s.

### Reader

- **Early file matching** (`reader`): the `allure2` reader uses a `matches()` pattern to skip irrelevant files immediately instead of trying to parse everything.

### Allure Awesome — before vs after

| Dataset | Gen before | Gen after | Gen Δ | Report before | Report after | Report Δ |
|---|---|---|---|---|---|---|
| 10k | 11.43s | 8.04s | 1.42x | 9.12s | 5.38s | 1.69x |
| 50k | 68.85s | 28.97s | 2.38x | 66.51s | 26.33s | 2.53x |

| Dataset | Load before | Load after | Speedup | Heap before | Heap after |
|---|---|---|---|---|---|
| 10k | 2216ms | 1351ms | 1.64x | 272.8 MB | 23.4 MB |
| 50k | 6939ms | 1381ms | 5.03x | 631.3 MB | 68.9 MB |