### PR TITLE
Respect configured output directory for allure open and allure serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To view a previously generated report locally, the `open` command serves it in y
 npx allure open <reportDir>
 ```
 
-If you’ve defined the output directory in your configuration file, specifying `<reportDir>` is optional. By default, Allure 3 looks for a directory named `allure-report`. To open the Awesome report directly, point to the nested directory:
+When `<reportDir>` is omitted, Allure 3 uses the configured output directory, falling back to `allure-report` when no output is configured. To open the Awesome report directly, point to the nested directory:
 
 ```bash
 npx allure open allure-report/awesome

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -94,7 +94,7 @@ To view a previously generated report locally, the `open` command serves it in y
 npx allure open <reportDir>
 ```
 
-If you’ve defined the output directory in your configuration file, specifying `<reportDir>` is optional. By default, Allure 3 looks for a directory named `allure-report`. To open the Awesome report directly, point to the nested directory:
+When `<reportDir>` is omitted, Allure 3 uses the configured output directory, falling back to `allure-report` when no output is configured. To open the Awesome report directly, point to the nested directory:
 
 ```bash
 npx allure open allure-report/awesome

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -24,7 +24,7 @@ export class OpenCommand extends Command {
   });
 
   resultsDir = Option.String({
-    name: "A report to open or a pattern to match test results directories in the current working directory (default: ./allure-results)",
+    name: "A report to open or a pattern to match test results directories in the current working directory (default: configured output)",
     required: false,
   });
 
@@ -47,7 +47,10 @@ export class OpenCommand extends Command {
   async execute() {
     const cwd = this.cwd ?? processCwd();
     const hideLabels = this.hideLabels?.length ? this.hideLabels : undefined;
-    const targetFullPath = join(cwd, this.resultsDir ?? "allure-report");
+    const config = await readConfig(cwd, this.config, {
+      port: this.port,
+    });
+    const targetFullPath = this.resultsDir ? join(cwd, this.resultsDir) : config.output;
     const summaryFiles = existsSync(targetFullPath)
       ? await glob(join(targetFullPath, "**", "summary.json"), {
           mark: true,
@@ -60,10 +63,6 @@ export class OpenCommand extends Command {
       : [];
 
     if (summaryFiles.length > 0) {
-      const config = await readConfig(cwd, this.config, {
-        port: this.port,
-      });
-
       await serve({
         port: config.port ? parseInt(config.port, 10) : undefined,
         servePath: targetFullPath,

--- a/packages/cli/test/commands/open.test.ts
+++ b/packages/cli/test/commands/open.test.ts
@@ -328,8 +328,9 @@ describe("open command", () => {
     });
   });
 
-  it("should use default resultsDir when not provided", async () => {
+  it("should use configured output when target is not provided", async () => {
     const fixtures = {
+      configuredOutput: "/custom/allure-report",
       tmpDir: "/tmp/allure-report-abc123",
     };
 
@@ -337,7 +338,9 @@ describe("open command", () => {
     (tmpdir as Mock).mockReturnValue("/tmp");
     (mkdtemp as Mock).mockResolvedValue(fixtures.tmpDir);
     (glob as unknown as Mock).mockResolvedValue([]);
-    (readConfig as Mock).mockResolvedValue({ output: fixtures.tmpDir });
+    (readConfig as Mock)
+      .mockResolvedValueOnce({ output: fixtures.configuredOutput })
+      .mockResolvedValueOnce({ output: fixtures.tmpDir });
     (generate as Mock).mockResolvedValue(undefined);
     (serve as Mock).mockResolvedValue(undefined);
 
@@ -348,9 +351,45 @@ describe("open command", () => {
 
     await command.execute();
 
+    expect(existsSync).toHaveBeenCalledWith(fixtures.configuredOutput);
     expect(generate).toHaveBeenCalledWith(
       expect.objectContaining({
-        resultsDir: join(".", "allure-report"),
+        resultsDir: fixtures.configuredOutput,
+      }),
+    );
+  });
+
+  it("should serve configured output when no target is provided", async () => {
+    const fixtures = {
+      configuredOutput: "/custom/allure-report",
+      port: "8080",
+    };
+
+    (existsSync as Mock).mockReturnValue(true);
+    (glob as unknown as Mock).mockResolvedValue([join(fixtures.configuredOutput, "summary.json")]);
+    (readConfig as Mock).mockResolvedValue({ output: fixtures.configuredOutput, port: fixtures.port });
+    (serve as Mock).mockResolvedValue(undefined);
+
+    await run(OpenCommand, ["serve", "--port", fixtures.port]);
+
+    expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
+      port: fixtures.port,
+    });
+    expect(glob).toHaveBeenCalledWith(join(fixtures.configuredOutput, "**", "summary.json"), {
+      mark: true,
+      nodir: false,
+      absolute: true,
+      dot: true,
+      windowsPathsNoEscape: true,
+      cwd: expect.any(String),
+    });
+    expect(mkdtemp).not.toHaveBeenCalled();
+    expect(generate).not.toHaveBeenCalled();
+    expect(serve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 8080,
+        servePath: fixtures.configuredOutput,
+        open: true,
       }),
     );
   });


### PR DESCRIPTION
This update makes `allure open` and `allure serve` use the output directory from your Allure config when no report directory is provided. If your config sets `output: "./out/allure-report"`, running `allure open` now opens that report by default instead of looking for `./allure-report`.

Explicit paths still work the same way. For example, `allure open ./some-report` opens `./some-report`, and `allure open ./allure-results` still generates and serves a temporary report from those results.

Example:

```bash
# allurerc.mjs
export default {
  output: "./out/allure-report"
}

# Opens ./out/allure-report
allure open

# Same behavior through the serve alias
allure serve
```