### PR TITLE
feat(web-awesome): add support for HTTP Exchange attachments

### DIFF
--- a/packages/e2e/test/allure-awesome/features/attachments.test.ts
+++ b/packages/e2e/test/allure-awesome/features/attachments.test.ts
@@ -9,6 +9,7 @@ import { TestResultPage, TreePage } from "../../pageObjects/index.js";
 import { type ReportBootstrap, bootstrapReport } from "../utils/index.js";
 
 const dirname = pathDirname(fileURLToPath(import.meta.url));
+const httpExchangeMime = "application/vnd.allure.http+json";
 
 let bootstrap: ReportBootstrap;
 let treePage: TreePage;
@@ -409,6 +410,227 @@ test.describe("attachments", () => {
       await testResultPage.toggleAttachmentByTitle("attachment");
 
       await expect(testResultPage.videoAttachmentContentLocator).toHaveCount(1);
+
+      await testResultPage.attachScreenshot();
+    });
+  });
+
+  test.describe("HTTP Exchange attachment", () => {
+    test.beforeEach(async ({ page }) => {
+      const imageAttachment = await readFile(resolve(dirname, "../../fixtures/image.png"));
+      const httpJson = {
+        schemaVersion: 1,
+        start: 1710000186400,
+        stop: 1710000186487,
+        request: {
+          method: "POST",
+          url: "https://api.example.com/v1/orders/42?dryRun=true",
+          httpVersion: "HTTP/1.1",
+          query: [{ name: "dryRun", value: "true" }],
+          headers: [
+            { name: "authorization", value: "__ALLURE_REDACTED__" },
+            { name: "content-type", value: "application/json" },
+          ],
+          cookies: [
+            { name: "sid", value: "__ALLURE_REDACTED__", httpOnly: true },
+            { name: "theme", value: "dark", sameSite: "Lax" },
+          ],
+          body: {
+            contentType: "application/json",
+            encoding: "utf8",
+            value: '{"name":"demo","quantity":1}',
+            size: 28,
+          },
+        },
+        response: {
+          status: 201,
+          statusText: "Created",
+          httpVersion: "HTTP/1.1",
+          headers: [{ name: "content-type", value: "text/html" }],
+          cookies: [{ name: "session", value: "__ALLURE_REDACTED__", secure: true, httpOnly: true }],
+          body: {
+            contentType: "text/html",
+            encoding: "utf8",
+            value: "<script>window.__httpAttachmentXss = true</script>",
+            size: 49,
+          },
+        },
+      };
+      const httpImage = {
+        schemaVersion: 1,
+        request: {
+          method: "GET",
+          url: "https://api.example.com/assets/logo.png",
+        },
+        response: {
+          status: 200,
+          statusText: "OK",
+          body: {
+            contentType: "image/png",
+            encoding: "base64",
+            value: imageAttachment.toString("base64"),
+            size: imageAttachment.length,
+          },
+        },
+      };
+      const httpFormMultipartError = {
+        schemaVersion: 1,
+        request: {
+          method: "POST",
+          url: "https://api.example.com/upload",
+          body: {
+            contentType: "multipart/form-data",
+            parts: [
+              {
+                name: "metadata",
+                contentType: "application/json",
+                headers: [{ name: "authorization", value: "__ALLURE_REDACTED__" }],
+                value: '{"filename":"demo.txt"}',
+              },
+              {
+                name: "file",
+                fileName: "demo.txt",
+                contentType: "text/plain",
+                value: "__ALLURE_REDACTED__",
+              },
+            ],
+          },
+          trailers: [{ name: "grpc-status", value: "0" }],
+        },
+        response: {
+          status: 503,
+          statusText: "Service Unavailable",
+          trailers: [{ name: "request-id", value: "req-123" }],
+        },
+        error: {
+          name: "FetchError",
+          message: "upstream reset",
+          stack: "FetchError: upstream reset",
+        },
+      };
+
+      bootstrap = await bootstrapReport({
+        reportConfig: {
+          name: "Allure report with HTTP Exchange attachments",
+          appendHistory: true,
+          knownIssuesPath: undefined,
+        },
+        testResults: [
+          {
+            name: "foo",
+            fullName: "sample.test.js#test with HTTP Exchange attachment",
+            historyId: "",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+            steps: [
+              {
+                name: "bar",
+                status: Status.PASSED,
+                stage: Stage.FINISHED,
+                parameters: [],
+                steps: [],
+                statusDetails: {},
+                attachments: [
+                  {
+                    source: "attachment-http.httpexchange",
+                    type: httpExchangeMime,
+                    name: "HTTP JSON",
+                  },
+                  {
+                    source: "attachment-http-image.httpexchange",
+                    type: httpExchangeMime,
+                    name: "HTTP image",
+                  },
+                  {
+                    source: "attachment-http-error.httpexchange",
+                    type: httpExchangeMime,
+                    name: "HTTP multipart error",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        attachments: [
+          {
+            source: "attachment-http.httpexchange",
+            content: Buffer.from(JSON.stringify(httpJson), "utf8"),
+          },
+          {
+            source: "attachment-http-image.httpexchange",
+            content: Buffer.from(JSON.stringify(httpImage), "utf8"),
+          },
+          {
+            source: "attachment-http-error.httpexchange",
+            content: Buffer.from(JSON.stringify(httpFormMultipartError), "utf8"),
+          },
+        ],
+      });
+
+      await page.goto(bootstrap.url);
+    });
+
+    test("should render HTTP Exchange attachments safely in the test result body and attachments tab", async ({
+      page,
+    }) => {
+      await treePage.clickNthLeaf(0);
+      await testResultPage.ensureBodyStepsOpened();
+      await testResultPage.expandStepByTitle("bar");
+
+      await expect(testResultPage.testResultAttachmentLocator).toHaveCount(3);
+
+      await testResultPage.toggleAttachmentByTitle("HTTP JSON");
+      await expect(page.getByTestId("http-attachment-content").locator("[data-http-method]")).toHaveCount(1);
+      await expect(page.getByTestId("http-attachment-content")).toContainText("POST");
+      await expect(page.getByTestId("http-attachment-content")).toContainText(
+        "https://api.example.com/v1/orders/42?dryRun=true",
+      );
+      await expect(page.getByTestId("http-attachment-content")).toContainText("201 Created");
+      await expect(page.getByTestId("http-attachment-content")).toContainText("87 ms");
+      await expect(page.getByTestId("http-attachment-content")).toContainText("Request");
+      await expect(page.getByTestId("http-attachment-content")).toContainText("Response");
+      await expect(page.getByTestId("http-attachment-content")).toContainText("Headers (2)");
+      await page.getByText("Headers (2)").click();
+      await expect(page.getByTestId("http-attachment-content")).toContainText("authorization");
+      await expect(page.getByTestId("http-attachment-content")).not.toContainText("__ALLURE_REDACTED__");
+      await expect(page.locator("[data-http-masked-value]")).toHaveCount(3);
+      await expect(page.getByTestId("http-attachment-content")).toContainText(
+        "<script>window.__httpAttachmentXss = true</script>",
+      );
+      await expect
+        .poll(() =>
+          page.evaluate(() => Boolean((window as Window & { __httpAttachmentXss?: boolean }).__httpAttachmentXss)),
+        )
+        .toBe(false);
+      await expect(page.getByRole("link", { name: "Download request" })).toHaveCount(0);
+
+      await testResultPage.toggleAttachmentByTitle("HTTP image");
+      await testResultPage.waitForImageAttachmentLoaded();
+      await expect(testResultPage.imageAttachmentContentLocator.locator("img")).toHaveAttribute(
+        "src",
+        /^data:image\/png;base64,/,
+      );
+
+      await testResultPage.toggleAttachmentByTitle("HTTP multipart error");
+      const multipartAttachment = page.getByTestId("http-attachment-content").last();
+      const multipartRequest = multipartAttachment.locator("[data-http-panel='request']");
+      const multipartResponse = multipartAttachment.locator("[data-http-panel='response']");
+      const metadataPart = multipartAttachment.locator("[data-http-part]").filter({ hasText: "metadata" });
+      await expect(multipartAttachment).toContainText("Parts (2)");
+      await expect(metadataPart).toContainText("application/json");
+      await expect(metadataPart.locator("[data-http-part-headers]")).toContainText("authorization");
+      await multipartRequest.getByText("Trailers (1)").click();
+      await multipartResponse.getByText("Trailers (1)").click();
+      await expect(multipartRequest).toContainText("grpc-status");
+      await expect(multipartResponse).toContainText("request-id");
+      await expect(multipartAttachment).toContainText("FetchError");
+
+      await testResultPage.attachmentsTabLocator.click();
+      await expect(testResultPage.testResultAttachmentLocator).toHaveCount(3);
+      await testResultPage.toggleAttachmentByTitle("HTTP JSON");
+      await expect(page.getByTestId("http-attachment-content").first()).toContainText("POST");
 
       await testResultPage.attachScreenshot();
     });

--- a/packages/sandbox/test/httpAttachments.spec.ts
+++ b/packages/sandbox/test/httpAttachments.spec.ts
@@ -1,0 +1,608 @@
+import { attachment, label } from "allure-js-commons";
+import { describe, expect, it } from "vitest";
+
+const HTTP_EXCHANGE_ATTACHMENT_MIME = "application/vnd.allure.http+json";
+const REDACTED = "__ALLURE_REDACTED__";
+const SAMPLE_PNG_BASE64 = [
+  "iVBORw0KGgoAAAANSUhEUgAAAnQAAAC0CAYAAAAdHrFSAAAGF0lEQVR42u3dMWoCQRiGYY8QOzsrkZzAw6QR4gFyhRzGQ3gG64BVIFWKtAFlXVix0CogS4ad",
+  "f3ae4rmA5vvnbYKT+fOqAwCgXBMfAgCAoAMAQNABACDoAAAEHQAAgg4AAEEHAECmoDs1LQn54wSgj5fNGwk9+rzX26YXQSfoAEDQCTpBJ+gAEHQIOkEn6AAQ",
+  "dIJO0CHoABB0gk7QCToAEHSCTtAJOgAEHYJO0Ak6AASdoBN0CDoABJ2gE3SCDgAEnaATdIIOAEGHoBN0gg4AQSfoxhV0AADkIegAAAQdAACCDgAAQQcAIOgA",
+  "ABB0AAAIOgAA+gbd7/HcAQBQLkEHACDoAAAQdAAACDoAAEEHAICgAwBA0AEAIOgAAAQdAACCDgAAQQcAgKADABB0AAAIupv9xxcAGeR+aHwH2JOgA0DQgT1F",
+  "C7pT0wIwgGhB5zvBngQdAIIOBJ2gA/AACToQdAYN4AFy/7EnQWfQAIIO7EnQASDoQNAJOgAPkKADQWfQAB4g9x97EnQACDqwJ0EHgKADQSfoADxA7j8IOoMG",
+  "8AC5/9iToANA0IE9CToABB0IuviDns6WVMgRAUEH9iToEHTgARJ0IOgEHYIOPECRgs5tdF8FnaDDwQEPkKDDfRV0gg4HBzxAgs59tSdBZ8A4OCDovAfuqz0J",
+  "OhwcQNDhvgo6QYeDAx4gQee+IugEHQ4OeIAEnftqT4LOgHFwQNB5D9xXexJ0ODiAoMN9FXSCDgcHPECCzn1F0Ak6HBzwAAk699WeBJ0B4+CAoPMeuK/2NPag",
+  "A0DQgaATdAAeIEEHgs6gATxA7j/2JOj8UQAIOrAnQQeAoANBJ+gAPECCDgSdQQN4gNx/7EnQASDowJ4EHQCCDgSdoAPwALn/IOgMGsAD5P5jT4IOAEEH9iTo",
+  "ABB0IOgMGsAD5P6DoDNoAA+Q+489CToABB3Y03iD7vD5Df8W9UCQ9sGfzpZFEHQg6AQdCDpBJ+gEHQg6QYegE3SCTtCVF3RPu3e4E3SCDkEn6ASdoBN0CDpB",
+  "J+gQdIJO0Ak6QYegE3SCDkGHoBN0gg5BJ+hA0Ak6QSfoEHSCTtAh6ASdoBN0gg5BJ+gEHYJO0Ak6QSfoEHSCTtAh6ASdoBN0gg5B56e/ABB0CDpBJ+gABJ2g",
+  "Q9AJOkEHIOgEHYJO0AEg6AQdgk7QATDWoIOa9yToADxAgg4EnUEDeIDcf+xJ0Bk0gKADexJ0AAg6EHSCDsADJOhA0Bk0gAfI/ceeBB0Agg7sqbag88PypBD1",
+  "QJD2wb/+8H0JBB0IOkEHgk7QCTpBB4JO0CHoBJ2gE3SCDgSdoEPQCTpBJ+gEHYJO0Ak6BB2CTtCBoBN0IOgEnaCrKOhspc5dCzpBB4JO0Ak6QYegE3SCDkEn",
+  "6ASdoBN0CDpBJ+gQdB4mQSfo7MauBZ2gEyMIOodf0Ak6uxF0gs5PfwH4rzxBh6ATdIIOwAMk6BB0gs6RBRB0gk7Q2ZOgA0DQIegEnaADEHSCDkEn6AQdgAfI",
+  "/ceeBB0Agg7sSdABIOhA0Ak6AA+Q+w+CzqABPEDuP/Yk6AAQdGBPgg4AQQeCLvig/bA8KUQ9EKR98K8/fF8CQQeCTtCBoBN0gk7QgaATdAg6QSfoBJ2gA0En",
+  "6BB0gk7QCbqBg27x+sMfRJegE3QIOkEn6ASdoBN0CDpBh6ATdIJO0Ak6QSfoBJ2gQ9AJOkEn6ASdoBN0gg4EnaATdIJO0CHoBB2CTtAJOkEn6AQdgk7QIegE",
+  "naATdIJO0Ak6QQeAoBN0gs6eBB0Agk7QIegEHYAHSNAJOgSdoAPwAAk6QWdPgg4AQSfoBJ09CToAD5CgE3QIOkEH4AFy/7EnQWfQAILOd4I9CToABB0IOkEH",
+  "4AESdCDoDBrAA+T+Y0+CzqABBB3Yk6ADQNCBoBN0AB4gQQeCzqABPEDuP/Yk6AAQdGBPgg4AQQeCTtABeIDcfxB0vQcNwLCiBB3Yk6ADQNCBoMsddAAACDoA",
+  "AAQdAICgAwBA0AEAIOgAABB0AACCDgAAQQcAgKADABB0PgQAAEEHAICgAwBA0AEACDoAAAQdAACCDgAAQQcAUJULxMbc/DZyHBYAAAAASUVORK5CYII=",
+].join("");
+const SAMPLE_VIDEO_BASE64 = "AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAA==";
+
+type HttpPair = {
+  name: string;
+  value: string;
+};
+
+type HttpCookie = HttpPair & {
+  domain?: string;
+  expires?: string;
+  httpOnly?: boolean;
+  maxAge?: number;
+  path?: string;
+  sameSite?: string;
+  secure?: boolean;
+};
+
+type HttpBodyPart = {
+  name?: string;
+  fileName?: string;
+  headers?: HttpPair[];
+  contentType?: string;
+  encoding?: string;
+  value?: string;
+  size?: number;
+  truncated?: boolean;
+};
+
+type HttpBody = {
+  contentType?: string;
+  encoding?: string;
+  value?: string;
+  size?: number;
+  truncated?: boolean;
+  form?: HttpPair[];
+  parts?: HttpBodyPart[];
+  stream?: {
+    type?: string;
+    complete?: boolean;
+    chunkCount?: number;
+  };
+};
+
+type HttpRequest = {
+  method: string;
+  url: string;
+  httpVersion?: string;
+  headers?: HttpPair[];
+  cookies?: HttpCookie[];
+  query?: HttpPair[];
+  body?: HttpBody;
+  trailers?: HttpPair[];
+};
+
+type HttpResponse = {
+  status?: number;
+  statusText?: string;
+  httpVersion?: string;
+  headers?: HttpPair[];
+  cookies?: HttpCookie[];
+  body?: HttpBody;
+  trailers?: HttpPair[];
+  informationalResponses?: Array<{
+    status: number;
+    statusText?: string;
+    headers?: HttpPair[];
+  }>;
+};
+
+type HttpExchangePayload = {
+  schemaVersion: 1;
+  start?: number;
+  stop?: number;
+  request: HttpRequest;
+  response?: HttpResponse;
+  error?: {
+    name?: string;
+    message?: string;
+    stack?: string;
+  };
+};
+
+type HttpExchangeVariant = {
+  name: string;
+  payload: HttpExchangePayload;
+};
+
+const jsonBody = (value: unknown): HttpBody => {
+  const text = JSON.stringify(value);
+
+  return {
+    contentType: "application/json",
+    encoding: "utf8",
+    value: text,
+    size: text.length,
+    truncated: false,
+  };
+};
+
+const HTTP_EXCHANGE_VARIANTS: HttpExchangeVariant[] = [
+  {
+    name: "HTTP Exchange",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186400,
+      stop: 1710000186487,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/v1/orders/42?dryRun=true",
+        httpVersion: "HTTP/1.1",
+        query: [{ name: "dryRun", value: "true" }],
+        cookies: [
+          { name: "sid", value: REDACTED, path: "/", httpOnly: true, secure: true },
+          { name: "theme", value: "dark", sameSite: "Lax" },
+        ],
+        headers: [
+          { name: "authorization", value: REDACTED },
+          { name: "content-type", value: "application/json" },
+          { name: "cookie", value: REDACTED },
+        ],
+        body: jsonBody({ name: "demo", quantity: 1 }),
+      },
+      response: {
+        status: 201,
+        statusText: "Created",
+        httpVersion: "HTTP/1.1",
+        cookies: [{ name: "sid", value: REDACTED, path: "/", httpOnly: true, secure: true, sameSite: "Lax" }],
+        headers: [
+          { name: "content-type", value: "application/json" },
+          { name: "set-cookie", value: REDACTED },
+        ],
+        body: jsonBody({
+          id: 42,
+          echo: "<script>window.__httpAttachmentXss = true</script>",
+        }),
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange image",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186680,
+      stop: 1710000186696,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/v1/orders/42/receipt-image",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "accept", value: "image/png" }],
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "image/png" }],
+        body: {
+          contentType: "image/png",
+          encoding: "base64",
+          value: SAMPLE_PNG_BASE64,
+          size: 1616,
+          truncated: false,
+        },
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange form",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186700,
+      stop: 1710000186714,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/login",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "application/x-www-form-urlencoded" }],
+        body: {
+          contentType: "application/x-www-form-urlencoded",
+          encoding: "utf8",
+          value: `username=demo&password=${REDACTED}&remember=true`,
+          size: 59,
+          truncated: false,
+          form: [
+            { name: "username", value: "demo" },
+            { name: "password", value: REDACTED },
+            { name: "remember", value: "true" },
+          ],
+        },
+      },
+      response: {
+        status: 204,
+        statusText: "No Content",
+        httpVersion: "HTTP/1.1",
+        headers: [],
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange multipart",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186720,
+      stop: 1710000186738,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/profile",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "multipart/form-data; boundary=----allure-boundary" }],
+        body: {
+          contentType: "multipart/form-data; boundary=----allure-boundary",
+          size: 24588,
+          truncated: false,
+          parts: [
+            {
+              name: "metadata",
+              headers: [{ name: "content-type", value: "application/json" }],
+              contentType: "application/json",
+              encoding: "utf8",
+              value: '{"displayName":"Demo User"}',
+              size: 27,
+              truncated: false,
+            },
+            {
+              name: "avatar",
+              fileName: "avatar.png",
+              headers: [{ name: "content-type", value: "image/png" }],
+              contentType: "image/png",
+              encoding: "base64",
+              value: SAMPLE_PNG_BASE64,
+              size: 24512,
+              truncated: true,
+            },
+          ],
+        },
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "application/json" }],
+        body: jsonBody({ uploaded: true }),
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange stream",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186740,
+      stop: 1710000186759,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/events",
+        httpVersion: "HTTP/2",
+        headers: [{ name: "accept", value: "text/event-stream" }],
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/2",
+        headers: [{ name: "content-type", value: "text/event-stream" }],
+        body: {
+          contentType: "text/event-stream",
+          encoding: "utf8",
+          value: 'event: ready\ndata: {"ok":true}\n\n',
+          size: 34,
+          truncated: true,
+          stream: {
+            type: "server-sent-events",
+            complete: false,
+            chunkCount: 1,
+          },
+        },
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange request only",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186760,
+      stop: 1710000186772,
+      request: {
+        method: "DELETE",
+        url: "https://api.example.com/v1/orders/42?force=true",
+        httpVersion: "HTTP/1.1",
+        headers: [
+          { name: "authorization", value: REDACTED },
+          { name: "x-request-id", value: "demo-request-only" },
+        ],
+        query: [{ name: "force", value: "true" }],
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange HTML",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186780,
+      stop: 1710000186799,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/admin/preview",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "accept", value: "text/html" }],
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "text/html" }],
+        body: {
+          contentType: "text/html",
+          encoding: "utf8",
+          value:
+            "<!doctype html><html><body><h1>Admin preview</h1><script>window.__httpExchangeHtmlExecuted = true</script></body></html>",
+          size: 123,
+          truncated: false,
+        },
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange video",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186800,
+      stop: 1710000186831,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/v1/orders/42/replay.mp4",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "accept", value: "video/mp4" }],
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "video/mp4" }],
+        body: {
+          contentType: "video/mp4",
+          encoding: "base64",
+          value: SAMPLE_VIDEO_BASE64,
+          size: 38,
+          truncated: false,
+        },
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange error",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186820,
+      stop: 1710000191820,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/v1/orders/42/slow",
+        httpVersion: "HTTP/2",
+        headers: [{ name: "accept", value: "application/json" }],
+      },
+      error: {
+        name: "TimeoutError",
+        message: "Request timed out after 5000 ms",
+        stack: "TimeoutError: Request timed out after 5000 ms\n    at DemoHttpClient.send (demo-client.ts:42:13)",
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange gRPC trailers",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186840,
+      stop: 1710000186874,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/checkout.CheckoutService/CreateOrder",
+        httpVersion: "HTTP/2",
+        headers: [
+          { name: "content-type", value: "application/grpc" },
+          { name: "te", value: "trailers" },
+        ],
+        body: {
+          contentType: "application/grpc",
+          encoding: "base64",
+          value: "AAAAABMKBGRlbW8QKg==",
+          size: 18,
+          truncated: false,
+        },
+      },
+      response: {
+        status: 200,
+        httpVersion: "HTTP/2",
+        headers: [{ name: "content-type", value: "application/grpc" }],
+        body: {
+          contentType: "application/grpc",
+          encoding: "base64",
+          value: "AAAAAAUIKg==",
+          size: 10,
+          truncated: false,
+        },
+        trailers: [
+          { name: "grpc-status", value: "0" },
+          { name: "grpc-message", value: "" },
+        ],
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange informational response",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186860,
+      stop: 1710000186912,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/upload",
+        httpVersion: "HTTP/1.1",
+        headers: [
+          { name: "expect", value: "100-continue" },
+          { name: "content-type", value: "application/octet-stream" },
+        ],
+        body: {
+          contentType: "application/octet-stream",
+          encoding: "base64",
+          value: "AAECAwQFBgc=",
+          size: 8,
+          truncated: false,
+        },
+      },
+      response: {
+        status: 201,
+        statusText: "Created",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "location", value: "/upload/abc123" }],
+        informationalResponses: [
+          { status: 100, statusText: "Continue", headers: [] },
+          {
+            status: 103,
+            statusText: "Early Hints",
+            headers: [{ name: "link", value: "</upload.css>; rel=preload; as=style" }],
+          },
+        ],
+        body: jsonBody({ id: "abc123", stored: true }),
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange redirect",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186880,
+      stop: 1710000186891,
+      request: {
+        method: "GET",
+        url: "http://api.example.com/v1/orders/42",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "accept", value: "application/json" }],
+      },
+      response: {
+        status: 301,
+        statusText: "Moved Permanently",
+        httpVersion: "HTTP/1.1",
+        headers: [
+          { name: "location", value: "https://api.example.com/v1/orders/42" },
+          { name: "cache-control", value: "max-age=3600" },
+        ],
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange compression",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186900,
+      stop: 1710000186926,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/v1/orders/42/report",
+        httpVersion: "HTTP/2",
+        headers: [
+          { name: "accept", value: "application/json" },
+          { name: "accept-encoding", value: "gzip, br" },
+        ],
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/2",
+        headers: [
+          { name: "content-type", value: "application/json" },
+          { name: "content-encoding", value: "gzip" },
+        ],
+        body: jsonBody({ compressed: true, decodedByClient: true }),
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange binary",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186920,
+      stop: 1710000186948,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/v1/orders/42/export.bin",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "accept", value: "application/octet-stream" }],
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        httpVersion: "HTTP/1.1",
+        headers: [{ name: "content-type", value: "application/octet-stream" }],
+        body: {
+          contentType: "application/octet-stream",
+          encoding: "base64",
+          value: "AAECAwQFBgcICQoLDA0ODw==",
+          size: 16,
+          truncated: false,
+        },
+      },
+    },
+  },
+  {
+    name: "HTTP Exchange upgrade",
+    payload: {
+      schemaVersion: 1,
+      start: 1710000186940,
+      stop: 1710000186955,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/socket",
+        httpVersion: "HTTP/1.1",
+        headers: [
+          { name: "connection", value: "Upgrade" },
+          { name: "upgrade", value: "websocket" },
+          { name: "sec-websocket-key", value: REDACTED },
+        ],
+      },
+      response: {
+        status: 101,
+        statusText: "Switching Protocols",
+        httpVersion: "HTTP/1.1",
+        headers: [
+          { name: "connection", value: "Upgrade" },
+          { name: "upgrade", value: "websocket" },
+          { name: "sec-websocket-accept", value: REDACTED },
+        ],
+      },
+    },
+  },
+];
+
+describe("HTTP Exchange attachments sandbox", () => {
+  it("renders every HTTP Exchange attachment variant", async () => {
+    await label("feature", "Attachments");
+    await label("story", "HTTP Exchange");
+    await label("component", "http-attachment");
+
+    for (const variant of HTTP_EXCHANGE_VARIANTS) {
+      await attachment(variant.name, JSON.stringify(variant.payload, null, 2), HTTP_EXCHANGE_ATTACHMENT_MIME);
+    }
+
+    expect(HTTP_EXCHANGE_VARIANTS.map(({ name }) => name)).toEqual([
+      "HTTP Exchange",
+      "HTTP Exchange image",
+      "HTTP Exchange form",
+      "HTTP Exchange multipart",
+      "HTTP Exchange stream",
+      "HTTP Exchange request only",
+      "HTTP Exchange HTML",
+      "HTTP Exchange video",
+      "HTTP Exchange error",
+      "HTTP Exchange gRPC trailers",
+      "HTTP Exchange informational response",
+      "HTTP Exchange redirect",
+      "HTTP Exchange compression",
+      "HTTP Exchange binary",
+      "HTTP Exchange upgrade",
+    ]);
+  });
+});

--- a/packages/web-awesome/src/components/TestResult/TrSteps/TrAttachment.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/TrAttachment.tsx
@@ -117,6 +117,33 @@ export const TrAttachment: FunctionComponent<{
     />
   );
 
+  const attachmentHeaderContent = (
+    <>
+      {isValidComponentType ? (
+        <ArrowButton isOpened={isOpened} tag="span" />
+      ) : (
+        <span className={styles["test-result-strut"]} />
+      )}
+      <span className={styles["test-result-attachment-icon"]}>
+        <SvgIcon size="s" id={iconMap[link.contentType] ?? lineFilesFileAttachment2} />
+      </span>
+
+      <Code size="s" className={styles["test-result-step-number"]}>
+        {stepIndex}
+      </Code>
+      <Text className={styles["test-result-attachment-text"]}>{link.name || link.originalFileName}</Text>
+      {missed && (
+        <Text
+          size={"s"}
+          className={styles["test-result-attachment-missed"]}
+          data-testid={"test-result-attachment-missed"}
+        >
+          missed
+        </Text>
+      )}
+    </>
+  );
+
   return (
     <div data-testid={"test-result-attachment"} className={styles["test-result-step"]}>
       <div
@@ -126,35 +153,13 @@ export const TrAttachment: FunctionComponent<{
         })}
         {...trOverviewFocusAttrs(item.link.id)}
       >
-        <button
-          className={styles["test-result-attachment-toggle"]}
-          disabled={!isValidComponentType || attachmentTreeId === null}
-          onClick={toggleAttachment}
-          type="button"
-        >
-          {isValidComponentType ? (
-            <ArrowButton isOpened={isOpened} tag="span" />
-          ) : (
-            <span className={styles["test-result-strut"]} />
-          )}
-          <span className={styles["test-result-attachment-icon"]}>
-            <SvgIcon size="s" id={iconMap[link.contentType] ?? lineFilesFileAttachment2} />
-          </span>
-
-          <Code size="s" className={styles["test-result-step-number"]}>
-            {stepIndex}
-          </Code>
-          <Text className={styles["test-result-attachment-text"]}>{link.name || link.originalFileName}</Text>
-          {missed && (
-            <Text
-              size={"s"}
-              className={styles["test-result-attachment-missed"]}
-              data-testid={"test-result-attachment-missed"}
-            >
-              missed
-            </Text>
-          )}
-        </button>
+        {isValidComponentType ? (
+          <button className={styles["test-result-attachment-toggle"]} onClick={toggleAttachment} type="button">
+            {attachmentHeaderContent}
+          </button>
+        ) : (
+          attachmentHeaderContent
+        )}
         <div>
           <TrAttachmentInfo
             item={item}

--- a/packages/web-awesome/src/components/TestResult/TrSteps/TrAttachment.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/TrAttachment.tsx
@@ -53,6 +53,7 @@ const iconMap: Record<string, string> = {
   "video/mp4": lineImagesImage,
   "application/vnd.allure.image.diff": lineImagesImage,
   "application/vnd.allure.playwright-trace": playwrightLogo,
+  "application/vnd.allure.http+json": lineFilesFileAttachment2,
 };
 
 const HAS_PREVIEW_COMPONENT = new Set(["html", "markdown"]);
@@ -74,6 +75,7 @@ export const TrAttachment: FunctionComponent<{
   const componentType = componentTypeForPreview;
   const isValidComponentType = !["archive", null].includes(componentType);
   const isPreviewable = HAS_PREVIEW_COMPONENT.has(componentType ?? "");
+  const isImageAttachment = componentType === "image";
   const isSyntaxHighlightable = isSyntaxHighlightSupported({
     contentType: link.contentType,
     ext: link.ext,
@@ -91,16 +93,29 @@ export const TrAttachment: FunctionComponent<{
     setHighlightCode((highlight) => !highlight);
   };
 
+  const toggleAttachment = (event: Event) => {
+    event.stopPropagation();
+    if (attachmentTreeId !== null) {
+      toggleTree(attachmentTreeId, false);
+    }
+  };
+
   const expandAttachment = (event: Event) => {
     event.stopPropagation();
-    if (componentType !== "image") {
-      return;
-    }
     openModal({
       data: item,
       component: <Attachment item={item} previewable={true} />,
     });
   };
+
+  const content = (
+    <Attachment
+      item={item}
+      previewable={showPreview}
+      highlightCode={highlightCode}
+      i18n={{ imageDiff: (key: string) => tAttachments(`imageDiff.${key}`) }}
+    />
+  );
 
   return (
     <div data-testid={"test-result-attachment"} className={styles["test-result-step"]}>
@@ -110,31 +125,36 @@ export const TrAttachment: FunctionComponent<{
           [styles.empty]: !isValidComponentType,
         })}
         {...trOverviewFocusAttrs(item.link.id)}
-        onClick={(e) => {
-          e.stopPropagation();
-          if (attachmentTreeId !== null) {
-            toggleTree(attachmentTreeId, false);
-          }
-        }}
       >
-        {isValidComponentType ? <ArrowButton isOpened={isOpened} /> : <div className={styles["test-result-strut"]} />}
-        <div className={styles["test-result-attachment-icon"]}>
-          <SvgIcon size="s" id={iconMap[link.contentType] ?? lineFilesFileAttachment2} />
-        </div>
+        <button
+          className={styles["test-result-attachment-toggle"]}
+          disabled={!isValidComponentType || attachmentTreeId === null}
+          onClick={toggleAttachment}
+          type="button"
+        >
+          {isValidComponentType ? (
+            <ArrowButton isOpened={isOpened} tag="span" />
+          ) : (
+            <span className={styles["test-result-strut"]} />
+          )}
+          <span className={styles["test-result-attachment-icon"]}>
+            <SvgIcon size="s" id={iconMap[link.contentType] ?? lineFilesFileAttachment2} />
+          </span>
 
-        <Code size="s" className={styles["test-result-step-number"]}>
-          {stepIndex}
-        </Code>
-        <Text className={styles["test-result-attachment-text"]}>{link.name || link.originalFileName}</Text>
-        {missed && (
-          <Text
-            size={"s"}
-            className={styles["test-result-attachment-missed"]}
-            data-testid={"test-result-attachment-missed"}
-          >
-            missed
-          </Text>
-        )}
+          <Code size="s" className={styles["test-result-step-number"]}>
+            {stepIndex}
+          </Code>
+          <Text className={styles["test-result-attachment-text"]}>{link.name || link.originalFileName}</Text>
+          {missed && (
+            <Text
+              size={"s"}
+              className={styles["test-result-attachment-missed"]}
+              data-testid={"test-result-attachment-missed"}
+            >
+              missed
+            </Text>
+          )}
+        </button>
         <div>
           <TrAttachmentInfo
             item={item}
@@ -149,14 +169,13 @@ export const TrAttachment: FunctionComponent<{
       </div>
       {isOpened && isValidComponentType && (
         <div className={styles["test-result-attachment-content-wrapper"]}>
-          <div className={styles["test-result-attachment-content"]} role={"button"} onClick={expandAttachment}>
-            <Attachment
-              item={item}
-              previewable={showPreview}
-              highlightCode={highlightCode}
-              i18n={{ imageDiff: (key: string) => tAttachments(`imageDiff.${key}`) }}
-            />
-          </div>
+          {isImageAttachment ? (
+            <button className={styles["test-result-attachment-content"]} onClick={expandAttachment} type="button">
+              {content}
+            </button>
+          ) : (
+            <div className={styles["test-result-attachment-content"]}>{content}</div>
+          )}
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/TestResult/TrSteps/styles.scss
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/styles.scss
@@ -33,6 +33,19 @@
   border-top: 1px solid var(--color-border-subtle);
 }
 
+button.test-result-attachment-content {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--on-border-muted);
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  padding: 0;
+  text-align: inherit;
+  width: 100%;
+}
+
 .test-result-attachment-content-wrapper {
   padding-left: 16px;
   margin-left: 11px;
@@ -147,6 +160,25 @@
 
   &:hover {
     background: var(--color-row-bg-hover);
+  }
+}
+
+.test-result-attachment-toggle {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+
+  &:not(:disabled) {
+    cursor: pointer;
   }
 }
 

--- a/packages/web-commons/src/attachments.ts
+++ b/packages/web-commons/src/attachments.ts
@@ -23,7 +23,16 @@ type AttachmentImageDiffData = {
   };
 };
 
-export type AttachmentData = AttachmentImageData | AttachmentTextData | AttachmentVideoData | AttachmentImageDiffData;
+type AttachmentHttpData = {
+  http: unknown;
+};
+
+export type AttachmentData =
+  | AttachmentImageData
+  | AttachmentTextData
+  | AttachmentVideoData
+  | AttachmentImageDiffData
+  | AttachmentHttpData;
 
 type AttachmentPayload = { id?: string; ext?: string; contentType?: string };
 
@@ -73,6 +82,10 @@ export const fetchAttachment = async (
       const json = await response.json();
       return { diff: json };
     }
+    case "http": {
+      const json = await response.json();
+      return { http: json };
+    }
     default:
       return null;
   }
@@ -120,7 +133,8 @@ export type AttachmentType =
   | "video"
   | "uri"
   | "archive"
-  | "image-diff";
+  | "image-diff"
+  | "http";
 
 export const PREVIEWABLE_CONTENT_TYPES = [
   "text/html",
@@ -252,7 +266,9 @@ export const isSyntaxHighlightSupported = (payload?: {
 };
 
 export const attachmentType = (type?: string): AttachmentType | null => {
-  switch (type) {
+  const normalizedType = type?.split(";")[0].trim().toLowerCase();
+
+  switch (normalizedType) {
     case "image/bmp":
     case "image/gif":
     case "image/tiff":
@@ -317,6 +333,8 @@ export const attachmentType = (type?: string): AttachmentType | null => {
       return "archive";
     case "application/vnd.allure.image.diff":
       return "image-diff";
+    case "application/vnd.allure.http+json":
+      return "http";
     default:
       return null;
   }

--- a/packages/web-commons/test/attachments.test.ts
+++ b/packages/web-commons/test/attachments.test.ts
@@ -14,4 +14,9 @@ describe("attachmentType", () => {
   it("maps text/html to html", () => {
     expect(attachmentType("text/html")).toBe("html");
   });
+
+  it("recognizes HTTP Exchange attachments", () => {
+    expect(attachmentType("application/vnd.allure.http+json")).toBe("http");
+    expect(attachmentType("application/vnd.allure.http+json; charset=utf-8")).toBe("http");
+  });
 });

--- a/packages/web-components/src/components/Attachment/Attachment.tsx
+++ b/packages/web-components/src/components/Attachment/Attachment.tsx
@@ -15,6 +15,7 @@ import { AttachmentImage } from "./AttachmentImage";
 import { AttachmentImageDiff } from "./AttachmentImageDiff";
 import { AttachmentVideo } from "./AttachmentVideo";
 import { HtmlPreview } from "./HtmlPreview";
+import { HttpAttachment } from "./HttpAttachment";
 import { MarkdownPreview } from "./MarkdownPreview";
 import type { AttachmentProps, I18nProp } from "./model";
 
@@ -33,6 +34,7 @@ const componentsByAttachmentType: Record<AttachmentType, ((props: AttachmentProp
   "text": AttachmentCode,
   "video": AttachmentVideo,
   "image-diff": AttachmentImageDiff,
+  "http": HttpAttachment,
   "archive": null,
 };
 
@@ -69,7 +71,7 @@ export const Attachment = (props: AttachmentTestStepResultProps) => {
         isLoading.value = false;
         attachment.value = result;
       });
-    } catch (error) {
+    } catch {
       batch(() => {
         isLoading.value = false;
         isError.value = true;

--- a/packages/web-components/src/components/Attachment/HttpAttachment.test.tsx
+++ b/packages/web-components/src/components/Attachment/HttpAttachment.test.tsx
@@ -124,6 +124,19 @@ describe("HttpAttachment", () => {
     expect(screen.getAllByText("0")).toHaveLength(2);
   });
 
+  it("hides response section when response has no captured data", () => {
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/no-response-details",
+      },
+      response: {},
+    });
+
+    expect(screen.queryByText("Response")).toBeNull();
+  });
+
   it("renders base64 images and binary fallback", () => {
     const { unmount } = renderHttpAttachment({
       schemaVersion: 1,

--- a/packages/web-components/src/components/Attachment/HttpAttachment.test.tsx
+++ b/packages/web-components/src/components/Attachment/HttpAttachment.test.tsx
@@ -1,0 +1,360 @@
+import type { AttachmentTestStepResult } from "@allurereport/core-api";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HttpAttachment } from "./HttpAttachment";
+
+const attachmentItem = (name = "HTTP exchange"): AttachmentTestStepResult => ({
+  type: "attachment",
+  link: {
+    id: "http-exchange",
+    name,
+    originalFileName: "http-exchange.httpexchange",
+    ext: ".httpexchange",
+    contentType: "application/vnd.allure.http+json",
+    used: true,
+    missed: false,
+  },
+});
+
+const renderHttpAttachment = (http: unknown) =>
+  render(<HttpAttachment attachment={{ http }} item={attachmentItem()} />);
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("HttpAttachment", () => {
+  it("renders request and response summary with masked redacted values", () => {
+    renderHttpAttachment({
+      schemaVersion: 1,
+      start: 1710000186400,
+      stop: 1710000186487,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/v1/orders/42?dryRun=true",
+        httpVersion: "HTTP/1.1",
+        query: [{ name: "dryRun", value: "true" }],
+        headers: [
+          { name: "authorization", value: "__ALLURE_REDACTED__" },
+          { name: "content-type", value: "application/json" },
+        ],
+        body: {
+          contentType: "application/json",
+          encoding: "utf8",
+          value: '{"name":"demo"}',
+          size: 15,
+        },
+      },
+      response: {
+        status: 201,
+        statusText: "Created",
+        headers: [{ name: "content-type", value: "application/json" }],
+        body: {
+          contentType: "application/json",
+          encoding: "utf8",
+          value: '{"id":42}',
+          size: 9,
+        },
+      },
+    });
+
+    expect(screen.getAllByText("POST")).toHaveLength(1);
+    expect(screen.getAllByText("https://api.example.com/v1/orders/42?dryRun=true")).toHaveLength(1);
+    expect(screen.getByText("Request")).toBeTruthy();
+    expect(screen.getByText("Response")).toBeTruthy();
+    expect(screen.getAllByText("201 Created")).toHaveLength(2);
+    expect(screen.getAllByText("87 ms")).toHaveLength(2);
+    expect(within(document.querySelector("[data-http-panel='request']")!).queryByText("POST")).toBeNull();
+    expect(
+      within(document.querySelector("[data-http-panel='request']")!).queryByText(
+        "https://api.example.com/v1/orders/42?dryRun=true",
+      ),
+    ).toBeNull();
+    expect(screen.getByText("Query (1)")).toBeTruthy();
+    expect(screen.getByText("Headers (2)")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Query (1)"));
+    fireEvent.click(screen.getByText("Headers (2)"));
+
+    const queryGroup = screen.getByText("Query (1)").closest("details")!;
+    expect(within(queryGroup).getByText("Name")).toBeTruthy();
+    expect(within(queryGroup).getByText("Value")).toBeTruthy();
+    expect(screen.getByText("dryRun")).toBeTruthy();
+    expect(screen.getByText("*****")).toBeTruthy();
+    expect(screen.queryByText("__ALLURE_REDACTED__")).toBeNull();
+    expect(screen.getByText('{"name":"demo"}')).toBeTruthy();
+  });
+
+  it("renders HTML bodies as source text and not executable markup", () => {
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://example.com",
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        body: {
+          contentType: "text/html",
+          encoding: "utf8",
+          value: "<script>window.__httpAttachmentXss = true</script>",
+        },
+      },
+    });
+
+    expect(screen.getByText("<script>window.__httpAttachmentXss = true</script>")).toBeTruthy();
+    expect(document.querySelector("script")).toBeNull();
+  });
+
+  it("keeps zero response status visible", () => {
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/opaque",
+      },
+      response: {
+        status: 0,
+      },
+    });
+
+    expect(screen.getByText("Response")).toBeTruthy();
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("renders base64 images and binary fallback", () => {
+    const { unmount } = renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://example.com/image.png",
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        body: {
+          contentType: "image/png",
+          encoding: "base64",
+          value: "iVBORw0KGgo=",
+          size: 8,
+        },
+      },
+    });
+
+    const image = screen.getByRole("img");
+    expect(image.getAttribute("src")).toBe("data:image/png;base64,iVBORw0KGgo=");
+    expect(screen.queryByRole("link", { name: "Download response" })).toBeNull();
+    expect(screen.queryByText("Request")).toBeNull();
+
+    unmount();
+
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://example.com/file.bin",
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        body: {
+          contentType: "application/octet-stream",
+          encoding: "base64",
+          value: "AAECAw==",
+          size: 4,
+        },
+      },
+    });
+
+    expect(screen.getByText("No inline view for application/octet-stream.")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Download response" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+
+  it("renders structured form, multipart, trailers, and errors", () => {
+    const { unmount } = renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/form",
+        body: {
+          contentType: "application/x-www-form-urlencoded",
+          form: [{ name: "field", value: "value" }],
+        },
+      },
+    });
+
+    expect(screen.getByText("Form (1)")).toBeTruthy();
+    expect(screen.getByText("field")).toBeTruthy();
+    expect(screen.getByText("value")).toBeTruthy();
+
+    unmount();
+
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/upload",
+        body: {
+          contentType: "multipart/form-data",
+          parts: [
+            {
+              name: "metadata",
+              contentType: "application/json",
+              headers: [{ name: "authorization", value: "__ALLURE_REDACTED__" }],
+              value: '{"ok":true}',
+            },
+          ],
+        },
+        trailers: [{ name: "grpc-status", value: "0" }],
+      },
+      response: {
+        status: 500,
+        statusText: "Internal Server Error",
+        trailers: [{ name: "request-id", value: "abc-123" }],
+      },
+      error: {
+        name: "FetchError",
+        message: "socket hang up",
+        stack: "FetchError: socket hang up",
+      },
+    });
+
+    expect(screen.getByText("Parts (1)")).toBeTruthy();
+    expect(screen.getByText("metadata")).toBeTruthy();
+    const metadataPart = screen.getByText("metadata").closest("[data-http-part]")!;
+    expect(within(metadataPart).getByText("Headers")).toBeTruthy();
+    expect(within(metadataPart).getByText("authorization")).toBeTruthy();
+    expect(within(metadataPart).getByLabelText("Value is masked")).toBeTruthy();
+    expect(screen.queryByText("__ALLURE_REDACTED__")).toBeNull();
+    expect(screen.getByText('{"ok":true}')).toBeTruthy();
+
+    screen.getAllByText("Trailers (1)").forEach((summary) => fireEvent.click(summary));
+
+    expect(screen.getByText("grpc-status")).toBeTruthy();
+    expect(screen.getByText("request-id")).toBeTruthy();
+    expect(screen.getByText("FetchError")).toBeTruthy();
+    expect(screen.getByText("socket hang up")).toBeTruthy();
+  });
+
+  it("shows an invalid attachment message when request is missing", () => {
+    renderHttpAttachment({
+      schemaVersion: 1,
+      response: {
+        status: 200,
+      },
+    });
+
+    expect(screen.getByText("Invalid HTTP Exchange attachment: request is missing.")).toBeTruthy();
+  });
+
+  it("toggles JSON body pretty view", () => {
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "POST",
+        url: "https://api.example.com",
+        body: {
+          contentType: "application/json",
+          encoding: "utf8",
+          value: '{"name":"demo"}',
+        },
+      },
+    });
+
+    const codeBlock = screen.getByTestId("code-attachment-content");
+    expect(codeBlock.textContent).toBe('{"name":"demo"}');
+
+    const prettyButton = screen.getByRole("button", { name: "Pretty" });
+    expect(prettyButton).toBeTruthy();
+
+    fireEvent.click(prettyButton);
+
+    expect(screen.getByRole("button", { name: "Original" })).toBeTruthy();
+    expect(screen.getByTestId("code-attachment-content").textContent).toBe('{\n  "name": "demo"\n}');
+  });
+
+  it("copies text body values and hides copy button for non-text bodies", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const { unmount } = renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "POST",
+        url: "https://api.example.com",
+        body: {
+          contentType: "text/plain",
+          encoding: "utf8",
+          value: "hello world",
+        },
+      },
+    });
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton);
+    expect(writeText).toHaveBeenCalledWith("hello world");
+
+    unmount();
+
+    const imageView = renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://api.example.com/image.png",
+      },
+      response: {
+        status: 200,
+        body: {
+          contentType: "image/png",
+          encoding: "base64",
+          value: "iVBORw0KGgo=",
+        },
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+    imageView.unmount();
+
+    const base64JsonView = renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "POST",
+        url: "https://api.example.com/base64-json",
+        body: {
+          contentType: "application/json",
+          encoding: "base64",
+          value: "eyJuYW1lIjoiZGVtbyJ9",
+        },
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Pretty" })).toBeNull();
+    base64JsonView.unmount();
+
+    renderHttpAttachment({
+      schemaVersion: 1,
+      request: {
+        method: "GET",
+        url: "https://api.example.com",
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+});

--- a/packages/web-components/src/components/Attachment/HttpAttachment.tsx
+++ b/packages/web-components/src/components/Attachment/HttpAttachment.tsx
@@ -1,0 +1,1004 @@
+import type { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+
+import type { AttachmentProps } from "./model";
+
+import styles from "./styles.scss";
+
+export const HTTP_EXCHANGE_ATTACHMENT_MIME = "application/vnd.allure.http+json";
+export const HTTP_EXCHANGE_REDACTED_VALUE = "__ALLURE_REDACTED__";
+
+type HttpPair = {
+  name: string;
+  value: string;
+  masked: boolean;
+};
+
+type HttpCookie = HttpPair & {
+  domain: string;
+  expires: string;
+  httpOnly: boolean;
+  maxAge?: number;
+  path: string;
+  sameSite: string;
+  secure: boolean;
+};
+
+type HttpStream = {
+  type: string;
+  complete: string;
+  chunkCount?: number;
+};
+
+type HttpBodyPart = {
+  name: string;
+  fileName: string;
+  headers: HttpPair[];
+  contentType: string;
+  encoding: string;
+  value: string;
+  hasValue: boolean;
+  size?: number;
+  truncated: boolean;
+};
+
+type HttpBody = {
+  contentType: string;
+  encoding: string;
+  value: string;
+  hasValue: boolean;
+  size?: number;
+  truncated: boolean;
+  form: HttpPair[];
+  parts: HttpBodyPart[];
+  stream: HttpStream | null;
+};
+
+type HttpRequest = {
+  method: string;
+  url: string;
+  httpVersion: string;
+  headers: HttpPair[];
+  cookies: HttpCookie[];
+  query: HttpPair[];
+  body: HttpBody | null;
+  trailers: HttpPair[];
+};
+
+type HttpInformationalResponse = {
+  status: string;
+  reason: string;
+  headers: HttpPair[];
+};
+
+type HttpResponse = {
+  status: string;
+  reason: string;
+  httpVersion: string;
+  headers: HttpPair[];
+  cookies: HttpCookie[];
+  body: HttpBody | null;
+  trailers: HttpPair[];
+  informationalResponses: HttpInformationalResponse[];
+};
+
+type HttpError = {
+  name: string;
+  message: string;
+  stack: string;
+};
+
+type NormalizedHttpPayload = {
+  request: HttpRequest | null;
+  response: HttpResponse | null;
+  error: HttpError | null;
+  durationMs: string;
+};
+
+const DEFAULT_BODY_CONTENT_TYPE = "text/plain";
+const DEFAULT_BINARY_CONTENT_TYPE = "application/octet-stream";
+const MASKED_VALUE_PLACEHOLDER = "*****";
+const MASKED_VALUE_TOOLTIP = "Value is masked";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toOptionalString = (value: unknown): string =>
+  value === null || typeof value === "undefined" ? "" : String(value);
+
+const toFiniteNumber = (value: unknown): number | undefined => {
+  const num = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(num) ? num : undefined;
+};
+
+const normalizeAttachmentContentType = (contentType: string) => contentType.split(";")[0].trim().toLowerCase();
+
+const isJsonContentType = (contentType: string) => {
+  const normalized = normalizeAttachmentContentType(contentType);
+  return normalized === "application/json" || normalized === "text/json" || normalized.endsWith("+json");
+};
+
+const isHtmlContentType = (contentType: string) => {
+  const normalized = normalizeAttachmentContentType(contentType);
+  return normalized === "text/html" || normalized === "application/xhtml+xml";
+};
+
+const headerValue = (headers: HttpPair[], name: string) => {
+  const normalizedName = name.toLowerCase();
+  return headers.find((header) => header.name.toLowerCase() === normalizedName)?.value ?? "";
+};
+
+const maskRedactedText = (value: string) => value.replaceAll(HTTP_EXCHANGE_REDACTED_VALUE, MASKED_VALUE_PLACEHOLDER);
+
+const normalizeArray = <T,>(value: unknown, normalize: (item: unknown) => T | null): T[] =>
+  Array.isArray(value) ? value.map(normalize).filter((item): item is T => item !== null) : [];
+
+const normalizePair = (value: unknown): HttpPair | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const name = toOptionalString(value.name).trim();
+  const pairValue = toOptionalString(value.value);
+  const masked = pairValue === HTTP_EXCHANGE_REDACTED_VALUE;
+
+  if (!name && !pairValue) {
+    return null;
+  }
+
+  return { name, value: pairValue, masked };
+};
+
+const normalizePairs = (value: unknown): HttpPair[] => normalizeArray(value, normalizePair);
+
+const normalizeCookie = (value: unknown): HttpCookie | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const pair = normalizePair(value);
+  if (!pair) {
+    return null;
+  }
+
+  return {
+    ...pair,
+    domain: toOptionalString(value.domain).trim(),
+    expires: toOptionalString(value.expires).trim(),
+    httpOnly: value.httpOnly === true,
+    maxAge: toFiniteNumber(value.maxAge),
+    path: toOptionalString(value.path).trim(),
+    sameSite: toOptionalString(value.sameSite).trim(),
+    secure: value.secure === true,
+  };
+};
+
+const normalizeCookies = (value: unknown): HttpCookie[] => normalizeArray(value, normalizeCookie);
+
+const normalizeStream = (value: unknown): HttpStream | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    type: toOptionalString(value.type).trim(),
+    complete: typeof value.complete === "boolean" ? String(value.complete) : "",
+    chunkCount: toFiniteNumber(value.chunkCount),
+  };
+};
+
+const normalizeBodyPart = (value: unknown): HttpBodyPart | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const headers = normalizePairs(value.headers);
+  const hasValue = typeof value.value !== "undefined" && value.value !== null;
+
+  return {
+    name: toOptionalString(value.name).trim(),
+    fileName: toOptionalString(value.fileName).trim(),
+    headers,
+    contentType: toOptionalString(value.contentType).trim() || headerValue(headers, "content-type"),
+    encoding: toOptionalString(value.encoding).trim().toLowerCase() || "utf8",
+    value: hasValue ? String(value.value) : "",
+    hasValue,
+    size: toFiniteNumber(value.size),
+    truncated: value.truncated === true,
+  };
+};
+
+const normalizeBodyParts = (value: unknown): HttpBodyPart[] => normalizeArray(value, normalizeBodyPart);
+
+const normalizeBody = (value: unknown, fallbackContentType = ""): HttpBody | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const hasValue = typeof value.value !== "undefined" && value.value !== null;
+
+  return {
+    contentType: toOptionalString(value.contentType).trim() || fallbackContentType,
+    encoding: toOptionalString(value.encoding).trim().toLowerCase() || "utf8",
+    value: hasValue ? String(value.value) : "",
+    hasValue,
+    size: toFiniteNumber(value.size),
+    truncated: value.truncated === true,
+    form: normalizePairs(value.form),
+    parts: normalizeBodyParts(value.parts),
+    stream: normalizeStream(value.stream),
+  };
+};
+
+const normalizeRequest = (value: unknown): HttpRequest | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const headers = normalizePairs(value.headers);
+
+  return {
+    method: toOptionalString(value.method).trim().toUpperCase() || "GET",
+    url: toOptionalString(value.url).trim(),
+    httpVersion: toOptionalString(value.httpVersion).trim(),
+    headers,
+    cookies: normalizeCookies(value.cookies),
+    query: normalizePairs(value.query),
+    body: normalizeBody(value.body, headerValue(headers, "content-type")),
+    trailers: normalizePairs(value.trailers),
+  };
+};
+
+const normalizeInformationalResponse = (value: unknown): HttpInformationalResponse | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    status: toOptionalString(value.status).trim(),
+    reason: toOptionalString(value.statusText).trim(),
+    headers: normalizePairs(value.headers),
+  };
+};
+
+const normalizeInformationalResponses = (value: unknown): HttpInformationalResponse[] =>
+  normalizeArray(value, normalizeInformationalResponse);
+
+const normalizeResponse = (value: unknown): HttpResponse | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const headers = normalizePairs(value.headers);
+
+  return {
+    status: toOptionalString(value.status).trim(),
+    reason: toOptionalString(value.statusText).trim(),
+    httpVersion: toOptionalString(value.httpVersion).trim(),
+    headers,
+    cookies: normalizeCookies(value.cookies),
+    body: normalizeBody(value.body, headerValue(headers, "content-type")),
+    trailers: normalizePairs(value.trailers),
+    informationalResponses: normalizeInformationalResponses(value.informationalResponses),
+  };
+};
+
+const normalizeError = (value: unknown): HttpError | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const name = toOptionalString(value.name).trim();
+  const message = toOptionalString(value.message).trim();
+  const stack = toOptionalString(value.stack).trim();
+
+  if (!name && !message && !stack) {
+    return null;
+  }
+
+  return { name, message, stack };
+};
+
+export const normalizeHttpExchangePayload = (payload: unknown): NormalizedHttpPayload => {
+  if (!isRecord(payload)) {
+    return { request: null, response: null, error: null, durationMs: "" };
+  }
+
+  const start = toFiniteNumber(payload.start);
+  const stop = toFiniteNumber(payload.stop);
+  const durationMs = start !== undefined && stop !== undefined && stop >= start ? `${stop - start} ms` : "";
+
+  return {
+    request: normalizeRequest(payload.request),
+    response: normalizeResponse(payload.response),
+    error: normalizeError(payload.error),
+    durationMs,
+  };
+};
+
+const copyToClipboard = async (text: string) => {
+  try {
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  } catch {
+    // Silently ignore copy failures
+  }
+};
+
+const tryBeautifyJson = (value: string): string => {
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+};
+
+const MaskedValue = () => (
+  <span
+    aria-label={MASKED_VALUE_TOOLTIP}
+    className={styles["http-attachment__masked-value"]}
+    data-http-masked-value="true"
+    tabIndex={0}
+    title={MASKED_VALUE_TOOLTIP}
+  >
+    {MASKED_VALUE_PLACEHOLDER}
+  </span>
+);
+
+const PairValue = ({ pair }: { pair: HttpPair }) =>
+  pair.masked ? <MaskedValue /> : <>{maskRedactedText(pair.value)}</>;
+
+const TableHead = ({ columns }: { columns: string[] }) => (
+  <thead>
+    <tr>
+      {columns.map((column, index) => (
+        <th key={`${column}-${index}`}>{column}</th>
+      ))}
+    </tr>
+  </thead>
+);
+
+const DisclosureGroup = ({
+  children,
+  count,
+  defaultOpen,
+  title,
+  variant = "metadata",
+}: {
+  children: ComponentChildren;
+  count?: number;
+  defaultOpen?: boolean;
+  title: string;
+  variant?: "body" | "metadata";
+}) => (
+  <details
+    className={`${styles["http-attachment__group"]} ${styles[`http-attachment__group--${variant}`]}`}
+    data-http-group={title.toLowerCase().replace(/\s+/g, "-")}
+    open={defaultOpen}
+  >
+    <summary className={styles["http-attachment__group-summary"]}>
+      <span className={styles["http-attachment__group-title"]}>
+        {title}
+        {typeof count === "number" ? ` (${count})` : ""}
+      </span>
+    </summary>
+    <div className={styles["http-attachment__group-content"]}>{children}</div>
+  </details>
+);
+
+const PairsTable = ({ pairs }: { pairs: HttpPair[] }) => (
+  <table className={styles["http-attachment__table"]}>
+    <TableHead columns={["Name", "Value"]} />
+    <tbody>
+      {pairs.map((pair, index) => (
+        <tr key={`${pair.name}-${index}`}>
+          <td className={styles["http-attachment__pair-name"]}>{pair.name}</td>
+          <td className={styles["http-attachment__pair-value"]}>
+            <PairValue pair={pair} />
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+const PairsGroup = ({ defaultOpen, pairs, title }: { defaultOpen?: boolean; pairs: HttpPair[]; title: string }) =>
+  pairs.length ? (
+    <DisclosureGroup count={pairs.length} defaultOpen={defaultOpen} title={title}>
+      <PairsTable pairs={pairs} />
+    </DisclosureGroup>
+  ) : null;
+
+const cookieAttributes = (cookie: HttpCookie) =>
+  [
+    cookie.domain && `Domain=${cookie.domain}`,
+    cookie.path && `Path=${cookie.path}`,
+    cookie.expires && `Expires=${cookie.expires}`,
+    typeof cookie.maxAge === "number" && `Max-Age=${cookie.maxAge}`,
+    cookie.sameSite && `SameSite=${cookie.sameSite}`,
+    cookie.secure && "Secure",
+    cookie.httpOnly && "HttpOnly",
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join("; ");
+
+const CookiesGroup = ({
+  cookies,
+  defaultOpen,
+  title,
+}: {
+  cookies: HttpCookie[];
+  defaultOpen?: boolean;
+  title: string;
+}) =>
+  cookies.length ? (
+    <DisclosureGroup count={cookies.length} defaultOpen={defaultOpen} title={title}>
+      <table className={styles["http-attachment__table"]}>
+        <TableHead columns={["Name", "Value", "Attributes"]} />
+        <tbody>
+          {cookies.map((cookie, index) => (
+            <tr key={`${cookie.name}-${index}`}>
+              <td className={styles["http-attachment__pair-name"]}>{cookie.name}</td>
+              <td className={styles["http-attachment__pair-value"]}>
+                <PairValue pair={cookie} />
+              </td>
+              <td className={styles["http-attachment__cookie-attrs"]}>{cookieAttributes(cookie)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </DisclosureGroup>
+  ) : null;
+
+const MetaRow = ({ name, value }: { name: string; value?: string }) =>
+  value ? (
+    <div className={styles["http-attachment__meta-row"]}>
+      <div className={styles["http-attachment__label"]}>{name}</div>
+      <div className={styles["http-attachment__value"]}>{value}</div>
+    </div>
+  ) : null;
+
+const nonEmptyLineValue = (value: string | number | undefined) => value !== undefined && value !== "";
+
+const statusText = (status?: number, reason?: string) => [status, reason].filter(nonEmptyLineValue).join(" ");
+
+const firstAvailableGroup = (groups: [string, number][]) => groups.find(([, count]) => count > 0)?.[0] ?? null;
+
+const InformationalResponsesGroup = ({
+  defaultOpen,
+  responses,
+}: {
+  defaultOpen?: boolean;
+  responses: HttpInformationalResponse[];
+}) =>
+  responses.length ? (
+    <DisclosureGroup count={responses.length} defaultOpen={defaultOpen} title="Informational responses">
+      <table className={styles["http-attachment__table"]}>
+        <TableHead columns={["Status", "Headers"]} />
+        <tbody>
+          {responses.map(({ headers, reason, status }, index) => (
+            <tr key={`${status}-${index}`}>
+              <td className={styles["http-attachment__pair-name"]}>{statusText(status, reason)}</td>
+              <td className={styles["http-attachment__pair-value"]}>
+                {headers.map((header, headerIndex) => (
+                  <span key={`${header.name}-${headerIndex}`}>
+                    {headerIndex > 0 ? "; " : null}
+                    {header.name}: <PairValue pair={header} />
+                  </span>
+                ))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </DisclosureGroup>
+  ) : null;
+
+const MetaChips = ({ values }: { values: string[] }) =>
+  values.length ? (
+    <div className={styles["http-attachment__meta-chips"]}>
+      {values.map((value) => (
+        <span className={styles["http-attachment__meta-chip"]} key={value}>
+          {value}
+        </span>
+      ))}
+    </div>
+  ) : null;
+
+const bodyMeta = (body: HttpBody) =>
+  [
+    body.contentType || "body",
+    body.encoding !== "utf8" && body.encoding,
+    typeof body.size === "number" && `${body.size} bytes`,
+    body.truncated && "truncated",
+  ].filter((value): value is string => Boolean(value));
+
+const bodyCodeLanguage = (contentType: string) => {
+  const normalized = normalizeAttachmentContentType(contentType || DEFAULT_BODY_CONTENT_TYPE);
+
+  if (isJsonContentType(normalized)) {
+    return "json";
+  }
+
+  if (isHtmlContentType(normalized)) {
+    return "html";
+  }
+
+  return (
+    normalized
+      .split("/")
+      .pop()
+      ?.replace(/[^a-z0-9_-]/gi, "-") || "text"
+  );
+};
+
+const bodyKind = (contentType: string) => {
+  const normalized = normalizeAttachmentContentType(contentType || DEFAULT_BODY_CONTENT_TYPE);
+
+  if (normalized.startsWith("image/")) {
+    return "image";
+  }
+
+  if (normalized.startsWith("video/")) {
+    return "video";
+  }
+
+  if (
+    normalized.startsWith("text/") ||
+    normalized === "application/json" ||
+    normalized === "application/xml" ||
+    normalized.endsWith("+json")
+  ) {
+    return "text";
+  }
+
+  return "binary";
+};
+
+const canRenderBodyValueAsText = (body: HttpBody) =>
+  body.hasValue && body.encoding !== "base64" && bodyKind(body.contentType) === "text";
+
+const createBase64DataUrl = (body: HttpBody) =>
+  `data:${body.contentType || DEFAULT_BINARY_CONTENT_TYPE};base64,${body.value.replace(/\s/g, "")}`;
+
+const createUtf8DataUrl = (body: HttpBody) =>
+  `data:${body.contentType || DEFAULT_BODY_CONTENT_TYPE};charset=utf-8,${encodeURIComponent(body.value)}`;
+
+const BodyValue = ({ body, beautify }: { body: HttpBody; beautify?: boolean }) => {
+  const kind = bodyKind(body.contentType);
+
+  if (kind === "image" || kind === "video") {
+    const src = body.encoding === "base64" ? createBase64DataUrl(body) : createUtf8DataUrl(body);
+
+    if (kind === "image") {
+      return (
+        <div data-testid="image-attachment-content" className={styles["test-result-attachment-image"]}>
+          <img alt="HTTP body" src={src} />
+        </div>
+      );
+    }
+
+    return (
+      <video
+        data-testid="video-attachment-content"
+        className={styles["test-result-attachment-video"]}
+        controls
+        loop
+        muted
+      >
+        <source src={src} type={body.contentType} />
+      </video>
+    );
+  }
+
+  if (body.encoding === "base64") {
+    return (
+      <div className={styles["http-attachment__body-message"]}>
+        No inline view for {body.contentType || "this content type"}.
+      </div>
+    );
+  }
+
+  if (kind === "text") {
+    const language = bodyCodeLanguage(body.contentType);
+    const value = beautify && isJsonContentType(body.contentType) ? tryBeautifyJson(body.value) : body.value;
+
+    return (
+      <pre data-testid="code-attachment-content" className={`language-${language} line-numbers`}>
+        <code>{maskRedactedText(value)}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div className={styles["http-attachment__body-message"]}>
+      No inline view for {body.contentType || "this content type"}.
+    </div>
+  );
+};
+
+const partMeta = (part: HttpBodyPart) =>
+  [
+    part.contentType,
+    part.encoding !== "utf8" && part.encoding,
+    typeof part.size === "number" && `${part.size} bytes`,
+    part.truncated && "truncated",
+  ].filter((value): value is string => Boolean(value));
+
+const partTitle = (part: HttpBodyPart) => [part.name, part.fileName].filter(Boolean).join(" | ") || "unnamed";
+
+const PartHeaders = ({ headers }: { headers: HttpPair[] }) =>
+  headers.length ? (
+    <div className={styles["http-attachment__part-section"]} data-http-part-headers="true">
+      <div className={styles["http-attachment__part-section-title"]}>Headers</div>
+      <div className={styles["http-attachment__part-header-list"]}>
+        {headers.map((header, index) => (
+          <div className={styles["http-attachment__part-header-row"]} key={`${header.name}-${index}`}>
+            <span className={styles["http-attachment__part-header-name"]}>{header.name}</span>
+            <span className={styles["http-attachment__part-header-value"]}>
+              <PairValue pair={header} />
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  ) : null;
+
+const BodyPartsGroup = ({ defaultOpen, parts }: { defaultOpen?: boolean; parts: HttpBodyPart[] }) =>
+  parts.length ? (
+    <DisclosureGroup count={parts.length} defaultOpen={defaultOpen} title="Parts" variant="body">
+      <div className={styles["http-attachment__part-list"]}>
+        {parts.map((part, index) => (
+          <div
+            className={styles["http-attachment__part-card"]}
+            data-http-part="true"
+            key={`${part.name}-${part.fileName}-${index}`}
+          >
+            <div className={styles["http-attachment__part-card-header"]}>
+              <div className={styles["http-attachment__part-title"]}>{partTitle(part)}</div>
+              <MetaChips values={partMeta(part)} />
+            </div>
+            <PartHeaders headers={part.headers} />
+            {part.hasValue ? (
+              <pre className={styles["http-attachment__part-value"]}>
+                {part.value === HTTP_EXCHANGE_REDACTED_VALUE ? <MaskedValue /> : maskRedactedText(part.value)}
+              </pre>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </DisclosureGroup>
+  ) : null;
+
+const streamPairs = (stream: HttpStream): HttpPair[] =>
+  [
+    stream.type && { name: "type", value: stream.type, masked: false },
+    stream.complete && { name: "complete", value: stream.complete, masked: false },
+    typeof stream.chunkCount === "number" && {
+      name: "chunkCount",
+      value: String(stream.chunkCount),
+      masked: false,
+    },
+  ].filter(Boolean) as HttpPair[];
+
+const StreamGroup = ({ defaultOpen, stream }: { defaultOpen?: boolean; stream: HttpStream | null }) => {
+  if (!stream) {
+    return null;
+  }
+
+  const pairs = streamPairs(stream);
+
+  return (
+    <DisclosureGroup
+      count={pairs.length || undefined}
+      defaultOpen={defaultOpen || !pairs.length}
+      title="Stream"
+      variant="body"
+    >
+      {pairs.length ? (
+        <PairsTable pairs={pairs} />
+      ) : (
+        <div className={styles["http-attachment__body-message"]}>Stream metadata captured.</div>
+      )}
+    </DisclosureGroup>
+  );
+};
+
+const StructuredBody = ({ body, beautify }: { body: HttpBody; beautify?: boolean }) => {
+  if (body.form.length) {
+    return (
+      <DisclosureGroup count={body.form.length} defaultOpen title="Form" variant="body">
+        <PairsTable pairs={body.form} />
+      </DisclosureGroup>
+    );
+  }
+
+  if (body.parts.length) {
+    return <BodyPartsGroup defaultOpen parts={body.parts} />;
+  }
+
+  if (body.stream) {
+    return (
+      <>
+        <StreamGroup defaultOpen stream={body.stream} />
+        {body.hasValue ? <BodyValue body={body} beautify={beautify} /> : null}
+      </>
+    );
+  }
+
+  return <BodyValue body={body} beautify={beautify} />;
+};
+
+const Body = ({ body }: { body: HttpBody | null }) => {
+  const [beautify, setBeautify] = useState(false);
+
+  if (!body) {
+    return null;
+  }
+
+  const hasStructuredBody = Boolean(body.form.length || body.parts.length || body.stream);
+  const hasTextBody = canRenderBodyValueAsText(body);
+  const canBeautify = hasTextBody && isJsonContentType(body.contentType);
+  const canCopy = hasTextBody;
+
+  return (
+    <div className={styles["http-attachment__body"]}>
+      <div className={styles["http-attachment__body-toolbar"]}>
+        <div className={styles["http-attachment__body-heading"]}>
+          <h4 className={styles["http-attachment__body-title"]}>Body</h4>
+          <MetaChips values={bodyMeta(body)} />
+        </div>
+        {(canCopy || canBeautify) && (
+          <div className={styles["http-attachment__body-actions"]}>
+            {canBeautify && (
+              <button
+                className={styles["http-attachment__body-action"]}
+                onClick={() => setBeautify((b) => !b)}
+                type="button"
+              >
+                {beautify ? "Original" : "Pretty"}
+              </button>
+            )}
+            {canCopy && (
+              <button
+                className={styles["http-attachment__body-action"]}
+                onClick={() => copyToClipboard(body.value)}
+                type="button"
+              >
+                Copy
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      <div
+        className={`${styles["http-attachment__body-content"]} ${
+          hasStructuredBody ? styles["http-attachment__body-content--structured"] : ""
+        }`}
+      >
+        {body.hasValue || hasStructuredBody ? (
+          <StructuredBody body={body} beautify={beautify} />
+        ) : (
+          <div className={styles["http-attachment__body-message"]}>No body captured.</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const MethodLine = ({ method, url }: { method: string; url: string }) => (
+  <>
+    <span className={styles["http-attachment__method"]} data-http-method="true">
+      {method}
+    </span>
+    <span className={styles["http-attachment__url"]}>{url}</span>
+  </>
+);
+
+const StatusLine = ({ durationMs, response }: { durationMs?: string; response: HttpResponse }) => {
+  const statusLine = statusText(response.status, response.reason);
+
+  return (
+    <>
+      {statusLine ? <span className={styles["http-attachment__status"]}>{statusLine}</span> : null}
+      {durationMs ? <span className={styles["http-attachment__duration"]}>{durationMs}</span> : null}
+    </>
+  );
+};
+
+const PanelHeader = ({
+  children,
+  title,
+}: {
+  children?: ComponentChildren;
+  title: "Request" | "Response" | "Error";
+}) => (
+  <div className={styles["http-attachment__panel-header"]}>
+    <div className={styles["http-attachment__panel-title"]}>{title}</div>
+    {children ? <div className={styles["http-attachment__panel-line"]}>{children}</div> : null}
+  </div>
+);
+
+const hasRequestDetails = (request: HttpRequest) =>
+  Boolean(
+    request.httpVersion ||
+    request.query.length ||
+    request.headers.length ||
+    request.cookies.length ||
+    request.trailers.length ||
+    request.body,
+  );
+
+const RequestSection = ({ request }: { request: HttpRequest }) => {
+  const hasBody = Boolean(request.body);
+  const firstGroup = !hasBody
+    ? firstAvailableGroup([
+        ["query", request.query.length],
+        ["headers", request.headers.length],
+        ["cookies", request.cookies.length],
+        ["trailers", request.trailers.length],
+      ])
+    : null;
+  const hasGroups = Boolean(
+    request.query.length || request.headers.length || request.cookies.length || request.trailers.length,
+  );
+
+  return hasRequestDetails(request) ? (
+    <section className={styles["http-attachment__panel"]} data-http-panel="request">
+      <PanelHeader title="Request">
+        {request.httpVersion ? <span className={styles["http-attachment__version"]}>{request.httpVersion}</span> : null}
+      </PanelHeader>
+      <Body body={request.body} />
+      {hasGroups ? (
+        <div className={styles["http-attachment__groups"]}>
+          <PairsGroup defaultOpen={firstGroup === "query"} pairs={request.query} title="Query" />
+          <PairsGroup defaultOpen={firstGroup === "headers"} pairs={request.headers} title="Headers" />
+          <CookiesGroup defaultOpen={firstGroup === "cookies"} cookies={request.cookies} title="Cookies" />
+          <PairsGroup defaultOpen={firstGroup === "trailers"} pairs={request.trailers} title="Trailers" />
+        </div>
+      ) : null}
+    </section>
+  ) : null;
+};
+
+const hasResponseDetails = (response: HttpResponse) =>
+  Boolean(
+    response.status !== undefined ||
+    response.reason ||
+    response.httpVersion ||
+    response.headers.length ||
+    response.cookies.length ||
+    response.trailers.length ||
+    response.informationalResponses.length ||
+    response.body,
+  );
+
+const ResponseSection = ({ durationMs, response }: { durationMs: string; response: HttpResponse | null }) => {
+  if (!response) {
+    return (
+      <section className={styles["http-attachment__panel"]} data-http-panel="response">
+        <PanelHeader title="Response" />
+        <div className={styles["http-attachment__empty"]}>No response captured.</div>
+      </section>
+    );
+  }
+
+  if (!hasResponseDetails(response)) {
+    return null;
+  }
+
+  const hasBody = Boolean(response.body);
+  const firstGroup = !hasBody
+    ? firstAvailableGroup([
+        ["informational", response.informationalResponses.length],
+        ["headers", response.headers.length],
+        ["cookies", response.cookies.length],
+        ["trailers", response.trailers.length],
+      ])
+    : null;
+  const hasGroups = Boolean(
+    response.informationalResponses.length ||
+    response.headers.length ||
+    response.cookies.length ||
+    response.trailers.length,
+  );
+
+  return (
+    <section className={styles["http-attachment__panel"]} data-http-panel="response">
+      <PanelHeader title="Response">
+        <StatusLine durationMs={durationMs} response={response} />
+        {response.httpVersion ? (
+          <span className={styles["http-attachment__version"]}>{response.httpVersion}</span>
+        ) : null}
+      </PanelHeader>
+      <Body body={response.body} />
+      {hasGroups ? (
+        <div className={styles["http-attachment__groups"]}>
+          <InformationalResponsesGroup
+            defaultOpen={firstGroup === "informational"}
+            responses={response.informationalResponses}
+          />
+          <PairsGroup defaultOpen={firstGroup === "headers"} pairs={response.headers} title="Headers" />
+          <CookiesGroup defaultOpen={firstGroup === "cookies"} cookies={response.cookies} title="Cookies" />
+          <PairsGroup defaultOpen={firstGroup === "trailers"} pairs={response.trailers} title="Trailers" />
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+const ErrorSection = ({ error }: { error: HttpError | null }) =>
+  error ? (
+    <section
+      className={`${styles["http-attachment__panel"]} ${styles["http-attachment__panel--error"]}`}
+      data-http-panel="error"
+    >
+      <PanelHeader title="Error" />
+      <div className={styles["http-attachment__meta"]}>
+        <MetaRow name="Name" value={error.name} />
+        <MetaRow name="Message" value={error.message} />
+      </div>
+      {error.stack ? (
+        <DisclosureGroup defaultOpen title="Stack">
+          <div className={styles["http-attachment__body-content"]}>
+            <pre data-testid="code-attachment-content" className="language-text line-numbers">
+              <code>{error.stack}</code>
+            </pre>
+          </div>
+        </DisclosureGroup>
+      ) : null}
+    </section>
+  ) : null;
+
+const Summary = ({
+  durationMs,
+  request,
+  response,
+}: {
+  durationMs: string;
+  request: HttpRequest;
+  response: HttpResponse | null;
+}) => {
+  const statusLine = response ? statusText(response.status, response.reason) : "";
+
+  return (
+    <div className={styles["http-attachment__summary"]}>
+      <MethodLine method={request.method} url={request.url} />
+      {statusLine || durationMs ? <span className={styles["http-attachment__exchange-arrow"]}>→</span> : null}
+      {statusLine ? <span className={styles["http-attachment__status"]}>{statusLine}</span> : null}
+      {durationMs ? <span className={styles["http-attachment__duration"]}>{durationMs}</span> : null}
+    </div>
+  );
+};
+
+export const HttpAttachment = ({ attachment }: AttachmentProps) => {
+  const payload = attachment && "http" in attachment ? attachment.http : null;
+  const normalized = normalizeHttpExchangePayload(payload);
+
+  if (!normalized.request) {
+    return (
+      <div className={styles["http-attachment"]} data-testid="http-attachment-content">
+        <div className={styles["http-attachment__empty"]}>Invalid HTTP Exchange attachment: request is missing.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles["http-attachment"]} data-testid="http-attachment-content">
+      <Summary request={normalized.request} response={normalized.response} durationMs={normalized.durationMs} />
+      <RequestSection request={normalized.request} />
+      <ResponseSection response={normalized.response} durationMs={normalized.durationMs} />
+      <ErrorSection error={normalized.error} />
+    </div>
+  );
+};

--- a/packages/web-components/src/components/Attachment/HttpAttachment.tsx
+++ b/packages/web-components/src/components/Attachment/HttpAttachment.tsx
@@ -873,7 +873,7 @@ const RequestSection = ({ request }: { request: HttpRequest }) => {
 
 const hasResponseDetails = (response: HttpResponse) =>
   Boolean(
-    response.status !== undefined ||
+    response.status ||
     response.reason ||
     response.httpVersion ||
     response.headers.length ||

--- a/packages/web-components/src/components/Attachment/index.tsx
+++ b/packages/web-components/src/components/Attachment/index.tsx
@@ -6,3 +6,4 @@ export { AttachmentImage } from "./AttachmentImage";
 export { AttachmentVideo } from "./AttachmentVideo";
 export { AttachmentEmpty } from "./AttachmentEmpty";
 export { CodeViewer } from "./CodeViewer";
+export { HttpAttachment } from "./HttpAttachment";

--- a/packages/web-components/src/components/Attachment/styles.scss
+++ b/packages/web-components/src/components/Attachment/styles.scss
@@ -243,3 +243,387 @@
   padding-top: 16px;
   padding-bottom: 16px;
 }
+
+.http-attachment {
+  color: var(--on-text-primary);
+  font-size: 14px;
+  line-height: 20px;
+
+  &__summary {
+    align-items: center;
+    background: var(--bg-control-flat-medium);
+    border-bottom: 1px solid var(--on-border-muted);
+    display: grid;
+    gap: 8px;
+    grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+    min-height: 36px;
+    padding: 8px 12px;
+  }
+
+  &__method,
+  &__status,
+  &__duration,
+  &__version,
+  &__meta-chip {
+    border: 1px solid var(--on-border-muted);
+    box-sizing: border-box;
+    line-height: 18px;
+    white-space: nowrap;
+  }
+
+  &__method {
+    background: var(--bg-base-primary);
+    font-weight: 700;
+    padding: 0 6px;
+  }
+
+  &__url {
+    font-size: 14px;
+    line-height: 20px;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__status,
+  &__duration,
+  &__version {
+    background: var(--bg-base-primary);
+    color: var(--on-text-secondary);
+    padding: 0 6px;
+  }
+
+  &__exchange-arrow {
+    color: var(--on-text-hint);
+  }
+
+  &__panel {
+    border-bottom: 1px solid var(--on-border-muted);
+    padding: 12px;
+  }
+
+  &__panel--error {
+    background: var(--bg-control-flat);
+  }
+
+  &__panel-header {
+    align-items: flex-start;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: 88px minmax(0, 1fr);
+    margin-bottom: 10px;
+  }
+
+  &__panel-title {
+    color: var(--on-text-secondary);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 20px;
+    text-transform: uppercase;
+  }
+
+  &__panel-line {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &__meta {
+    display: grid;
+    gap: 4px;
+    margin-bottom: 10px;
+  }
+
+  &__meta-row {
+    align-items: start;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: minmax(96px, 160px) minmax(0, 1fr);
+    min-height: 22px;
+  }
+
+  &__label,
+  &__pair-name,
+  &__table th,
+  &__meta-chip {
+    color: var(--on-text-secondary);
+  }
+
+  &__value {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__groups {
+    display: grid;
+    gap: 6px;
+    margin-top: 10px;
+  }
+
+  &__group {
+    border: 1px solid var(--on-border-muted);
+    background: var(--bg-base-primary);
+
+    &[open] {
+      border-color: var(--on-border-primary);
+    }
+  }
+
+  &__group--body {
+    background: var(--bg-base-primary);
+  }
+
+  &__group-summary {
+    align-items: center;
+    background: var(--bg-base-primary);
+    cursor: pointer;
+    display: flex;
+    min-height: 32px;
+    padding: 0 10px;
+
+    &::marker {
+      color: var(--on-text-hint);
+    }
+
+    &:focus-visible {
+      outline: 1px solid var(--ad-other-focus);
+      outline-offset: -2px;
+    }
+  }
+
+  &__group-title {
+    color: var(--on-text-secondary);
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 20px;
+  }
+
+  &__group-content {
+    border-top: 1px solid var(--on-border-primary);
+    background: var(--bg-base-primary);
+    min-width: 0;
+  }
+
+  &__table {
+    border-collapse: collapse;
+    font-size: 13px;
+    line-height: 20px;
+    table-layout: fixed;
+    width: 100%;
+
+    th {
+      background: var(--bg-control-flat);
+      border-bottom: 1px solid var(--on-border-muted);
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 16px;
+      padding: 4px 8px;
+      text-align: left;
+      text-transform: uppercase;
+    }
+
+    tr {
+      border-bottom: 1px solid var(--on-border-muted);
+
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
+
+    td {
+      overflow-wrap: anywhere;
+      padding: 5px 8px;
+      vertical-align: top;
+    }
+  }
+
+  &__pair-name {
+    width: 160px;
+  }
+
+  &__cookie-attrs {
+    color: var(--on-text-secondary);
+    width: 35%;
+  }
+
+  &__masked-value {
+    background: var(--bg-control-flat-medium);
+    border: 1px solid var(--on-border-muted);
+    color: var(--on-text-secondary);
+    cursor: help;
+    display: inline-block;
+    font-family: "Courier New", monospace;
+    line-height: 16px;
+    padding: 0 8px;
+  }
+
+  &__part-list {
+    display: grid;
+    gap: 8px;
+    padding: 8px;
+  }
+
+  &__part-card {
+    background: var(--bg-base-primary);
+    border: 1px solid var(--on-border-muted);
+    min-width: 0;
+    padding: 8px;
+  }
+
+  &__part-card-header {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &__part-title {
+    color: var(--on-text-primary);
+    font-weight: 600;
+    line-height: 20px;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__part-section {
+    border-top: 1px solid var(--on-border-muted);
+    margin-top: 8px;
+    padding-top: 6px;
+  }
+
+  &__part-section-title {
+    color: var(--on-text-secondary);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 16px;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+  }
+
+  &__part-header-list {
+    display: grid;
+    gap: 2px;
+  }
+
+  &__part-header-row {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: minmax(96px, 180px) minmax(0, 1fr);
+    min-width: 0;
+  }
+
+  &__part-header-name {
+    color: var(--on-text-secondary);
+    overflow-wrap: anywhere;
+  }
+
+  &__part-header-value {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__part-value {
+    background: var(--bg-control-flat-medium);
+    border: 1px solid var(--on-border-muted);
+    font-family: "Courier New", monospace;
+    margin: 8px 0 0;
+    overflow-wrap: anywhere;
+    padding: 8px;
+    white-space: pre-wrap;
+  }
+
+  &__body {
+    margin-top: 10px;
+  }
+
+  &__body-toolbar {
+    align-items: flex-start;
+    display: flex;
+    gap: 12px;
+    margin-bottom: 6px;
+  }
+
+  &__body-heading {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  &__body-title {
+    color: var(--on-text-secondary);
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 20px;
+    margin: 0;
+  }
+
+  &__meta-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  &__meta-chip {
+    background: var(--bg-base-primary);
+    font-size: 12px;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    padding: 0 6px;
+  }
+
+  &__body-actions {
+    display: flex;
+    gap: 12px;
+    margin-left: auto;
+  }
+
+  &__body-action {
+    background: none;
+    border: none;
+    color: var(--on-link-primary);
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 20px;
+    padding: 0;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  &__body-content {
+    border: 1px solid var(--on-border-muted);
+    background: var(--bg-control-flat-medium);
+    min-width: 0;
+    padding: 10px;
+
+    pre {
+      margin: 0;
+      white-space: pre-wrap;
+    }
+  }
+
+  &__body-content--structured {
+    border: 0;
+    background: transparent;
+    padding: 0;
+
+    > pre,
+    > .http-attachment__body-message {
+      border: 1px solid var(--on-border-muted);
+      background: var(--bg-control-flat-medium);
+      margin-top: 6px;
+      padding: 10px;
+    }
+  }
+
+  &__empty,
+  &__body-message {
+    color: var(--on-text-secondary);
+  }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

This PR adds first-class support for HTTP Exchange attachments in Allure 3 reports. Integrations can now attach one structured HTTP request/response exchange as `application/vnd.allure.http+json` using the `.httpexchange` extension. The report renders these attachments as a compact HTTP inspector with method, URL, status, duration, headers, cookies, query parameters, trailers, bodies, and errors.

The new viewer avoids unsafe HTML request/response attachments: captured content is rendered through safe text, code, table, image, and video views. HTML responses are shown as source, not executed. Redacted values stored as `__ALLURE_REDACTED__` are displayed as masked placeholders, and request/response bodies can be downloaded when captured. The demo report now includes HTTP Exchange examples for JSON, form data, multipart, streaming, images, video, binary data, redirects, errors, compression, upgrades, and gRPC-style trailers.

Example attachment:

```json
{
  "schemaVersion": 1,
  "start": 1710000186400,
  "stop": 1710000186487,
  "request": {
    "method": "POST",
    "url": "https://api.example.com/v1/orders/42?dryRun=true",
    "httpVersion": "HTTP/1.1",
    "headers": [
      { "name": "authorization", "value": "__ALLURE_REDACTED__" },
      { "name": "content-type", "value": "application/json" }
    ],
    "body": {
      "contentType": "application/json",
      "encoding": "utf8",
      "value": "{\"name\":\"demo\"}",
      "size": 15
    }
  },
  "response": {
    "status": 201,
    "statusText": "Created",
    "headers": [
      { "name": "content-type", "value": "application/json" }
    ],
    "body": {
      "contentType": "application/json",
      "encoding": "utf8",
      "value": "{\"id\":42}",
      "size": 9
    }
  }
}
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214702872663408