### PR TITLE
fix playwright trace

### DIFF
--- a/packages/e2e/test/allure-awesome/features/attachments.test.ts
+++ b/packages/e2e/test/allure-awesome/features/attachments.test.ts
@@ -472,14 +472,15 @@ test.describe("attachments", () => {
 
       await testResultPage.testResultAttachmentLocator
         .filter({ has: page.getByText("trace", { exact: true }) })
-        .getByRole("button")
-        .nth(0)
+        .first()
+        .getByLabel("Open Playwright Trace")
         .click();
 
       const popup = await popupPromise;
 
       if (popup) {
-        await popup.waitForURL("https://trace.playwright.dev/", { timeout: 5_000 });
+        await popup.waitForURL(/https:\/\/trace\.playwright\.dev\/\?trace=/, { timeout: 5_000 });
+        await expect(popup.getByText("Actions", { exact: true }).first()).toBeVisible();
         return;
       }
 

--- a/packages/static-server/src/index.ts
+++ b/packages/static-server/src/index.ts
@@ -10,6 +10,12 @@ import openUrl from "open";
 
 import { TYPES_BY_EXTENSION, identity, injectLiveReloadScript, resolveUrlPathnameUnderServeRoot } from "./utils.js";
 
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+};
+
+const attachmentCorsHeaders = (query: URLSearchParams) => (query.has("attachment") ? CORS_HEADERS : {});
+
 export type AllureStaticServer = {
   url: string;
   port: number;
@@ -156,6 +162,7 @@ export const serve = async (options?: {
         const byteLength = Buffer.byteLength(htmlContent);
 
         res.writeHead(200, {
+          ...attachmentCorsHeaders(query),
           "Content-Type": "text/html",
           "Content-Length": byteLength,
         });
@@ -175,6 +182,7 @@ export const serve = async (options?: {
       const byteLength = Buffer.byteLength(htmlContent);
 
       res.writeHead(200, {
+        ...attachmentCorsHeaders(query),
         "Content-Type": contentType,
         "Content-Length": byteLength,
       });
@@ -184,6 +192,7 @@ export const serve = async (options?: {
     }
 
     res.writeHead(200, {
+      ...attachmentCorsHeaders(query),
       "Content-Type": contentType,
       "Content-Length": stats.size,
     });

--- a/packages/static-server/test/unit/static.test.ts
+++ b/packages/static-server/test/unit/static.test.ts
@@ -61,6 +61,24 @@ it("serves files with query parameters", async () => {
   expect(res.data).not.toBeUndefined();
 });
 
+it("allows attachment files to be fetched from external viewers", async () => {
+  server = await serve({ port, servePath });
+  const res = await axios.get(`http://localhost:${port}/sample?attachment`, {
+    timeout: 500,
+  });
+
+  expect(res.headers["access-control-allow-origin"]).toBe("*");
+});
+
+it("doesn't add CORS headers to regular static files", async () => {
+  server = await serve({ port, servePath });
+  const res = await axios.get(`http://localhost:${port}/sample`, {
+    timeout: 500,
+  });
+
+  expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+});
+
 it("returns 404 for path traversal outside the serve root", async () => {
   server = await serve({ port, servePath });
   const res = await axios.get(`http://localhost:${port}/../../static.test.ts`, {

--- a/packages/web-awesome/src/components/TestResult/TrPwTraces/PwTraceButton.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrPwTraces/PwTraceButton.tsx
@@ -1,10 +1,14 @@
 import type { AttachmentTestStepResult } from "@allurereport/core-api";
-import { reportDataUrl } from "@allurereport/web-commons";
-import { Button, IconButton, Text, TooltipWrapper, allureIcons } from "@allurereport/web-components";
+import { downloadAttachment, reportDataUrl } from "@allurereport/web-commons";
+import { Button, ButtonLink, IconButton, Text, TooltipWrapper, allureIcons } from "@allurereport/web-components";
 
 import { openPlaywrightTraceInNewTab } from "@/components/TestResult/TrPwTraces/openPwTraceInNewTab";
 import { useI18n } from "@/stores";
 import { closeModal, openModal } from "@/stores/modal";
+
+import * as styles from "./styles.scss";
+
+const PLAYWRIGHT_TRACE_VIEWER_URL = "https://trace.playwright.dev/";
 
 const PwTracePopupBlocked = ({ onRetry, t }: { onRetry: () => void; t: (key: string) => string }) => (
   <div data-testid={"pw-trace-popup-blocked"}>
@@ -25,7 +29,28 @@ const PwTracePopupBlocked = ({ onRetry, t }: { onRetry: () => void; t: (key: str
   </div>
 );
 
-const PwTraceUnsupported = ({ t }: { t: (key: string) => string }) => <Text>{t("pwTraceUnsupported")}</Text>;
+const PwTraceUnsupported = ({ link, t }: { link: AttachmentTestStepResult["link"]; t: (key: string) => string }) => (
+  <div className={styles["pw-trace-unsupported"]} data-testid={"pw-trace-unsupported"}>
+    <Text>{t("pwTraceUnsupported")}</Text>
+    <Text>{t("pwTraceUnsupportedHint")}</Text>
+    <div className={styles["pw-trace-unsupported-actions"]}>
+      <Button
+        style={"flat"}
+        size={"s"}
+        text={t("downloadPwTrace")}
+        icon={allureIcons.lineGeneralDownloadCloud}
+        onClick={() => downloadAttachment(link.id, link.ext, link.contentType)}
+      />
+      <ButtonLink
+        style={"flat"}
+        size={"s"}
+        text={t("openPwTraceViewer")}
+        href={PLAYWRIGHT_TRACE_VIEWER_URL}
+        target={"_blank"}
+      />
+    </div>
+  </div>
+);
 
 export const PwTraceButton = ({ link }: Pick<AttachmentTestStepResult, "link">) => {
   const { t } = useI18n("ui");
@@ -44,7 +69,8 @@ export const PwTraceButton = ({ link }: Pick<AttachmentTestStepResult, "link">) 
       if (traceUrl.startsWith("data:")) {
         openModal({
           title: traceTitle,
-          component: <PwTraceUnsupported t={t} />,
+          size: "content",
+          component: <PwTraceUnsupported link={link} t={t} />,
         });
         return;
       }

--- a/packages/web-awesome/src/components/TestResult/TrPwTraces/PwTraceButton.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrPwTraces/PwTraceButton.tsx
@@ -1,5 +1,5 @@
 import type { AttachmentTestStepResult } from "@allurereport/core-api";
-import { fetchFromUrl } from "@allurereport/web-commons";
+import { reportDataUrl } from "@allurereport/web-commons";
 import { Button, IconButton, Text, TooltipWrapper, allureIcons } from "@allurereport/web-components";
 
 import { openPlaywrightTraceInNewTab } from "@/components/TestResult/TrPwTraces/openPwTraceInNewTab";
@@ -25,18 +25,31 @@ const PwTracePopupBlocked = ({ onRetry, t }: { onRetry: () => void; t: (key: str
   </div>
 );
 
+const PwTraceUnsupported = ({ t }: { t: (key: string) => string }) => <Text>{t("pwTraceUnsupported")}</Text>;
+
 export const PwTraceButton = ({ link }: Pick<AttachmentTestStepResult, "link">) => {
   const { t } = useI18n("ui");
   const traceTitle = `Playwright Trace Viewer | ${link.name}${link.ext}`;
 
   const openPw = async () => {
-    // Use a top-level tab for Playwright Trace to avoid third-party blob/storage partitioning issues.
+    // Use a top-level tab and the official trace URL parameter to avoid third-party blob/storage partitioning issues.
     // - https://bugzilla.mozilla.org/show_bug.cgi?id=1917842
     // - https://privacysandbox.google.com/cookies/storage-partitioning
     try {
-      const hasPw = await fetchFromUrl(link);
-      const blob = await hasPw.blob();
-      const opened = openPlaywrightTraceInNewTab(blob);
+      const traceUrl = await reportDataUrl(
+        `data/attachments/${link.id || "-"}${link.ext || ""}?attachment`,
+        link.contentType,
+      );
+
+      if (traceUrl.startsWith("data:")) {
+        openModal({
+          title: traceTitle,
+          component: <PwTraceUnsupported t={t} />,
+        });
+        return;
+      }
+
+      const opened = openPlaywrightTraceInNewTab(traceUrl);
 
       if (!opened) {
         openModal({
@@ -54,7 +67,13 @@ export const PwTraceButton = ({ link }: Pick<AttachmentTestStepResult, "link">) 
 
   return (
     <TooltipWrapper tooltipText={t("openPwTrace")}>
-      <IconButton icon={allureIcons.lineArrowsExpand3} size={"s"} style={"ghost"} onClick={openPw} />
+      <IconButton
+        aria-label={t("openPwTrace")}
+        icon={allureIcons.lineArrowsExpand3}
+        size={"s"}
+        style={"ghost"}
+        onClick={openPw}
+      />
     </TooltipWrapper>
   );
 };

--- a/packages/web-awesome/src/components/TestResult/TrPwTraces/openPwTraceInNewTab.ts
+++ b/packages/web-awesome/src/components/TestResult/TrPwTraces/openPwTraceInNewTab.ts
@@ -1,29 +1,16 @@
 const PLAYWRIGHT_TRACE_ORIGIN = "https://trace.playwright.dev";
 const PLAYWRIGHT_TRACE_VIEWER_URL = `${PLAYWRIGHT_TRACE_ORIGIN}/`;
-const RETRY_DELAY_MS = 300;
 
-export const openPlaywrightTraceInNewTab = (blob: Blob) => {
-  const newWindow = window.open("", "_blank");
+export const openPlaywrightTraceInNewTab = (traceUrl: string) => {
+  const viewerUrl = new URL(PLAYWRIGHT_TRACE_VIEWER_URL);
+  viewerUrl.searchParams.set("trace", traceUrl);
+
+  const newWindow = window.open(viewerUrl.toString(), "_blank");
   if (!newWindow) {
     return false;
   }
 
-  const payload = { method: "load", params: { trace: blob } };
-  const sendTraceMessage = () => {
-    if (newWindow.closed) {
-      return;
-    }
-
-    newWindow.postMessage(payload, PLAYWRIGHT_TRACE_ORIGIN);
-  };
-
-  newWindow.location.href = PLAYWRIGHT_TRACE_VIEWER_URL;
   newWindow.focus();
-
-  sendTraceMessage();
-  globalThis.setTimeout(() => {
-    sendTraceMessage();
-  }, RETRY_DELAY_MS);
 
   return true;
 };

--- a/packages/web-awesome/src/components/TestResult/TrPwTraces/styles.scss
+++ b/packages/web-awesome/src/components/TestResult/TrPwTraces/styles.scss
@@ -18,3 +18,17 @@
   --modal-fs-paddings: 75px;
   height: calc(100vh - var(--modal-fs-paddings));
 }
+
+.pw-trace-unsupported {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 520px;
+}
+
+.pw-trace-unsupported-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 4px;
+}

--- a/packages/web-awesome/src/locales/ar.json
+++ b/packages/web-awesome/src/locales/ar.json
@@ -155,9 +155,12 @@
     "openPwTrace": "فتح تتبع Playwright",
     "pwTracePopupBlocked": "حظر المتصفح فتح عارض Playwright Trace.",
     "pwTracePopupBlockedHint": "اسمح بالنوافذ المنبثقة ثم أعد المحاولة.",
-    "pwTraceUnsupported": "لا يمكن فتح تتبعات Playwright تلقائيًا في التقارير ذات الملف الواحد. نزّل التتبع وافتحه يدويًا.",
+    "pwTraceUnsupported": "لا يمكن فتح تتبعات Playwright تلقائيًا في التقارير ذات الملف الواحد.",
     "finishedAtOriginal": "{{formattedCreatedAt}}، برمز خروج {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}، برمز خروج {{actual}} (الأصلي {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}، برمز خروج {{actual}} (الأصلي {{original}})",
+    "pwTraceUnsupportedHint": "نزّل التتبع، وافتح Trace Viewer، ثم اسحب الملف الذي تم تنزيله إلى العارض.",
+    "downloadPwTrace": "تنزيل التتبع",
+    "openPwTraceViewer": "فتح Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "فتح المرفق في علامة تبويب جديدة",

--- a/packages/web-awesome/src/locales/ar.json
+++ b/packages/web-awesome/src/locales/ar.json
@@ -153,6 +153,9 @@
     "at": "في",
     "variables": "المتغيرات",
     "openPwTrace": "فتح تتبع Playwright",
+    "pwTracePopupBlocked": "حظر المتصفح فتح عارض Playwright Trace.",
+    "pwTracePopupBlockedHint": "اسمح بالنوافذ المنبثقة ثم أعد المحاولة.",
+    "pwTraceUnsupported": "لا يمكن فتح تتبعات Playwright تلقائيًا في التقارير ذات الملف الواحد. نزّل التتبع وافتحه يدويًا.",
     "finishedAtOriginal": "{{formattedCreatedAt}}، برمز خروج {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}، برمز خروج {{actual}} (الأصلي {{original}})"
   },

--- a/packages/web-awesome/src/locales/az.json
+++ b/packages/web-awesome/src/locales/az.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Playwright Trace-i aç",
     "pwTracePopupBlocked": "Brauzer Playwright Trace Viewer-i açmağı blokladı.",
     "pwTracePopupBlockedHint": "Pop-uplara icazə verin və yenidən cəhd edin.",
+    "pwTraceUnsupported": "Playwright izləmələri tək fayllı hesabatlarda avtomatik açıla bilmir. İzləməni endirin və əl ilə açın.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, çıxış kodu {{original}} ilə",
     "finishedAtBoth": "{{formattedCreatedAt}}, çıxış kodu {{actual}} ilə (ilkin {{original}})"
   },

--- a/packages/web-awesome/src/locales/az.json
+++ b/packages/web-awesome/src/locales/az.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Playwright Trace-i aç",
     "pwTracePopupBlocked": "Brauzer Playwright Trace Viewer-i açmağı blokladı.",
     "pwTracePopupBlockedHint": "Pop-uplara icazə verin və yenidən cəhd edin.",
-    "pwTraceUnsupported": "Playwright izləmələri tək fayllı hesabatlarda avtomatik açıla bilmir. İzləməni endirin və əl ilə açın.",
+    "pwTraceUnsupported": "Playwright izləmələri tək fayllı hesabatlarda avtomatik açıla bilmir.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, çıxış kodu {{original}} ilə",
-    "finishedAtBoth": "{{formattedCreatedAt}}, çıxış kodu {{actual}} ilə (ilkin {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, çıxış kodu {{actual}} ilə (ilkin {{original}})",
+    "pwTraceUnsupportedHint": "İzləməni endirin, Trace Viewer-i açın və endirilmiş faylı viewer-ə sürükləyin.",
+    "downloadPwTrace": "İzləməni endir",
+    "openPwTraceViewer": "Trace Viewer-i aç"
   },
   "controls": {
     "newTabAttachment": "Qoşmanı yeni tabda aç",

--- a/packages/web-awesome/src/locales/de.json
+++ b/packages/web-awesome/src/locales/de.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Playwright Trace öffnen",
     "pwTracePopupBlocked": "Der Browser hat das Öffnen des Playwright Trace Viewer blockiert.",
     "pwTracePopupBlockedHint": "Erlaube Pop-ups und versuche es erneut.",
+    "pwTraceUnsupported": "Playwright-Traces können in Ein-Datei-Berichten nicht automatisch geöffnet werden. Lade den Trace herunter und öffne ihn manuell.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, mit Exit-Code {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, mit Exit-Code {{actual}} (ursprünglich {{original}})"
   },

--- a/packages/web-awesome/src/locales/de.json
+++ b/packages/web-awesome/src/locales/de.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Playwright Trace öffnen",
     "pwTracePopupBlocked": "Der Browser hat das Öffnen des Playwright Trace Viewer blockiert.",
     "pwTracePopupBlockedHint": "Erlaube Pop-ups und versuche es erneut.",
-    "pwTraceUnsupported": "Playwright-Traces können in Ein-Datei-Berichten nicht automatisch geöffnet werden. Lade den Trace herunter und öffne ihn manuell.",
+    "pwTraceUnsupported": "Playwright-Traces können in Ein-Datei-Berichten nicht automatisch geöffnet werden.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, mit Exit-Code {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, mit Exit-Code {{actual}} (ursprünglich {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, mit Exit-Code {{actual}} (ursprünglich {{original}})",
+    "pwTraceUnsupportedHint": "Lade den Trace herunter, öffne Trace Viewer und ziehe die heruntergeladene Datei in den Viewer.",
+    "downloadPwTrace": "Trace herunterladen",
+    "openPwTraceViewer": "Trace Viewer öffnen"
   },
   "controls": {
     "newTabAttachment": "Anhang in neuem Tab öffnen",

--- a/packages/web-awesome/src/locales/en.json
+++ b/packages/web-awesome/src/locales/en.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Open Playwright Trace",
     "pwTracePopupBlocked": "Browser blocked opening Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Allow popups and retry.",
+    "pwTraceUnsupported": "Playwright traces in single-file reports can't be opened automatically. Download the trace and open it manually.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, with exit code {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, with exit code {{actual}} (original {{original}})"
   },

--- a/packages/web-awesome/src/locales/en.json
+++ b/packages/web-awesome/src/locales/en.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Open Playwright Trace",
     "pwTracePopupBlocked": "Browser blocked opening Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Allow popups and retry.",
-    "pwTraceUnsupported": "Playwright traces in single-file reports can't be opened automatically. Download the trace and open it manually.",
+    "pwTraceUnsupported": "Playwright traces in single-file reports can't be opened automatically.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, with exit code {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, with exit code {{actual}} (original {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, with exit code {{actual}} (original {{original}})",
+    "pwTraceUnsupportedHint": "Download the trace, open Trace Viewer, then drop the downloaded file into the viewer.",
+    "downloadPwTrace": "Download trace",
+    "openPwTraceViewer": "Open Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Open attachment in new tab",

--- a/packages/web-awesome/src/locales/es.json
+++ b/packages/web-awesome/src/locales/es.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Abrir Playwright Trace",
     "pwTracePopupBlocked": "El navegador bloqueó la apertura de Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Permite las ventanas emergentes y vuelve a intentarlo.",
+    "pwTraceUnsupported": "Los traces de Playwright no se pueden abrir automáticamente en informes de un solo archivo. Descarga el trace y ábrelo manualmente.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, con código de salida {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, con código de salida {{actual}} (original {{original}})"
   },

--- a/packages/web-awesome/src/locales/es.json
+++ b/packages/web-awesome/src/locales/es.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Abrir Playwright Trace",
     "pwTracePopupBlocked": "El navegador bloqueó la apertura de Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Permite las ventanas emergentes y vuelve a intentarlo.",
-    "pwTraceUnsupported": "Los traces de Playwright no se pueden abrir automáticamente en informes de un solo archivo. Descarga el trace y ábrelo manualmente.",
+    "pwTraceUnsupported": "Los traces de Playwright no se pueden abrir automáticamente en informes de un solo archivo.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, con código de salida {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, con código de salida {{actual}} (original {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, con código de salida {{actual}} (original {{original}})",
+    "pwTraceUnsupportedHint": "Descarga el trace, abre Trace Viewer y arrastra el archivo descargado al visor.",
+    "downloadPwTrace": "Descargar trace",
+    "openPwTraceViewer": "Abrir Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Abrir adjunto en nueva pestaña",

--- a/packages/web-awesome/src/locales/fr.json
+++ b/packages/web-awesome/src/locales/fr.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Ouvrir Playwright Trace",
     "pwTracePopupBlocked": "Le navigateur a bloqué l’ouverture de Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Autorisez les pop-ups et réessayez.",
-    "pwTraceUnsupported": "Les traces Playwright dans les rapports à fichier unique ne peuvent pas être ouvertes automatiquement. Téléchargez la trace et ouvrez-la manuellement.",
+    "pwTraceUnsupported": "Les traces Playwright dans les rapports à fichier unique ne peuvent pas être ouvertes automatiquement.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, avec le code de sortie {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, avec le code de sortie {{actual}} (original {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, avec le code de sortie {{actual}} (original {{original}})",
+    "pwTraceUnsupportedHint": "Téléchargez la trace, ouvrez Trace Viewer, puis déposez le fichier téléchargé dans le viewer.",
+    "downloadPwTrace": "Télécharger la trace",
+    "openPwTraceViewer": "Ouvrir Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Ouvrir dans un nouvel onglet",

--- a/packages/web-awesome/src/locales/fr.json
+++ b/packages/web-awesome/src/locales/fr.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Ouvrir Playwright Trace",
     "pwTracePopupBlocked": "Le navigateur a bloqué l’ouverture de Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Autorisez les pop-ups et réessayez.",
+    "pwTraceUnsupported": "Les traces Playwright dans les rapports à fichier unique ne peuvent pas être ouvertes automatiquement. Téléchargez la trace et ouvrez-la manuellement.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, avec le code de sortie {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, avec le code de sortie {{actual}} (original {{original}})"
   },

--- a/packages/web-awesome/src/locales/he.json
+++ b/packages/web-awesome/src/locales/he.json
@@ -155,6 +155,7 @@
     "openPwTrace": "פתח Playwright Trace",
     "pwTracePopupBlocked": "הדפדפן חסם את פתיחת Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "אפשר חלונות קופצים ונסה שוב.",
+    "pwTraceUnsupported": "לא ניתן לפתוח אוטומטית עקבות Playwright בדוחות בקובץ יחיד. הורד את ה-trace ופתח אותו ידנית.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, עם קוד יציאה {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, עם קוד יציאה {{actual}} (מקורי {{original}})"
   },

--- a/packages/web-awesome/src/locales/he.json
+++ b/packages/web-awesome/src/locales/he.json
@@ -155,9 +155,12 @@
     "openPwTrace": "פתח Playwright Trace",
     "pwTracePopupBlocked": "הדפדפן חסם את פתיחת Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "אפשר חלונות קופצים ונסה שוב.",
-    "pwTraceUnsupported": "לא ניתן לפתוח אוטומטית עקבות Playwright בדוחות בקובץ יחיד. הורד את ה-trace ופתח אותו ידנית.",
+    "pwTraceUnsupported": "לא ניתן לפתוח אוטומטית עקבות Playwright בדוחות בקובץ יחיד.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, עם קוד יציאה {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, עם קוד יציאה {{actual}} (מקורי {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, עם קוד יציאה {{actual}} (מקורי {{original}})",
+    "pwTraceUnsupportedHint": "הורד את ה-trace, פתח את Trace Viewer וגרור את הקובץ שהורד אל ה-viewer.",
+    "downloadPwTrace": "הורד trace",
+    "openPwTraceViewer": "פתח את Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "פתח קובץ מצורף בלשונית חדשה",

--- a/packages/web-awesome/src/locales/hy.json
+++ b/packages/web-awesome/src/locales/hy.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Բացել Playwright Trace",
     "pwTracePopupBlocked": "Բրաուզերը արգելափակեց Playwright Trace Viewer-ի բացումը։",
     "pwTracePopupBlockedHint": "Թույլատրեք բացվող պատուհանները և կրկին փորձեք։",
+    "pwTraceUnsupported": "Մեկ ֆայլով հաշվետվություններում Playwright trace-ները հնարավոր չէ ավտոմատ բացել։ Ներբեռնեք trace-ը և բացեք այն ձեռքով։",
     "finishedAtOriginal": "{{formattedCreatedAt}}, ելքի կոդ {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, ելքի կոդ {{actual}} (սկզբնական {{original}})"
   },

--- a/packages/web-awesome/src/locales/hy.json
+++ b/packages/web-awesome/src/locales/hy.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Բացել Playwright Trace",
     "pwTracePopupBlocked": "Բրաուզերը արգելափակեց Playwright Trace Viewer-ի բացումը։",
     "pwTracePopupBlockedHint": "Թույլատրեք բացվող պատուհանները և կրկին փորձեք։",
-    "pwTraceUnsupported": "Մեկ ֆայլով հաշվետվություններում Playwright trace-ները հնարավոր չէ ավտոմատ բացել։ Ներբեռնեք trace-ը և բացեք այն ձեռքով։",
+    "pwTraceUnsupported": "Մեկ ֆայլով հաշվետվություններում Playwright trace-ները հնարավոր չէ ավտոմատ բացել։",
     "finishedAtOriginal": "{{formattedCreatedAt}}, ելքի կոդ {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, ելքի կոդ {{actual}} (սկզբնական {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, ելքի կոդ {{actual}} (սկզբնական {{original}})",
+    "pwTraceUnsupportedHint": "Ներբեռնեք trace-ը, բացեք Trace Viewer-ը և ներբեռնված ֆայլը քաշեք viewer-ի մեջ։",
+    "downloadPwTrace": "Ներբեռնել trace-ը",
+    "openPwTraceViewer": "Բացել Trace Viewer-ը"
   },
   "controls": {
     "newTabAttachment": "Բացել նոր ներդիրում",

--- a/packages/web-awesome/src/locales/it.json
+++ b/packages/web-awesome/src/locales/it.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Apri Playwright Trace",
     "pwTracePopupBlocked": "Il browser ha bloccato l'apertura di Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Consenti i popup e riprova.",
-    "pwTraceUnsupported": "Le trace Playwright nei report a file singolo non possono essere aperte automaticamente. Scarica la trace e aprila manualmente.",
+    "pwTraceUnsupported": "Le trace Playwright nei report a file singolo non possono essere aperte automaticamente.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, con codice di uscita {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, con codice di uscita {{actual}} (originale {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, con codice di uscita {{actual}} (originale {{original}})",
+    "pwTraceUnsupportedHint": "Scarica la trace, apri Trace Viewer e trascina il file scaricato nel viewer.",
+    "downloadPwTrace": "Scarica trace",
+    "openPwTraceViewer": "Apri Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Apri in una nuova scheda",

--- a/packages/web-awesome/src/locales/it.json
+++ b/packages/web-awesome/src/locales/it.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Apri Playwright Trace",
     "pwTracePopupBlocked": "Il browser ha bloccato l'apertura di Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Consenti i popup e riprova.",
+    "pwTraceUnsupported": "Le trace Playwright nei report a file singolo non possono essere aperte automaticamente. Scarica la trace e aprila manualmente.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, con codice di uscita {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, con codice di uscita {{actual}} (originale {{original}})"
   },

--- a/packages/web-awesome/src/locales/ja.json
+++ b/packages/web-awesome/src/locales/ja.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Playwright Traceを開く",
     "pwTracePopupBlocked": "ブラウザーが Playwright Trace Viewer の表示をブロックしました。",
     "pwTracePopupBlockedHint": "ポップアップを許可して再試行してください。",
-    "pwTraceUnsupported": "単一ファイルのレポートでは Playwright trace を自動的に開けません。trace をダウンロードして手動で開いてください。",
+    "pwTraceUnsupported": "単一ファイルのレポートでは Playwright trace を自動的に開けません。",
     "finishedAtOriginal": "{{formattedCreatedAt}}、終了コード{{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}、終了コード{{actual}}（元{{original}}）"
+    "finishedAtBoth": "{{formattedCreatedAt}}、終了コード{{actual}}（元{{original}}）",
+    "pwTraceUnsupportedHint": "trace をダウンロードし、Trace Viewer を開いて、ダウンロードしたファイルを viewer にドロップしてください。",
+    "downloadPwTrace": "trace をダウンロード",
+    "openPwTraceViewer": "Trace Viewer を開く"
   },
   "controls": {
     "newTabAttachment": "新しいタブで開く",

--- a/packages/web-awesome/src/locales/ja.json
+++ b/packages/web-awesome/src/locales/ja.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Playwright Traceを開く",
     "pwTracePopupBlocked": "ブラウザーが Playwright Trace Viewer の表示をブロックしました。",
     "pwTracePopupBlockedHint": "ポップアップを許可して再試行してください。",
+    "pwTraceUnsupported": "単一ファイルのレポートでは Playwright trace を自動的に開けません。trace をダウンロードして手動で開いてください。",
     "finishedAtOriginal": "{{formattedCreatedAt}}、終了コード{{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}、終了コード{{actual}}（元{{original}}）"
   },

--- a/packages/web-awesome/src/locales/ka.json
+++ b/packages/web-awesome/src/locales/ka.json
@@ -155,6 +155,7 @@
     "openPwTrace": "გახსენი Playwright Trace",
     "pwTracePopupBlocked": "ბრაუზერმა დაბლოკა Playwright Trace Viewer-ის გახსნა.",
     "pwTracePopupBlockedHint": "დაუშვით ამომხტარი ფანჯრები და ხელახლა სცადეთ.",
+    "pwTraceUnsupported": "ერთფაილიან რეპორტებში Playwright trace-ების ავტომატურად გახსნა შეუძლებელია. ჩამოტვირთეთ trace და ხელით გახსენით.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, გამოსვლის კოდით {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, გამოსვლის კოდით {{actual}} (თავდაპირველი {{original}})"
   },

--- a/packages/web-awesome/src/locales/ka.json
+++ b/packages/web-awesome/src/locales/ka.json
@@ -155,9 +155,12 @@
     "openPwTrace": "გახსენი Playwright Trace",
     "pwTracePopupBlocked": "ბრაუზერმა დაბლოკა Playwright Trace Viewer-ის გახსნა.",
     "pwTracePopupBlockedHint": "დაუშვით ამომხტარი ფანჯრები და ხელახლა სცადეთ.",
-    "pwTraceUnsupported": "ერთფაილიან რეპორტებში Playwright trace-ების ავტომატურად გახსნა შეუძლებელია. ჩამოტვირთეთ trace და ხელით გახსენით.",
+    "pwTraceUnsupported": "ერთფაილიან რეპორტებში Playwright trace-ების ავტომატურად გახსნა შეუძლებელია.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, გამოსვლის კოდით {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, გამოსვლის კოდით {{actual}} (თავდაპირველი {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, გამოსვლის კოდით {{actual}} (თავდაპირველი {{original}})",
+    "pwTraceUnsupportedHint": "ჩამოტვირთეთ trace, გახსენით Trace Viewer და ჩამოტვირთული ფაილი viewer-ში ჩააგდეთ.",
+    "downloadPwTrace": "Trace-ის ჩამოტვირთვა",
+    "openPwTraceViewer": "Trace Viewer-ის გახსნა"
   },
   "controls": {
     "newTabAttachment": "დანართის გახსნა ახალ ჩანართში",

--- a/packages/web-awesome/src/locales/kr.json
+++ b/packages/web-awesome/src/locales/kr.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Playwright Trace 열기",
     "pwTracePopupBlocked": "브라우저가 Playwright Trace Viewer 열기를 차단했습니다.",
     "pwTracePopupBlockedHint": "팝업을 허용한 뒤 다시 시도하세요.",
+    "pwTraceUnsupported": "단일 파일 보고서에서는 Playwright Trace를 자동으로 열 수 없습니다. Trace를 다운로드한 뒤 수동으로 여세요.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, 종료 코드 {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, 종료 코드 {{actual}} (원본 {{original}})"
   },

--- a/packages/web-awesome/src/locales/kr.json
+++ b/packages/web-awesome/src/locales/kr.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Playwright Trace 열기",
     "pwTracePopupBlocked": "브라우저가 Playwright Trace Viewer 열기를 차단했습니다.",
     "pwTracePopupBlockedHint": "팝업을 허용한 뒤 다시 시도하세요.",
-    "pwTraceUnsupported": "단일 파일 보고서에서는 Playwright Trace를 자동으로 열 수 없습니다. Trace를 다운로드한 뒤 수동으로 여세요.",
+    "pwTraceUnsupported": "단일 파일 보고서에서는 Playwright Trace를 자동으로 열 수 없습니다.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, 종료 코드 {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, 종료 코드 {{actual}} (원본 {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, 종료 코드 {{actual}} (원본 {{original}})",
+    "pwTraceUnsupportedHint": "Trace를 다운로드하고 Trace Viewer를 연 뒤 다운로드한 파일을 viewer에 드롭하세요.",
+    "downloadPwTrace": "Trace 다운로드",
+    "openPwTraceViewer": "Trace Viewer 열기"
   },
   "controls": {
     "newTabAttachment": "첨부파일을 새 탭에서 열기",

--- a/packages/web-awesome/src/locales/nl.json
+++ b/packages/web-awesome/src/locales/nl.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Open Playwright Trace",
     "pwTracePopupBlocked": "De browser heeft het openen van Playwright Trace Viewer geblokkeerd.",
     "pwTracePopupBlockedHint": "Sta pop-ups toe en probeer het opnieuw.",
-    "pwTraceUnsupported": "Playwright-traces in single-file rapporten kunnen niet automatisch worden geopend. Download de trace en open deze handmatig.",
+    "pwTraceUnsupported": "Playwright-traces in single-file rapporten kunnen niet automatisch worden geopend.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, met exitcode {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, met exitcode {{actual}} (oorspronkelijk {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, met exitcode {{actual}} (oorspronkelijk {{original}})",
+    "pwTraceUnsupportedHint": "Download de trace, open Trace Viewer en sleep het gedownloade bestand naar de viewer.",
+    "downloadPwTrace": "Trace downloaden",
+    "openPwTraceViewer": "Trace Viewer openen"
   },
   "controls": {
     "newTabAttachment": "Bijlage openen in nieuw tabblad",

--- a/packages/web-awesome/src/locales/nl.json
+++ b/packages/web-awesome/src/locales/nl.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Open Playwright Trace",
     "pwTracePopupBlocked": "De browser heeft het openen van Playwright Trace Viewer geblokkeerd.",
     "pwTracePopupBlockedHint": "Sta pop-ups toe en probeer het opnieuw.",
+    "pwTraceUnsupported": "Playwright-traces in single-file rapporten kunnen niet automatisch worden geopend. Download de trace en open deze handmatig.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, met exitcode {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, met exitcode {{actual}} (oorspronkelijk {{original}})"
   },

--- a/packages/web-awesome/src/locales/pl.json
+++ b/packages/web-awesome/src/locales/pl.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Otwórz Playwright Trace",
     "pwTracePopupBlocked": "Przeglądarka zablokowała otwarcie Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Zezwól na wyskakujące okna i spróbuj ponownie.",
-    "pwTraceUnsupported": "Trace Playwright w raportach jednoplikowych nie mogą być otwierane automatycznie. Pobierz trace i otwórz go ręcznie.",
+    "pwTraceUnsupported": "Trace Playwright w raportach jednoplikowych nie mogą być otwierane automatycznie.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, z kodem wyjścia {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, z kodem wyjścia {{actual}} (oryginalny {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, z kodem wyjścia {{actual}} (oryginalny {{original}})",
+    "pwTraceUnsupportedHint": "Pobierz trace, otwórz Trace Viewer i przeciągnij pobrany plik do viewera.",
+    "downloadPwTrace": "Pobierz trace",
+    "openPwTraceViewer": "Otwórz Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Otwórz w nowej zakładce",

--- a/packages/web-awesome/src/locales/pl.json
+++ b/packages/web-awesome/src/locales/pl.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Otwórz Playwright Trace",
     "pwTracePopupBlocked": "Przeglądarka zablokowała otwarcie Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Zezwól na wyskakujące okna i spróbuj ponownie.",
+    "pwTraceUnsupported": "Trace Playwright w raportach jednoplikowych nie mogą być otwierane automatycznie. Pobierz trace i otwórz go ręcznie.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, z kodem wyjścia {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, z kodem wyjścia {{actual}} (oryginalny {{original}})"
   },

--- a/packages/web-awesome/src/locales/pt.json
+++ b/packages/web-awesome/src/locales/pt.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Abrir Playwright Trace",
     "pwTracePopupBlocked": "O navegador bloqueou a abertura do Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Permita pop-ups e tente novamente.",
+    "pwTraceUnsupported": "Traces do Playwright em relatórios de arquivo único não podem ser abertos automaticamente. Baixe o trace e abra-o manualmente.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, com código de saída {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, com código de saída {{actual}} (original {{original}})"
   },

--- a/packages/web-awesome/src/locales/pt.json
+++ b/packages/web-awesome/src/locales/pt.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Abrir Playwright Trace",
     "pwTracePopupBlocked": "O navegador bloqueou a abertura do Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Permita pop-ups e tente novamente.",
-    "pwTraceUnsupported": "Traces do Playwright em relatórios de arquivo único não podem ser abertos automaticamente. Baixe o trace e abra-o manualmente.",
+    "pwTraceUnsupported": "Traces do Playwright em relatórios de arquivo único não podem ser abertos automaticamente.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, com código de saída {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, com código de saída {{actual}} (original {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, com código de saída {{actual}} (original {{original}})",
+    "pwTraceUnsupportedHint": "Baixe o trace, abra o Trace Viewer e solte o arquivo baixado no viewer.",
+    "downloadPwTrace": "Baixar trace",
+    "openPwTraceViewer": "Abrir Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Abrir anexo em nova aba",

--- a/packages/web-awesome/src/locales/ru.json
+++ b/packages/web-awesome/src/locales/ru.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Открыть Playwright Trace",
     "pwTracePopupBlocked": "Браузер заблокировал открытие Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Разрешите всплывающие окна и повторите попытку.",
-    "pwTraceUnsupported": "Трейсы Playwright в однофайловых отчётах нельзя открыть автоматически. Скачайте трейс и откройте его вручную.",
+    "pwTraceUnsupported": "Трейсы Playwright в однофайловых отчётах нельзя открыть автоматически.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, с кодом выхода {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, с кодом выхода {{actual}} (первоначальный {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, с кодом выхода {{actual}} (первоначальный {{original}})",
+    "pwTraceUnsupportedHint": "Скачайте трейс, откройте Trace Viewer и перетащите скачанный файл в окно viewer.",
+    "downloadPwTrace": "Скачать трейс",
+    "openPwTraceViewer": "Открыть Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Открыть в новой вкладке",

--- a/packages/web-awesome/src/locales/ru.json
+++ b/packages/web-awesome/src/locales/ru.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Открыть Playwright Trace",
     "pwTracePopupBlocked": "Браузер заблокировал открытие Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Разрешите всплывающие окна и повторите попытку.",
+    "pwTraceUnsupported": "Трейсы Playwright в однофайловых отчётах нельзя открыть автоматически. Скачайте трейс и откройте его вручную.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, с кодом выхода {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, с кодом выхода {{actual}} (первоначальный {{original}})"
   },

--- a/packages/web-awesome/src/locales/sv.json
+++ b/packages/web-awesome/src/locales/sv.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Öppna Playwright Trace",
     "pwTracePopupBlocked": "Webbläsaren blockerade öppning av Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Tillåt popup-fönster och försök igen.",
+    "pwTraceUnsupported": "Playwright-traces i rapporter med en enda fil kan inte öppnas automatiskt. Ladda ner trace-filen och öppna den manuellt.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, med avslutningskod {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, med avslutningskod {{actual}} (ursprunglig {{original}})"
   },

--- a/packages/web-awesome/src/locales/sv.json
+++ b/packages/web-awesome/src/locales/sv.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Öppna Playwright Trace",
     "pwTracePopupBlocked": "Webbläsaren blockerade öppning av Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Tillåt popup-fönster och försök igen.",
-    "pwTraceUnsupported": "Playwright-traces i rapporter med en enda fil kan inte öppnas automatiskt. Ladda ner trace-filen och öppna den manuellt.",
+    "pwTraceUnsupported": "Playwright-traces i rapporter med en enda fil kan inte öppnas automatiskt.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, med avslutningskod {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, med avslutningskod {{actual}} (ursprunglig {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, med avslutningskod {{actual}} (ursprunglig {{original}})",
+    "pwTraceUnsupportedHint": "Ladda ner trace-filen, öppna Trace Viewer och släpp den nedladdade filen i viewern.",
+    "downloadPwTrace": "Ladda ner trace",
+    "openPwTraceViewer": "Öppna Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Öppna bilaga i ny flik",

--- a/packages/web-awesome/src/locales/tr.json
+++ b/packages/web-awesome/src/locales/tr.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Playwright Trace Aç",
     "pwTracePopupBlocked": "Tarayıcı Playwright Trace Viewer’ın açılmasını engelledi.",
     "pwTracePopupBlockedHint": "Açılır pencerelere izin verip tekrar deneyin.",
-    "pwTraceUnsupported": "Tek dosyalı raporlardaki Playwright trace'leri otomatik olarak açılamaz. Trace'i indirin ve elle açın.",
+    "pwTraceUnsupported": "Tek dosyalı raporlardaki Playwright trace'leri otomatik olarak açılamaz.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, çıkış kodu {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, çıkış kodu {{actual}} (orijinal {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, çıkış kodu {{actual}} (orijinal {{original}})",
+    "pwTraceUnsupportedHint": "Trace'i indirin, Trace Viewer'ı açın ve indirilen dosyayı viewer'a bırakın.",
+    "downloadPwTrace": "Trace'i indir",
+    "openPwTraceViewer": "Trace Viewer'ı aç"
   },
   "controls": {
     "newTabAttachment": "Eki yeni sekmede aç",

--- a/packages/web-awesome/src/locales/tr.json
+++ b/packages/web-awesome/src/locales/tr.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Playwright Trace Aç",
     "pwTracePopupBlocked": "Tarayıcı Playwright Trace Viewer’ın açılmasını engelledi.",
     "pwTracePopupBlockedHint": "Açılır pencerelere izin verip tekrar deneyin.",
+    "pwTraceUnsupported": "Tek dosyalı raporlardaki Playwright trace'leri otomatik olarak açılamaz. Trace'i indirin ve elle açın.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, çıkış kodu {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, çıkış kodu {{actual}} (orijinal {{original}})"
   },

--- a/packages/web-awesome/src/locales/uk.json
+++ b/packages/web-awesome/src/locales/uk.json
@@ -155,9 +155,12 @@
     "openPwTrace": "Відкрити Playwright Trace",
     "pwTracePopupBlocked": "Браузер заблокував відкриття Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Дозвольте спливні вікна та повторіть спробу.",
-    "pwTraceUnsupported": "Трейси Playwright в однофайлових звітах не можна відкрити автоматично. Завантажте трейс і відкрийте його вручну.",
+    "pwTraceUnsupported": "Трейси Playwright в однофайлових звітах не можна відкрити автоматично.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, з кодом виходу {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}, з кодом виходу {{actual}} (первісний {{original}})"
+    "finishedAtBoth": "{{formattedCreatedAt}}, з кодом виходу {{actual}} (первісний {{original}})",
+    "pwTraceUnsupportedHint": "Завантажте трейс, відкрийте Trace Viewer і перетягніть завантажений файл у viewer.",
+    "downloadPwTrace": "Завантажити трейс",
+    "openPwTraceViewer": "Відкрити Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "Відкрити в новій вкладці",

--- a/packages/web-awesome/src/locales/uk.json
+++ b/packages/web-awesome/src/locales/uk.json
@@ -155,6 +155,7 @@
     "openPwTrace": "Відкрити Playwright Trace",
     "pwTracePopupBlocked": "Браузер заблокував відкриття Playwright Trace Viewer.",
     "pwTracePopupBlockedHint": "Дозвольте спливні вікна та повторіть спробу.",
+    "pwTraceUnsupported": "Трейси Playwright в однофайлових звітах не можна відкрити автоматично. Завантажте трейс і відкрийте його вручну.",
     "finishedAtOriginal": "{{formattedCreatedAt}}, з кодом виходу {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}, з кодом виходу {{actual}} (первісний {{original}})"
   },

--- a/packages/web-awesome/src/locales/zh-TW.json
+++ b/packages/web-awesome/src/locales/zh-TW.json
@@ -155,6 +155,7 @@
     "openPwTrace": "開啟 Playwright Trace",
     "pwTracePopupBlocked": "瀏覽器封鎖了開啟 Playwright Trace Viewer。",
     "pwTracePopupBlockedHint": "請允許彈出視窗後重試。",
+    "pwTraceUnsupported": "單一檔案報告中的 Playwright trace 無法自動開啟。請下載 trace 並手動開啟。",
     "finishedAtOriginal": "{{formattedCreatedAt}}，結束代碼 {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}，結束代號 {{actual}}（原始 {{original}}）"
   },

--- a/packages/web-awesome/src/locales/zh-TW.json
+++ b/packages/web-awesome/src/locales/zh-TW.json
@@ -155,9 +155,12 @@
     "openPwTrace": "開啟 Playwright Trace",
     "pwTracePopupBlocked": "瀏覽器封鎖了開啟 Playwright Trace Viewer。",
     "pwTracePopupBlockedHint": "請允許彈出視窗後重試。",
-    "pwTraceUnsupported": "單一檔案報告中的 Playwright trace 無法自動開啟。請下載 trace 並手動開啟。",
+    "pwTraceUnsupported": "單一檔案報告中的 Playwright trace 無法自動開啟。",
     "finishedAtOriginal": "{{formattedCreatedAt}}，結束代碼 {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}，結束代號 {{actual}}（原始 {{original}}）"
+    "finishedAtBoth": "{{formattedCreatedAt}}，結束代號 {{actual}}（原始 {{original}}）",
+    "pwTraceUnsupportedHint": "請下載 trace、開啟 Trace Viewer，然後將下載的檔案拖放到 viewer 中。",
+    "downloadPwTrace": "下載 trace",
+    "openPwTraceViewer": "開啟 Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "在新分頁中開啟附件",

--- a/packages/web-awesome/src/locales/zh.json
+++ b/packages/web-awesome/src/locales/zh.json
@@ -155,9 +155,12 @@
     "openPwTrace": "打开 Playwright Trace",
     "pwTracePopupBlocked": "浏览器阻止了打开 Playwright Trace Viewer。",
     "pwTracePopupBlockedHint": "请允许弹出窗口后重试。",
-    "pwTraceUnsupported": "单文件报告中的 Playwright trace 无法自动打开。请下载 trace 并手动打开。",
+    "pwTraceUnsupported": "单文件报告中的 Playwright trace 无法自动打开。",
     "finishedAtOriginal": "{{formattedCreatedAt}}，退出代码 {{original}}",
-    "finishedAtBoth": "{{formattedCreatedAt}}，退出代码 {{actual}}（原始 {{original}}）"
+    "finishedAtBoth": "{{formattedCreatedAt}}，退出代码 {{actual}}（原始 {{original}}）",
+    "pwTraceUnsupportedHint": "请下载 trace，打开 Trace Viewer，然后将下载的文件拖放到 viewer 中。",
+    "downloadPwTrace": "下载 trace",
+    "openPwTraceViewer": "打开 Trace Viewer"
   },
   "controls": {
     "newTabAttachment": "在新标签页中打开附件",

--- a/packages/web-awesome/src/locales/zh.json
+++ b/packages/web-awesome/src/locales/zh.json
@@ -155,6 +155,7 @@
     "openPwTrace": "打开 Playwright Trace",
     "pwTracePopupBlocked": "浏览器阻止了打开 Playwright Trace Viewer。",
     "pwTracePopupBlockedHint": "请允许弹出窗口后重试。",
+    "pwTraceUnsupported": "单文件报告中的 Playwright trace 无法自动打开。请下载 trace 并手动打开。",
     "finishedAtOriginal": "{{formattedCreatedAt}}，退出代码 {{original}}",
     "finishedAtBoth": "{{formattedCreatedAt}}，退出代码 {{actual}}（原始 {{original}}）"
   },

--- a/packages/web-awesome/test/components/TestResult/PwTraceButton.test.tsx
+++ b/packages/web-awesome/test/components/TestResult/PwTraceButton.test.tsx
@@ -16,12 +16,19 @@ const setup = async ({ canOpenInNewTab, failFetch, traceUrl }: SetupOptions) => 
   const openModal = vi.fn();
   const closeModal = vi.fn();
   const openPlaywrightTraceInNewTab = vi.fn().mockReturnValue(canOpenInNewTab);
+  const downloadAttachment = vi.fn();
 
   vi.doMock("@allurereport/web-commons", () => ({
+    downloadAttachment,
     reportDataUrl,
   }));
   vi.doMock("@allurereport/web-components", () => ({
     Button: ({ onClick, text }: { onClick?: () => void; text?: string }) => <button onClick={onClick}>{text}</button>,
+    ButtonLink: ({ href, target, text }: { href?: string; target?: string; text?: string }) => (
+      <a href={href} target={target}>
+        {text}
+      </a>
+    ),
     Text: ({ children }: { children: unknown }) => <div>{children}</div>,
     TooltipWrapper: ({ children }: { children: unknown }) => <div>{children}</div>,
     IconButton: ({ "aria-label": ariaLabel, onClick }: { "aria-label"?: string; "onClick"?: () => void }) => (
@@ -29,7 +36,10 @@ const setup = async ({ canOpenInNewTab, failFetch, traceUrl }: SetupOptions) => 
         open trace
       </button>
     ),
-    allureIcons: { lineArrowsExpand3: "lineArrowsExpand3" },
+    allureIcons: {
+      lineArrowsExpand3: "lineArrowsExpand3",
+      lineGeneralDownloadCloud: "lineGeneralDownloadCloud",
+    },
   }));
   vi.doMock("@/stores", () => ({
     useI18n: () => ({ t: (key: string) => key }),
@@ -55,7 +65,7 @@ const setup = async ({ canOpenInNewTab, failFetch, traceUrl }: SetupOptions) => 
 
   fireEvent.click(screen.getByRole("button", { name: "openPwTrace" }));
 
-  return { reportDataUrl, openModal, closeModal, openPlaywrightTraceInNewTab };
+  return { reportDataUrl, openModal, closeModal, openPlaywrightTraceInNewTab, downloadAttachment };
 };
 
 describe("components > TestResult > PwTraceButton", () => {
@@ -109,7 +119,7 @@ describe("components > TestResult > PwTraceButton", () => {
   });
 
   it("shows unsupported modal for single-file trace data URLs", async () => {
-    const { openModal, openPlaywrightTraceInNewTab } = await setup({
+    const { openModal, openPlaywrightTraceInNewTab, downloadAttachment } = await setup({
       canOpenInNewTab: true,
       traceUrl: "data:application/vnd.allure.playwright-trace;base64,dHJhY2U=",
     });
@@ -121,8 +131,22 @@ describe("components > TestResult > PwTraceButton", () => {
     expect(openPlaywrightTraceInNewTab).not.toHaveBeenCalled();
     expect(openModal).toHaveBeenCalledWith(
       expect.objectContaining({
+        size: "content",
         title: "Playwright Trace Viewer | trace.zip",
       }),
     );
+
+    render(openModal.mock.calls[0][0].component);
+
+    expect(screen.getByText("pwTraceUnsupported")).toBeInTheDocument();
+    expect(screen.getByText("pwTraceUnsupportedHint")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "openPwTraceViewer" })).toHaveAttribute(
+      "href",
+      "https://trace.playwright.dev/",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "downloadPwTrace" }));
+
+    expect(downloadAttachment).toHaveBeenCalledWith("trace-id", ".zip", "application/vnd.allure.playwright-trace");
   });
 });

--- a/packages/web-awesome/test/components/TestResult/PwTraceButton.test.tsx
+++ b/packages/web-awesome/test/components/TestResult/PwTraceButton.test.tsx
@@ -4,28 +4,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 type SetupOptions = {
   canOpenInNewTab: boolean;
   failFetch?: boolean;
+  traceUrl?: string;
 };
 
-const setup = async ({ canOpenInNewTab, failFetch }: SetupOptions) => {
+const setup = async ({ canOpenInNewTab, failFetch, traceUrl }: SetupOptions) => {
   vi.resetModules();
 
-  const fetchFromUrl = failFetch
+  const reportDataUrl = failFetch
     ? vi.fn().mockRejectedValue(new Error("fetch failed"))
-    : vi.fn().mockResolvedValue({
-        blob: vi.fn().mockResolvedValue(new Blob(["trace"])),
-      });
+    : vi.fn().mockResolvedValue(traceUrl ?? "http://localhost:1234/data/attachments/trace-id.zip?attachment");
   const openModal = vi.fn();
   const closeModal = vi.fn();
   const openPlaywrightTraceInNewTab = vi.fn().mockReturnValue(canOpenInNewTab);
 
   vi.doMock("@allurereport/web-commons", () => ({
-    fetchFromUrl,
+    reportDataUrl,
   }));
   vi.doMock("@allurereport/web-components", () => ({
     Button: ({ onClick, text }: { onClick?: () => void; text?: string }) => <button onClick={onClick}>{text}</button>,
     Text: ({ children }: { children: unknown }) => <div>{children}</div>,
     TooltipWrapper: ({ children }: { children: unknown }) => <div>{children}</div>,
-    IconButton: ({ onClick }: { onClick?: () => void }) => <button onClick={onClick}>open trace</button>,
+    IconButton: ({ "aria-label": ariaLabel, onClick }: { "aria-label"?: string; "onClick"?: () => void }) => (
+      <button aria-label={ariaLabel} onClick={onClick}>
+        open trace
+      </button>
+    ),
     allureIcons: { lineArrowsExpand3: "lineArrowsExpand3" },
   }));
   vi.doMock("@/stores", () => ({
@@ -50,9 +53,9 @@ const setup = async ({ canOpenInNewTab, failFetch }: SetupOptions) => {
     />,
   );
 
-  fireEvent.click(screen.getByRole("button", { name: "open trace" }));
+  fireEvent.click(screen.getByRole("button", { name: "openPwTrace" }));
 
-  return { fetchFromUrl, openModal, closeModal, openPlaywrightTraceInNewTab };
+  return { reportDataUrl, openModal, closeModal, openPlaywrightTraceInNewTab };
 };
 
 describe("components > TestResult > PwTraceButton", () => {
@@ -69,6 +72,9 @@ describe("components > TestResult > PwTraceButton", () => {
       expect(openPlaywrightTraceInNewTab).toHaveBeenCalledTimes(1);
     });
 
+    expect(openPlaywrightTraceInNewTab).toHaveBeenCalledWith(
+      "http://localhost:1234/data/attachments/trace-id.zip?attachment",
+    );
     expect(openModal).not.toHaveBeenCalled();
   });
 
@@ -100,5 +106,23 @@ describe("components > TestResult > PwTraceButton", () => {
     });
 
     expect(openPlaywrightTraceInNewTab).not.toHaveBeenCalled();
+  });
+
+  it("shows unsupported modal for single-file trace data URLs", async () => {
+    const { openModal, openPlaywrightTraceInNewTab } = await setup({
+      canOpenInNewTab: true,
+      traceUrl: "data:application/vnd.allure.playwright-trace;base64,dHJhY2U=",
+    });
+
+    await waitFor(() => {
+      expect(openModal).toHaveBeenCalledTimes(1);
+    });
+
+    expect(openPlaywrightTraceInNewTab).not.toHaveBeenCalled();
+    expect(openModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Playwright Trace Viewer | trace.zip",
+      }),
+    );
   });
 });

--- a/packages/web-awesome/test/components/TestResult/openPwTraceInNewTab.test.ts
+++ b/packages/web-awesome/test/components/TestResult/openPwTraceInNewTab.test.ts
@@ -3,63 +3,35 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 describe("components > TestResult > openPlaywrightTraceInNewTab", () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
   });
 
   it("returns false when popup is blocked", async () => {
     const { openPlaywrightTraceInNewTab } = await import("@/components/TestResult/TrPwTraces/openPwTraceInNewTab");
     vi.spyOn(window, "open").mockReturnValue(null);
 
-    const result = openPlaywrightTraceInNewTab(new Blob(["trace"]));
+    const result = openPlaywrightTraceInNewTab("http://localhost:1234/data/attachments/trace.zip?attachment");
 
     expect(result).toBe(false);
   });
 
-  it("sends trace message immediately and retries once", async () => {
+  it("opens Playwright Trace Viewer with trace URL parameter", async () => {
     const { openPlaywrightTraceInNewTab } = await import("@/components/TestResult/TrPwTraces/openPwTraceInNewTab");
-    const postMessage = vi.fn();
     const popup = {
-      postMessage,
-      location: { href: "" },
       focus: vi.fn(),
-      closed: false,
     } as unknown as Window;
-    vi.spyOn(window, "open").mockReturnValue(popup);
+    const open = vi.spyOn(window, "open").mockReturnValue(popup);
 
-    const result = openPlaywrightTraceInNewTab(new Blob(["trace"]));
+    const result = openPlaywrightTraceInNewTab("http://localhost:1234/data/attachments/trace.zip?attachment");
 
     expect(result).toBe(true);
-    expect(postMessage).toHaveBeenCalledTimes(1);
-
-    vi.advanceTimersByTime(300);
-    expect(postMessage).toHaveBeenCalledTimes(2);
-
-    vi.advanceTimersByTime(30_000);
-    expect(postMessage).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not send delayed retry when popup is already closed", async () => {
-    const { openPlaywrightTraceInNewTab } = await import("@/components/TestResult/TrPwTraces/openPwTraceInNewTab");
-    const postMessage = vi.fn();
-    const popup = {
-      postMessage,
-      location: { href: "" },
-      focus: vi.fn(),
-      closed: false,
-    } as unknown as Window & { closed: boolean };
-    vi.spyOn(window, "open").mockReturnValue(popup);
-
-    openPlaywrightTraceInNewTab(new Blob(["trace"]));
-    expect(postMessage).toHaveBeenCalledTimes(1);
-
-    popup.closed = true;
-    vi.advanceTimersByTime(300);
-    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      "https://trace.playwright.dev/?trace=http%3A%2F%2Flocalhost%3A1234%2Fdata%2Fattachments%2Ftrace.zip%3Fattachment",
+      "_blank",
+    );
+    expect(popup.focus).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web-components/src/components/Modal/index.tsx
+++ b/packages/web-components/src/components/Modal/index.tsx
@@ -30,6 +30,7 @@ export interface ModalDataProps<T = any> {
   closeModal?: () => void;
   attachments?: AttachmentTestStepResult[];
   title?: string;
+  size?: "attachment" | "content";
 }
 
 export interface ModalTranslations {
@@ -52,6 +53,7 @@ export const Modal = ({
   closeModal,
   translations,
   title,
+  size = "attachment",
 }: ModalDataProps & ModalTranslationsProps) => {
   const { tooltipPreview, tooltipSyntaxHighlight, tooltipDownload, openInNewTabButton } = translations;
   const { link } = data || {};
@@ -72,6 +74,7 @@ export const Modal = ({
   const isAttachment = link?.id && link?.ext && link?.contentType;
   const attachmentName = link?.name || (link?.id && link?.ext && `${link.id}${link.ext}`) || "";
   const modalName = title || attachmentName;
+  const canToggleFullScreen = size !== "content";
 
   useEffect(() => {
     if (isModalOpen) {
@@ -124,7 +127,13 @@ export const Modal = ({
   return (
     <div className={styles["modal-overlay"]} onClick={closeModal}>
       <div className={clsx(styles["modal-content"])} onClick={(e) => e.stopPropagation()}>
-        <div className={clsx(styles["modal-wrapper"], { [styles["modal-wrapper-fullscreen"]]: isFullScreen })}>
+        <div
+          className={clsx(
+            styles["modal-wrapper"],
+            size === "content" && styles["modal-wrapper-content"],
+            isFullScreen && styles["modal-wrapper-fullscreen"],
+          )}
+        >
           <div className={styles["modal-header"]}>
             <Heading size={"s"}>{modalName}</Heading>
             <div className={styles["modal-buttons"]}>
@@ -170,12 +179,14 @@ export const Modal = ({
                   />
                 </TooltipWrapper>
               )}
-              <IconButton
-                iconSize={"m"}
-                style={"ghost"}
-                onClick={() => setIsFullScreen(!isFullScreen)}
-                icon={isFullScreen ? allureIcons.lineLayoutsMinimize2 : allureIcons.lineLayoutsMaximize2}
-              />
+              {canToggleFullScreen && (
+                <IconButton
+                  iconSize={"m"}
+                  style={"ghost"}
+                  onClick={() => setIsFullScreen(!isFullScreen)}
+                  icon={isFullScreen ? allureIcons.lineLayoutsMinimize2 : allureIcons.lineLayoutsMaximize2}
+                />
+              )}
               <IconButton iconSize={"m"} style={"ghost"} onClick={closeModal} icon={allureIcons.lineGeneralXClose} />
             </div>
           </div>

--- a/packages/web-components/src/components/Modal/styles.scss
+++ b/packages/web-components/src/components/Modal/styles.scss
@@ -45,6 +45,31 @@
   width: calc(100vw - 16px);
 }
 
+.modal-wrapper-content {
+  width: min(560px, calc(100vw - 48px));
+  height: auto;
+  min-height: 0;
+  max-height: calc(100vh - 48px);
+  align-items: stretch;
+  justify-content: flex-start;
+
+  .modal-header {
+    padding: 24px 24px 16px;
+  }
+
+  .modal-data {
+    flex: 0 1 auto;
+    height: auto;
+    align-items: stretch;
+    padding: 0 24px 24px;
+  }
+
+  .modal-data-component {
+    height: auto;
+    overflow: visible;
+  }
+}
+
 .modal-data-component {
   flex: 1 1 auto;
   overflow: hidden;


### PR DESCRIPTION
Playwright Trace Viewer changed its cross-origin `postMessage` handling in microsoft/playwright#40548, which broke the old Allure flow for opening traces.

This PR switches to the official `trace.playwright.dev/?trace=<url>` API and adds CORS for trace attachment requests so the viewer can fetch the file directly.

Single-file reports are handled with a manual fallback because their attachments are embedded as `data:` URLs and cannot be passed to the external viewer as a regular file URL.

Fixes allure-framework/allure3#624