### PR TITLE
feat(plugin-testops): attach git information on launch create

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -47,6 +47,10 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/e2e"\
     },\
     {\
+      "name": "@allurereport/git",\
+      "reference": "workspace:packages/git"\
+    },\
+    {\
       "name": "@allurereport/plugin-agent",\
       "reference": "workspace:packages/plugin-agent"\
     },\
@@ -162,6 +166,7 @@ const RAW_RUNTIME_STATE =
     ["@allurereport/core-api", ["workspace:packages/core-api"]],\
     ["@allurereport/directory-watcher", ["workspace:packages/directory-watcher"]],\
     ["@allurereport/e2e", ["workspace:packages/e2e"]],\
+    ["@allurereport/git", ["workspace:packages/git"]],\
     ["@allurereport/monorepo", ["workspace:."]],\
     ["@allurereport/plugin-agent", ["workspace:packages/plugin-agent"]],\
     ["@allurereport/plugin-allure2", ["workspace:packages/plugin-allure2"]],\
@@ -381,6 +386,23 @@ const RAW_RUNTIME_STATE =
           ["lodash.times", "npm:4.3.2"],\
           ["rimraf", "npm:6.1.2"],\
           ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"]\
+        ],\
+        "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@allurereport/git", [\
+      ["workspace:packages/git", {\
+        "packageLocation": "./packages/git/",\
+        "packageDependencies": [\
+          ["@allurereport/core-api", "workspace:packages/core-api"],\
+          ["@allurereport/git", "workspace:packages/git"],\
+          ["@types/node", "npm:20.19.41"],\
+          ["@vitest/runner", "npm:2.1.9"],\
+          ["@vitest/snapshot", "npm:2.1.9"],\
+          ["allure-vitest", "virtual:e545774f2ccef2393aca5c009a358532c03f065393263f9cbb3ab67366c2879624d5c1730fe5313387f3f2857386a5904c6581787f320ce570367a0ce47cf7b2#npm:3.9.0"],\
+          ["rimraf", "npm:6.1.2"],\
+          ["typescript", "patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"],\
+          ["vitest", "virtual:e545774f2ccef2393aca5c009a358532c03f065393263f9cbb3ab67366c2879624d5c1730fe5313387f3f2857386a5904c6581787f320ce570367a0ce47cf7b2#npm:4.1.8"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -659,6 +681,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@allurereport/ci", "workspace:packages/ci"],\
           ["@allurereport/core-api", "workspace:packages/core-api"],\
+          ["@allurereport/git", "workspace:packages/git"],\
           ["@allurereport/plugin-api", "workspace:packages/plugin-api"],\
           ["@allurereport/plugin-testops", "workspace:packages/plugin-testops"],\
           ["@allurereport/reader-api", "workspace:packages/reader-api"],\

--- a/packages/ci/src/detectors/amazon.ts
+++ b/packages/ci/src/detectors/amazon.ts
@@ -5,6 +5,10 @@ import { getEnv, getReponameFromRepoUrl } from "../utils.js";
 
 const AMAZON_REGEXP = /^arn:aws:codebuild:([^:]+):([\d]+):(?:build|build-batch)\/([^:]+):([\da-f-]+)$/;
 const PIPELINE_REGEXP = /^(?:codepipeline\/)(.+)$/;
+const REF_PREFIX = "refs/";
+const BRANCH_REF_PREFIX = "refs/heads/";
+const TAG_REF_PREFIX = "refs/tags/";
+const GIT_SHA_REGEXP = /^[\da-f]{40}$/i;
 
 export const parseArnValues = (source: string): string[] => {
   if (!source) {
@@ -36,23 +40,78 @@ export const getPipelineName = (): string => {
   return initiator.match(PIPELINE_REGEXP)?.[1] ?? "";
 };
 
-const parseBranchFromSourceVersion = (sourceVersion?: string): string | undefined => {
-  const prefix = "refs/heads/";
-  const normalizedSourceVersion = sourceVersion ?? "";
+const stripCommitSuffix = (sourceVersion: string): string => sourceVersion.replace(/\^\{[^}]+\}$/, "");
 
-  if (normalizedSourceVersion.startsWith(prefix)) {
-    const branch = normalizedSourceVersion.slice(prefix.length).replace(/\^\{[^}]+\}$/, "");
+const parseBranchFromWebhookTrigger = (): string | undefined => {
+  const branchTrigger = getEnv("CODEBUILD_WEBHOOK_TRIGGER") || "";
+
+  if (branchTrigger.startsWith("branch/")) {
+    const branch = branchTrigger.slice("branch/".length);
 
     return branch || undefined;
   }
 
-  const branchTrigger = getEnv("CODEBUILD_WEBHOOK_TRIGGER") || "";
+  return undefined;
+};
 
-  if (branchTrigger.startsWith("branch/")) {
-    return branchTrigger.slice("branch/".length);
+const isTagWebhookTrigger = (): boolean => (getEnv("CODEBUILD_WEBHOOK_TRIGGER") || "").startsWith("tag/");
+
+const parseBranchFromSourceVersion = (sourceVersion?: string): string | undefined => {
+  const normalizedSourceVersion = stripCommitSuffix((sourceVersion ?? "").trim());
+
+  if (!normalizedSourceVersion) {
+    return undefined;
   }
 
-  return undefined;
+  if (normalizedSourceVersion.startsWith(BRANCH_REF_PREFIX)) {
+    const branch = normalizedSourceVersion.slice(BRANCH_REF_PREFIX.length);
+
+    return branch || undefined;
+  }
+
+  if (
+    normalizedSourceVersion.startsWith(TAG_REF_PREFIX) ||
+    normalizedSourceVersion.match(/^pr\/\d+$/i) ||
+    normalizedSourceVersion.match(/^refs\/pull\/\d+\//i)
+  ) {
+    return undefined;
+  }
+
+  if (normalizedSourceVersion.startsWith(REF_PREFIX)) {
+    return undefined;
+  }
+
+  const triggerBranch = parseBranchFromWebhookTrigger();
+
+  if (triggerBranch) {
+    return triggerBranch;
+  }
+
+  if (isTagWebhookTrigger() || GIT_SHA_REGEXP.test(normalizedSourceVersion)) {
+    return undefined;
+  }
+
+  return normalizedSourceVersion;
+};
+
+const parseBranchFromWebhookHeadRef = (headRef?: string): string | undefined => {
+  const normalizedHeadRef = (headRef ?? "").trim();
+
+  if (!normalizedHeadRef || normalizedHeadRef.startsWith(TAG_REF_PREFIX) || isTagWebhookTrigger()) {
+    return undefined;
+  }
+
+  if (normalizedHeadRef.startsWith(BRANCH_REF_PREFIX)) {
+    const branch = normalizedHeadRef.slice(BRANCH_REF_PREFIX.length);
+
+    return branch || undefined;
+  }
+
+  if (normalizedHeadRef.startsWith(REF_PREFIX)) {
+    return undefined;
+  }
+
+  return normalizedHeadRef;
 };
 
 const parsePullRequestFromSourceVersion = (sourceVersion?: string): string | undefined => {
@@ -222,10 +281,8 @@ export const amazon: CiDescriptor = {
   },
 
   get sourceBranch() {
-    const headRef = getEnv("CODEBUILD_WEBHOOK_HEAD_REF");
-
     return (
-      (headRef ? stripRefsHeads(headRef) : undefined) ||
+      parseBranchFromWebhookHeadRef(getEnv("CODEBUILD_WEBHOOK_HEAD_REF")) ||
       parseBranchFromSourceVersion(getEnv("CODEBUILD_SOURCE_VERSION")) ||
       this.jobRunBranch ||
       undefined

--- a/packages/ci/src/detectors/amazon.ts
+++ b/packages/ci/src/detectors/amazon.ts
@@ -1,5 +1,6 @@
 import { type CiDescriptor, CiType } from "@allurereport/core-api";
 
+import { resolveRepositoryFromGitUrl, stripRefsHeads } from "../helpers/gitProvider.js";
 import { getEnv, getReponameFromRepoUrl } from "../utils.js";
 
 const AMAZON_REGEXP = /^arn:aws:codebuild:([^:]+):([\d]+):(?:build|build-batch)\/([^:]+):([\da-f-]+)$/;
@@ -33,6 +34,48 @@ export const getPipelineName = (): string => {
   }
 
   return initiator.match(PIPELINE_REGEXP)?.[1] ?? "";
+};
+
+const parseBranchFromSourceVersion = (sourceVersion?: string): string | undefined => {
+  const prefix = "refs/heads/";
+  const normalizedSourceVersion = sourceVersion ?? "";
+
+  if (normalizedSourceVersion.startsWith(prefix)) {
+    const branch = normalizedSourceVersion.slice(prefix.length).replace(/\^\{[^}]+\}$/, "");
+
+    return branch || undefined;
+  }
+
+  const branchTrigger = getEnv("CODEBUILD_WEBHOOK_TRIGGER") || "";
+
+  if (branchTrigger.startsWith("branch/")) {
+    return branchTrigger.slice("branch/".length);
+  }
+
+  return undefined;
+};
+
+const parsePullRequestFromSourceVersion = (sourceVersion?: string): string | undefined => {
+  const normalizedSourceVersion = sourceVersion ?? "";
+  const prPrefixMatch = normalizedSourceVersion.match(/^pr\/(?<id>\d+)$/i)?.groups?.id;
+
+  if (prPrefixMatch) {
+    return prPrefixMatch;
+  }
+
+  return normalizedSourceVersion.match(/refs\/pull\/(?<id>\d+)\//)?.groups?.id;
+};
+
+const parsePullRequestFromWebhookTrigger = (): string | undefined => {
+  const trigger = getEnv("CODEBUILD_WEBHOOK_TRIGGER") || "";
+
+  return trigger.match(/^pr\/(?<id>\d+)$/i)?.groups?.id;
+};
+
+const getRepository = () => {
+  const repoUrl = getEnv("CODEBUILD_SOURCE_REPO_URL");
+
+  return repoUrl ? resolveRepositoryFromGitUrl(repoUrl) : undefined;
 };
 
 export const amazon: CiDescriptor = {
@@ -151,9 +194,8 @@ export const amazon: CiDescriptor = {
 
   get jobRunBranch(): string {
     const sourceVersion = getEnv("CODEBUILD_SOURCE_VERSION");
-    const { branch } = sourceVersion?.match?.(/refs\/heads\/(?<branch>\S+)\^\{(?<commithash>\S+)\}/)?.groups ?? {};
 
-    return branch ?? "";
+    return parseBranchFromSourceVersion(sourceVersion) ?? "";
   },
 
   get pullRequestUrl(): string {
@@ -162,5 +204,48 @@ export const amazon: CiDescriptor = {
 
   get pullRequestName(): string {
     return "";
+  },
+
+  get provider() {
+    return getRepository()?.provider;
+  },
+
+  get repository() {
+    const repository = getRepository();
+
+    return repository
+      ? {
+          slug: repository.slug,
+          url: repository.url,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    const headRef = getEnv("CODEBUILD_WEBHOOK_HEAD_REF");
+
+    return (
+      (headRef ? stripRefsHeads(headRef) : undefined) ||
+      parseBranchFromSourceVersion(getEnv("CODEBUILD_SOURCE_VERSION")) ||
+      this.jobRunBranch ||
+      undefined
+    );
+  },
+
+  get targetBranch() {
+    return stripRefsHeads(getEnv("CODEBUILD_WEBHOOK_BASE_REF")) || undefined;
+  },
+
+  get pullRequest() {
+    const pullRequestId =
+      parsePullRequestFromWebhookTrigger() || parsePullRequestFromSourceVersion(getEnv("CODEBUILD_SOURCE_VERSION"));
+
+    return pullRequestId
+      ? {
+          id: pullRequestId,
+          url: this.pullRequestUrl || undefined,
+          title: this.pullRequestName || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/azure.ts
+++ b/packages/ci/src/detectors/azure.ts
@@ -1,5 +1,6 @@
-import { type CiDescriptor, CiType } from "@allurereport/core-api";
+import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
+import { resolveRepositoryFromGitUrl, stripRefsHeads } from "../helpers/gitProvider.js";
 import { getEnv } from "../utils.js";
 
 export const getRootURL = (): string => getEnv("SYSTEM_COLLECTIONURI");
@@ -9,6 +10,31 @@ export const getBuildID = (): string => getEnv("BUILD_BUILDID");
 export const getDefinitionID = (): string => getEnv("SYSTEM_DEFINITIONID");
 
 export const getProjectID = (): string => getEnv("SYSTEM_TEAMPROJECTID");
+
+const mapAzureRepositoryProvider = (provider: string): GitProvider | undefined => {
+  switch (provider) {
+    case "GitHub":
+      return GitProvider.Github;
+    case "Bitbucket":
+      return GitProvider.Bitbucket;
+    default:
+      return undefined;
+  }
+};
+
+const normalizeBranchRef = (branch?: string): string | undefined => {
+  const trimmed = branch?.trim() ?? "";
+
+  return trimmed ? stripRefsHeads(trimmed) : undefined;
+};
+
+const getRepositoryUrl = () => getEnv("BUILD_REPOSITORY_URI") || getEnv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI");
+
+const getRepositoryFromUrl = () => {
+  const repositoryUrl = getRepositoryUrl();
+
+  return repositoryUrl ? resolveRepositoryFromGitUrl(repositoryUrl) : undefined;
+};
 
 export const azure: CiDescriptor = {
   type: CiType.Azure,
@@ -53,8 +79,12 @@ export const azure: CiDescriptor = {
 
   get pullRequestUrl(): string {
     const repositoryProvider = getEnv("BUILD_REPOSITORY_PROVIDER");
-    const repositoryUrl = getEnv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI");
+    const repositoryUrl = getEnv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI") || getEnv("BUILD_REPOSITORY_URI");
     const pullRequestNumber = getEnv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER");
+
+    if (!repositoryUrl || !pullRequestNumber) {
+      return "";
+    }
 
     if (repositoryProvider === "GitHub") {
       return `${repositoryUrl}/pull/${pullRequestNumber}`;
@@ -69,5 +99,54 @@ export const azure: CiDescriptor = {
 
   get pullRequestName(): string {
     return "";
+  },
+
+  get provider() {
+    return getRepositoryFromUrl()?.provider ?? mapAzureRepositoryProvider(getEnv("BUILD_REPOSITORY_PROVIDER"));
+  },
+
+  get repository() {
+    const repositoryUrl = getRepositoryUrl();
+    const fromUrl = repositoryUrl ? resolveRepositoryFromGitUrl(repositoryUrl) : undefined;
+    const slug = fromUrl?.slug ?? (getEnv("BUILD_REPOSITORY_NAME") || undefined);
+
+    if (!this.provider || !slug) {
+      return undefined;
+    }
+
+    return {
+      slug,
+      url: fromUrl?.url ?? repositoryUrl,
+    };
+  },
+
+  get sourceBranch() {
+    return (
+      normalizeBranchRef(getEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH")) ||
+      getEnv("BUILD_SOURCEBRANCHNAME") ||
+      this.jobRunBranch ||
+      undefined
+    );
+  },
+
+  get targetBranch() {
+    return (
+      normalizeBranchRef(getEnv("SYSTEM_PULLREQUEST_TARGETBRANCH")) ||
+      getEnv("SYSTEM_PULLREQUEST_TARGETBRANCHNAME") ||
+      undefined
+    );
+  },
+
+  get pullRequest() {
+    const pullRequestNumber =
+      getEnv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER") || getEnv("SYSTEM_PULLREQUEST_PULLREQUESTID");
+
+    return pullRequestNumber
+      ? {
+          id: pullRequestNumber,
+          url: this.pullRequestUrl || undefined,
+          title: this.pullRequestName || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/azure.ts
+++ b/packages/ci/src/detectors/azure.ts
@@ -1,7 +1,11 @@
 import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
-import { resolveRepositoryFromGitUrl, stripRefsHeads } from "../helpers/gitProvider.js";
+import { resolveRepositoryFromGitUrl } from "../helpers/gitProvider.js";
 import { getEnv } from "../utils.js";
+
+const REF_PREFIX = "refs/";
+const BRANCH_REF_PREFIX = "refs/heads/";
+const TAG_REF_PREFIX = "refs/tags/";
 
 export const getRootURL = (): string => getEnv("SYSTEM_COLLECTIONURI");
 
@@ -25,7 +29,35 @@ const mapAzureRepositoryProvider = (provider: string): GitProvider | undefined =
 const normalizeBranchRef = (branch?: string): string | undefined => {
   const trimmed = branch?.trim() ?? "";
 
-  return trimmed ? stripRefsHeads(trimmed) : undefined;
+  if (!trimmed || trimmed.startsWith(TAG_REF_PREFIX)) {
+    return undefined;
+  }
+
+  if (trimmed.startsWith(BRANCH_REF_PREFIX)) {
+    const branchName = trimmed.slice(BRANCH_REF_PREFIX.length);
+
+    return branchName || undefined;
+  }
+
+  if (trimmed.startsWith(REF_PREFIX)) {
+    return undefined;
+  }
+
+  return trimmed;
+};
+
+const getSourceBranch = (): string | undefined => {
+  const sourceBranch = getEnv("BUILD_SOURCEBRANCH");
+
+  if (sourceBranch) {
+    return normalizeBranchRef(sourceBranch);
+  }
+
+  return normalizeBranchRef(getEnv("BUILD_SOURCEBRANCHNAME"));
+};
+
+const getPullRequestId = (): string | undefined => {
+  return getEnv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER") || getEnv("SYSTEM_PULLREQUEST_PULLREQUESTID") || undefined;
 };
 
 const getRepositoryUrl = () => getEnv("BUILD_REPOSITORY_URI") || getEnv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI");
@@ -74,24 +106,24 @@ export const azure: CiDescriptor = {
   },
 
   get jobRunBranch(): string {
-    return getEnv("BUILD_SOURCEBRANCHNAME");
+    return getSourceBranch() ?? "";
   },
 
   get pullRequestUrl(): string {
     const repositoryProvider = getEnv("BUILD_REPOSITORY_PROVIDER");
     const repositoryUrl = getEnv("SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI") || getEnv("BUILD_REPOSITORY_URI");
-    const pullRequestNumber = getEnv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER");
+    const pullRequestId = getPullRequestId();
 
-    if (!repositoryUrl || !pullRequestNumber) {
+    if (!repositoryUrl || !pullRequestId) {
       return "";
     }
 
     if (repositoryProvider === "GitHub") {
-      return `${repositoryUrl}/pull/${pullRequestNumber}`;
+      return `${repositoryUrl}/pull/${pullRequestId}`;
     }
 
     if (repositoryProvider === "TfsGit" || repositoryProvider === "TfsVersionControl") {
-      return `${repositoryUrl}/pullrequest/${pullRequestNumber}`;
+      return `${repositoryUrl}/pullrequest/${pullRequestId}`;
     }
 
     return "";
@@ -121,25 +153,19 @@ export const azure: CiDescriptor = {
   },
 
   get sourceBranch() {
-    return (
-      normalizeBranchRef(getEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH")) ||
-      getEnv("BUILD_SOURCEBRANCHNAME") ||
-      this.jobRunBranch ||
-      undefined
-    );
+    return normalizeBranchRef(getEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH")) || getSourceBranch() || undefined;
   },
 
   get targetBranch() {
     return (
       normalizeBranchRef(getEnv("SYSTEM_PULLREQUEST_TARGETBRANCH")) ||
-      getEnv("SYSTEM_PULLREQUEST_TARGETBRANCHNAME") ||
+      normalizeBranchRef(getEnv("SYSTEM_PULLREQUEST_TARGETBRANCHNAME")) ||
       undefined
     );
   },
 
   get pullRequest() {
-    const pullRequestNumber =
-      getEnv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER") || getEnv("SYSTEM_PULLREQUEST_PULLREQUESTID");
+    const pullRequestNumber = getPullRequestId();
 
     return pullRequestNumber
       ? {

--- a/packages/ci/src/detectors/bitbucket.ts
+++ b/packages/ci/src/detectors/bitbucket.ts
@@ -1,4 +1,4 @@
-import { type CiDescriptor, CiType } from "@allurereport/core-api";
+import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
 import { getEnv } from "../utils.js";
 
@@ -61,5 +61,40 @@ export const bitbucket: CiDescriptor = {
 
   get pullRequestName(): string {
     return "";
+  },
+
+  get provider() {
+    return GitProvider.Bitbucket;
+  },
+
+  get repository() {
+    const repositorySlug = getEnv("BITBUCKET_REPO_FULL_NAME");
+
+    return repositorySlug
+      ? {
+          slug: repositorySlug,
+          url: getEnv("BITBUCKET_GIT_HTTP_ORIGIN") || undefined,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return getEnv("BITBUCKET_BRANCH") || this.jobRunBranch || undefined;
+  },
+
+  get targetBranch() {
+    return getEnv("BITBUCKET_PR_DESTINATION_BRANCH") || undefined;
+  },
+
+  get pullRequest() {
+    const prId = getEnv("BITBUCKET_PR_ID");
+
+    return prId
+      ? {
+          id: prId,
+          url: this.pullRequestUrl || undefined,
+          title: this.pullRequestName || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/bitbucket.ts
+++ b/packages/ci/src/detectors/bitbucket.ts
@@ -2,8 +2,32 @@ import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
 import { getEnv } from "../utils.js";
 
+const stripGitSuffix = (url: string): string => url.replace(/\.git\/?$/i, "");
+
+const getRepositoryUrl = (): string => {
+  const origin = (getEnv("BITBUCKET_GIT_HTTP_ORIGIN") || "").trim();
+
+  if (!origin) {
+    return "";
+  }
+
+  try {
+    const url = new URL(origin);
+
+    url.username = "";
+    url.password = "";
+    url.pathname = stripGitSuffix(url.pathname).replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return stripGitSuffix(origin).replace(/\/+$/, "");
+  }
+};
+
 export const getJobURL = (): string => {
-  const origin = getEnv("BITBUCKET_GIT_HTTP_ORIGIN");
+  const origin = getRepositoryUrl();
 
   return `${origin}/pipelines`;
 };
@@ -54,7 +78,11 @@ export const bitbucket: CiDescriptor = {
       return "";
     }
 
-    const origin = getEnv("BITBUCKET_GIT_HTTP_ORIGIN");
+    const origin = getRepositoryUrl();
+
+    if (!origin) {
+      return "";
+    }
 
     return `${origin}/pull-requests/${prId}`;
   },
@@ -73,7 +101,7 @@ export const bitbucket: CiDescriptor = {
     return repositorySlug
       ? {
           slug: repositorySlug,
-          url: getEnv("BITBUCKET_GIT_HTTP_ORIGIN") || undefined,
+          url: getRepositoryUrl() || undefined,
         }
       : undefined;
   },

--- a/packages/ci/src/detectors/circle.ts
+++ b/packages/ci/src/detectors/circle.ts
@@ -1,5 +1,6 @@
 import { type CiDescriptor, CiType } from "@allurereport/core-api";
 
+import { parsePullRequestNumberFromUrl, resolveRepositoryFromGitUrl } from "../helpers/gitProvider.js";
 import { getEnv, parseURLPath } from "../utils.js";
 
 export const getBuildNumber = (): string => getEnv("CIRCLE_BUILD_NUM");
@@ -11,6 +12,12 @@ const getJobURL = (): string => {
   const buildNumber = getBuildNumber();
 
   return jobRunURL.replace(`/${buildNumber}`, "");
+};
+
+const getRepository = () => {
+  const repositoryUrl = getEnv("CIRCLE_REPOSITORY_URL");
+
+  return repositoryUrl ? resolveRepositoryFromGitUrl(repositoryUrl) : undefined;
 };
 
 export const circle: CiDescriptor = {
@@ -67,5 +74,37 @@ export const circle: CiDescriptor = {
 
   get pullRequestName(): string {
     return "";
+  },
+
+  get provider() {
+    return getRepository()?.provider;
+  },
+
+  get repository() {
+    const repository = getRepository();
+
+    return repository
+      ? {
+          slug: repository.slug,
+          url: repository.url,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return getEnv("CIRCLE_BRANCH") || this.jobRunBranch || undefined;
+  },
+
+  get pullRequest() {
+    const pullRequestUrl = getEnv("CIRCLE_PULL_REQUEST");
+    const pullRequestNumber = pullRequestUrl ? parsePullRequestNumberFromUrl(pullRequestUrl) : undefined;
+
+    return pullRequestNumber
+      ? {
+          id: pullRequestNumber,
+          url: this.pullRequestUrl || pullRequestUrl || undefined,
+          title: this.pullRequestName || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/circle.ts
+++ b/packages/ci/src/detectors/circle.ts
@@ -20,6 +20,28 @@ const getRepository = () => {
   return repositoryUrl ? resolveRepositoryFromGitUrl(repositoryUrl) : undefined;
 };
 
+const getPullRequestUrl = (): string => {
+  const pullRequestUrl = getEnv("CIRCLE_PULL_REQUEST").trim();
+
+  if (pullRequestUrl) {
+    return pullRequestUrl;
+  }
+
+  return (
+    getEnv("CIRCLE_PULL_REQUESTS")
+      .split(",")
+      .map((url) => url.trim())
+      .find(Boolean) ?? ""
+  );
+};
+
+const getPullRequestNumber = (): string | undefined => {
+  const pullRequestUrl = getPullRequestUrl();
+  const pullRequestNumber = pullRequestUrl ? parsePullRequestNumberFromUrl(pullRequestUrl) : undefined;
+
+  return pullRequestNumber || getEnv("CIRCLE_PR_NUMBER") || undefined;
+};
+
 export const circle: CiDescriptor = {
   type: CiType.Circle,
 
@@ -46,7 +68,7 @@ export const circle: CiDescriptor = {
   },
 
   get jobName(): string {
-    const username = getEnv("CIRCLE_USERNAME");
+    const username = getEnv("CIRCLE_PROJECT_USERNAME") || getEnv("CIRCLE_USERNAME");
     const reponame = getEnv("CIRCLE_PROJECT_REPONAME");
 
     return `${username}/${reponame}`;
@@ -69,7 +91,7 @@ export const circle: CiDescriptor = {
   },
 
   get pullRequestUrl(): string {
-    return "";
+    return getPullRequestUrl();
   },
 
   get pullRequestName(): string {
@@ -96,8 +118,8 @@ export const circle: CiDescriptor = {
   },
 
   get pullRequest() {
-    const pullRequestUrl = getEnv("CIRCLE_PULL_REQUEST");
-    const pullRequestNumber = pullRequestUrl ? parsePullRequestNumberFromUrl(pullRequestUrl) : undefined;
+    const pullRequestUrl = getPullRequestUrl();
+    const pullRequestNumber = getPullRequestNumber();
 
     return pullRequestNumber
       ? {

--- a/packages/ci/src/detectors/drone.ts
+++ b/packages/ci/src/detectors/drone.ts
@@ -1,5 +1,6 @@
 import { type CiDescriptor, CiType } from "@allurereport/core-api";
 
+import { resolveRepositoryFromGitUrl } from "../helpers/gitProvider.js";
 import { getEnv } from "../utils.js";
 
 export const getJobRunUID = (): string => getEnv("CI_BUILD_NUMBER");
@@ -11,6 +12,12 @@ export const getJobURL = (): string => {
   const jobRunUID = getJobRunUID();
 
   return jobRunURL.replace(jobRunUID, "");
+};
+
+const getRepository = () => {
+  const repoLink = getEnv("DRONE_REPO_LINK");
+
+  return repoLink ? resolveRepositoryFromGitUrl(repoLink) : undefined;
 };
 
 export const drone: CiDescriptor = {
@@ -53,16 +60,20 @@ export const drone: CiDescriptor = {
   },
 
   get pullRequestUrl(): string {
-    const githubServer = getEnv("DRONE_GITHUB_SERVER");
-    const gitlabServer = getEnv("DRONE_GITLAB_SERVER");
-    const repoLink = getEnv("DRONE_REPO_LINK");
-    const pullRequestNumber = getEnv("DRONE_PULL_REQUEST");
+    const githubServer = getEnv("DRONE_GITHUB_SERVER") || "";
+    const gitlabServer = getEnv("DRONE_GITLAB_SERVER") || "";
+    const repoLink = getEnv("DRONE_REPO_LINK") || "";
+    const pullRequestNumber = getEnv("DRONE_PULL_REQUEST") || "";
 
-    if (repoLink.startsWith(githubServer)) {
+    if (!pullRequestNumber || pullRequestNumber === "0") {
+      return "";
+    }
+
+    if (githubServer && repoLink.startsWith(githubServer)) {
       return `${repoLink}/pull/${pullRequestNumber}`;
     }
 
-    if (repoLink.startsWith(gitlabServer)) {
+    if (gitlabServer && repoLink.startsWith(gitlabServer)) {
       return `${repoLink}/-/merge_requests/${pullRequestNumber}`;
     }
 
@@ -71,5 +82,40 @@ export const drone: CiDescriptor = {
 
   get pullRequestName(): string {
     return getEnv("DRONE_PULL_REQUEST_TITLE");
+  },
+
+  get provider() {
+    return getRepository()?.provider;
+  },
+
+  get repository() {
+    const repository = getRepository();
+
+    return repository
+      ? {
+          slug: repository.slug,
+          url: repository.url,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return getEnv("DRONE_SOURCE_BRANCH") || getEnv("DRONE_BRANCH") || this.jobRunBranch || undefined;
+  },
+
+  get targetBranch() {
+    return getEnv("DRONE_TARGET_BRANCH") || undefined;
+  },
+
+  get pullRequest() {
+    const pullRequestNumber = getEnv("DRONE_PULL_REQUEST");
+
+    return pullRequestNumber && pullRequestNumber !== "0"
+      ? {
+          id: pullRequestNumber,
+          url: this.pullRequestUrl || undefined,
+          title: this.pullRequestName || getEnv("DRONE_PULL_REQUEST_TITLE") || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/drone.ts
+++ b/packages/ci/src/detectors/drone.ts
@@ -1,9 +1,9 @@
-import { type CiDescriptor, CiType } from "@allurereport/core-api";
+import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
 import { resolveRepositoryFromGitUrl } from "../helpers/gitProvider.js";
 import { getEnv } from "../utils.js";
 
-export const getJobRunUID = (): string => getEnv("CI_BUILD_NUMBER");
+export const getJobRunUID = (): string => getEnv("DRONE_BUILD_NUMBER");
 
 export const getJobRunURL = (): string => getEnv("DRONE_BUILD_LINK");
 
@@ -18,6 +18,59 @@ const getRepository = () => {
   const repoLink = getEnv("DRONE_REPO_LINK");
 
   return repoLink ? resolveRepositoryFromGitUrl(repoLink) : undefined;
+};
+
+const normalizeRepositoryUrl = (url: string): string =>
+  url
+    .trim()
+    .replace(/\.git\/?$/i, "")
+    .replace(/\/+$/, "");
+
+const getPullRequestNumber = (): string | undefined => {
+  const pullRequestNumber = getEnv("DRONE_PULL_REQUEST").trim();
+
+  return pullRequestNumber && pullRequestNumber !== "0" ? pullRequestNumber : undefined;
+};
+
+const getPullRequestUrlForProvider = (
+  provider: GitProvider,
+  repositoryUrl: string,
+  pullRequestNumber: string,
+): string => {
+  const normalizedRepositoryUrl = normalizeRepositoryUrl(repositoryUrl);
+
+  switch (provider) {
+    case GitProvider.Github:
+      return `${normalizedRepositoryUrl}/pull/${pullRequestNumber}`;
+    case GitProvider.Gitlab:
+      return `${normalizedRepositoryUrl}/-/merge_requests/${pullRequestNumber}`;
+    case GitProvider.Bitbucket:
+      return `${normalizedRepositoryUrl}/pull-requests/${pullRequestNumber}`;
+    default:
+      return "";
+  }
+};
+
+const getSourceBranch = (): string | undefined => {
+  if (getEnv("DRONE_TAG")) {
+    return undefined;
+  }
+
+  const sourceBranch = getEnv("DRONE_SOURCE_BRANCH");
+
+  if (sourceBranch) {
+    return sourceBranch;
+  }
+
+  return getPullRequestNumber() ? undefined : getEnv("DRONE_BRANCH") || undefined;
+};
+
+const getTargetBranch = (): string | undefined => {
+  if (getEnv("DRONE_TAG")) {
+    return undefined;
+  }
+
+  return getEnv("DRONE_TARGET_BRANCH") || (getPullRequestNumber() ? getEnv("DRONE_BRANCH") : "") || undefined;
 };
 
 export const drone: CiDescriptor = {
@@ -56,18 +109,25 @@ export const drone: CiDescriptor = {
   },
 
   get jobRunBranch(): string {
-    return getEnv("DRONE_BRANCH");
+    return getEnv("DRONE_TAG") ? "" : getEnv("DRONE_BRANCH");
   },
 
   get pullRequestUrl(): string {
-    const githubServer = getEnv("DRONE_GITHUB_SERVER") || "";
-    const gitlabServer = getEnv("DRONE_GITLAB_SERVER") || "";
-    const repoLink = getEnv("DRONE_REPO_LINK") || "";
-    const pullRequestNumber = getEnv("DRONE_PULL_REQUEST") || "";
+    const pullRequestNumber = getPullRequestNumber();
 
-    if (!pullRequestNumber || pullRequestNumber === "0") {
+    if (!pullRequestNumber) {
       return "";
     }
+
+    const repository = getRepository();
+
+    if (repository) {
+      return getPullRequestUrlForProvider(repository.provider, repository.url, pullRequestNumber);
+    }
+
+    const githubServer = normalizeRepositoryUrl(getEnv("DRONE_GITHUB_SERVER") || "");
+    const gitlabServer = normalizeRepositoryUrl(getEnv("DRONE_GITLAB_SERVER") || "");
+    const repoLink = normalizeRepositoryUrl(getEnv("DRONE_REPO_LINK") || "");
 
     if (githubServer && repoLink.startsWith(githubServer)) {
       return `${repoLink}/pull/${pullRequestNumber}`;
@@ -100,17 +160,17 @@ export const drone: CiDescriptor = {
   },
 
   get sourceBranch() {
-    return getEnv("DRONE_SOURCE_BRANCH") || getEnv("DRONE_BRANCH") || this.jobRunBranch || undefined;
+    return getSourceBranch();
   },
 
   get targetBranch() {
-    return getEnv("DRONE_TARGET_BRANCH") || undefined;
+    return getTargetBranch();
   },
 
   get pullRequest() {
-    const pullRequestNumber = getEnv("DRONE_PULL_REQUEST");
+    const pullRequestNumber = getPullRequestNumber();
 
-    return pullRequestNumber && pullRequestNumber !== "0"
+    return pullRequestNumber
       ? {
           id: pullRequestNumber,
           url: this.pullRequestUrl || undefined,

--- a/packages/ci/src/detectors/github.ts
+++ b/packages/ci/src/detectors/github.ts
@@ -14,6 +14,32 @@ const getWorkflow = () => getEnv("GITHUB_WORKFLOW");
 
 const getRepo = () => getEnv("GITHUB_REPOSITORY");
 
+const isTagRef = (): boolean => getEnv("GITHUB_REF_TYPE") === "tag" || getEnv("GITHUB_REF").startsWith("refs/tags/");
+
+const getBranchFromRef = (): string => {
+  const ref = getEnv("GITHUB_REF");
+
+  if (ref.startsWith("refs/heads/")) {
+    return stripRefsHeads(ref);
+  }
+
+  if (ref.startsWith("refs/tags/") || ref.startsWith("refs/pull/")) {
+    return "";
+  }
+
+  return getEnv("GITHUB_REF_TYPE") === "branch" ? getEnv("GITHUB_REF_NAME") : "";
+};
+
+const getSourceBranch = (): string => {
+  const headRef = getEnv("GITHUB_HEAD_REF");
+
+  if (headRef) {
+    return headRef;
+  }
+
+  return isTagRef() ? "" : getBranchFromRef();
+};
+
 export const github: CiDescriptor = {
   type: CiType.Github,
 
@@ -57,8 +83,7 @@ export const github: CiDescriptor = {
   },
 
   get jobRunBranch(): string {
-    // cut-off "refs/heads/" prefix
-    return (getEnv("GITHUB_HEAD_REF") || getEnv("GITHUB_REF")).replace("refs/heads/", "");
+    return getSourceBranch();
   },
 
   get pullRequestUrl(): string {
@@ -102,7 +127,7 @@ export const github: CiDescriptor = {
   },
 
   get sourceBranch() {
-    return getEnv("GITHUB_HEAD_REF") || stripRefsHeads(getEnv("GITHUB_REF") || "") || this.jobRunBranch || undefined;
+    return getSourceBranch() || undefined;
   },
 
   get targetBranch() {

--- a/packages/ci/src/detectors/github.ts
+++ b/packages/ci/src/detectors/github.ts
@@ -1,10 +1,10 @@
 import { join } from "node:path/posix";
 
-import { type CiDescriptor, CiType } from "@allurereport/core-api";
+import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
+import { resolveGithubPullRequestNumber } from "../helpers/github.js";
+import { stripRefsHeads } from "../helpers/gitProvider.js";
 import { getEnv } from "../utils.js";
-
-const pullRequestSuffixRe = /\/merge$/;
 
 const getBaseURL = () => getEnv("GITHUB_SERVER_URL");
 
@@ -62,13 +62,12 @@ export const github: CiDescriptor = {
   },
 
   get pullRequestUrl(): string {
-    const refName = getEnv("GITHUB_REF_NAME");
+    const pullRequestNumber = resolveGithubPullRequestNumber();
 
-    if (!pullRequestSuffixRe.test(refName)) {
+    if (!pullRequestNumber) {
       return "";
     }
 
-    const pullRequestNumber = refName.replace(pullRequestSuffixRe, "");
     const serverUrl = getEnv("GITHUB_SERVER_URL");
     const repo = getRepo();
     const pathname = join(repo, "pull", pullRequestNumber);
@@ -77,14 +76,48 @@ export const github: CiDescriptor = {
   },
 
   get pullRequestName(): string {
-    const refName = getEnv("GITHUB_REF_NAME");
+    const pullRequestNumber = resolveGithubPullRequestNumber();
 
-    if (!pullRequestSuffixRe.test(refName)) {
+    if (!pullRequestNumber) {
       return "";
     }
 
-    const pullRequestNumber = refName.replace(pullRequestSuffixRe, "");
-
     return `Pull request #${pullRequestNumber}`;
+  },
+
+  get provider() {
+    return GitProvider.Github;
+  },
+
+  get repository() {
+    const repositorySlug = getEnv("GITHUB_REPOSITORY");
+    const serverUrl = getEnv("GITHUB_SERVER_URL");
+
+    return repositorySlug
+      ? {
+          slug: repositorySlug,
+          url: serverUrl ? `${serverUrl}/${repositorySlug}` : undefined,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return getEnv("GITHUB_HEAD_REF") || stripRefsHeads(getEnv("GITHUB_REF") || "") || this.jobRunBranch || undefined;
+  },
+
+  get targetBranch() {
+    return getEnv("GITHUB_BASE_REF") || undefined;
+  },
+
+  get pullRequest() {
+    const pullRequestId = resolveGithubPullRequestNumber();
+
+    return pullRequestId
+      ? {
+          id: pullRequestId,
+          url: this.pullRequestUrl || undefined,
+          title: this.pullRequestName || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/gitlab.ts
+++ b/packages/ci/src/detectors/gitlab.ts
@@ -2,6 +2,23 @@ import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
 import { getEnv } from "../utils.js";
 
+const getMergeRequestProjectUrl = (): string => getEnv("CI_MERGE_REQUEST_PROJECT_URL") || getEnv("CI_PROJECT_URL");
+
+const isTagPipeline = (): boolean => Boolean(getEnv("CI_COMMIT_TAG"));
+
+const getSourceBranch = (): string | undefined => {
+  if (isTagPipeline()) {
+    return undefined;
+  }
+
+  return (
+    getEnv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME") ||
+    getEnv("CI_COMMIT_BRANCH") ||
+    getEnv("CI_COMMIT_REF_NAME") ||
+    undefined
+  );
+};
+
 export const gitlab: CiDescriptor = {
   type: CiType.Gitlab,
 
@@ -38,7 +55,7 @@ export const gitlab: CiDescriptor = {
   },
 
   get jobRunBranch(): string {
-    return getEnv("CI_COMMIT_REF_NAME");
+    return getSourceBranch() || "";
   },
 
   get pullRequestUrl(): string {
@@ -48,9 +65,9 @@ export const gitlab: CiDescriptor = {
       return "";
     }
 
-    const projectUrl = getEnv("CI_PROJECT_URL");
+    const projectUrl = getMergeRequestProjectUrl().replace(/\/+$/, "");
 
-    return `${projectUrl}/-/merge_requests/${mergeRequestIID}`;
+    return projectUrl ? `${projectUrl}/-/merge_requests/${mergeRequestIID}` : "";
   },
 
   get pullRequestName(): string {
@@ -73,9 +90,7 @@ export const gitlab: CiDescriptor = {
   },
 
   get sourceBranch() {
-    return (
-      getEnv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME") || getEnv("CI_COMMIT_REF_NAME") || this.jobRunBranch || undefined
-    );
+    return getSourceBranch();
   },
 
   get targetBranch() {

--- a/packages/ci/src/detectors/gitlab.ts
+++ b/packages/ci/src/detectors/gitlab.ts
@@ -1,4 +1,4 @@
-import { type CiDescriptor, CiType } from "@allurereport/core-api";
+import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
 import { getEnv } from "../utils.js";
 
@@ -55,5 +55,42 @@ export const gitlab: CiDescriptor = {
 
   get pullRequestName(): string {
     return getEnv("CI_MERGE_REQUEST_TITLE");
+  },
+
+  get provider() {
+    return GitProvider.Gitlab;
+  },
+
+  get repository() {
+    const projectPath = getEnv("CI_PROJECT_PATH");
+
+    return projectPath
+      ? {
+          slug: projectPath,
+          url: getEnv("CI_PROJECT_URL") || undefined,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return (
+      getEnv("CI_MERGE_REQUEST_SOURCE_BRANCH_NAME") || getEnv("CI_COMMIT_REF_NAME") || this.jobRunBranch || undefined
+    );
+  },
+
+  get targetBranch() {
+    return getEnv("CI_MERGE_REQUEST_TARGET_BRANCH_NAME") || undefined;
+  },
+
+  get pullRequest() {
+    const mergeRequestIid = getEnv("CI_MERGE_REQUEST_IID");
+
+    return mergeRequestIid
+      ? {
+          id: mergeRequestIid,
+          url: this.pullRequestUrl || undefined,
+          title: getEnv("CI_MERGE_REQUEST_TITLE") || this.pullRequestName || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/jenkins.ts
+++ b/packages/ci/src/detectors/jenkins.ts
@@ -1,6 +1,13 @@
 import { type CiDescriptor, CiType } from "@allurereport/core-api";
 
+import { resolveRepositoryFromGitUrl } from "../helpers/gitProvider.js";
 import { getEnv, getReponameFromRepoUrl } from "../utils.js";
+
+const getRepository = () => {
+  const gitUrl = getEnv("GIT_URL");
+
+  return gitUrl ? resolveRepositoryFromGitUrl(gitUrl) : undefined;
+};
 
 export const jenkins: CiDescriptor = {
   type: CiType.Jenkins,
@@ -53,5 +60,40 @@ export const jenkins: CiDescriptor = {
 
   get pullRequestName(): string {
     return getEnv("CHANGE_TITLE");
+  },
+
+  get provider() {
+    return getRepository()?.provider;
+  },
+
+  get repository() {
+    const repository = getRepository();
+
+    return repository
+      ? {
+          slug: repository.slug,
+          url: repository.url,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return getEnv("CHANGE_BRANCH") || getEnv("BRANCH_NAME") || this.jobRunBranch || undefined;
+  },
+
+  get targetBranch() {
+    return getEnv("CHANGE_TARGET") || undefined;
+  },
+
+  get pullRequest() {
+    const changeId = getEnv("CHANGE_ID");
+
+    return changeId
+      ? {
+          id: changeId,
+          url: this.pullRequestUrl || getEnv("CHANGE_URL") || undefined,
+          title: this.pullRequestName || getEnv("CHANGE_TITLE") || undefined,
+        }
+      : undefined;
   },
 };

--- a/packages/ci/src/detectors/jenkins.ts
+++ b/packages/ci/src/detectors/jenkins.ts
@@ -9,6 +9,35 @@ const getRepository = () => {
   return gitUrl ? resolveRepositoryFromGitUrl(gitUrl) : undefined;
 };
 
+const isTagBuild = (): boolean => Boolean(getEnv("TAG_NAME"));
+
+const getGitPluginBranch = (): string | undefined => {
+  const localBranch = (getEnv("GIT_LOCAL_BRANCH") || "").trim();
+
+  if (localBranch) {
+    return localBranch;
+  }
+
+  const gitBranch = (getEnv("GIT_BRANCH") || "").trim();
+
+  if (!gitBranch) {
+    return undefined;
+  }
+
+  const normalizedBranch = gitBranch.replace(/^refs\/heads\//, "");
+  const remoteBranchMatch = normalizedBranch.match(/^(?:refs\/remotes\/|remotes\/)?[^/]+\/(.+)$/);
+
+  return remoteBranchMatch?.[1] ?? normalizedBranch;
+};
+
+const getBranchName = (): string | undefined => {
+  if (isTagBuild()) {
+    return undefined;
+  }
+
+  return getEnv("BRANCH_NAME") || getGitPluginBranch();
+};
+
 export const jenkins: CiDescriptor = {
   type: CiType.Jenkins,
 
@@ -51,7 +80,7 @@ export const jenkins: CiDescriptor = {
   },
 
   get jobRunBranch(): string {
-    return getEnv("BRANCH_NAME");
+    return getBranchName() ?? "";
   },
 
   get pullRequestUrl(): string {
@@ -78,11 +107,15 @@ export const jenkins: CiDescriptor = {
   },
 
   get sourceBranch() {
-    return getEnv("CHANGE_BRANCH") || getEnv("BRANCH_NAME") || this.jobRunBranch || undefined;
+    if (isTagBuild()) {
+      return undefined;
+    }
+
+    return getEnv("CHANGE_BRANCH") || getBranchName();
   },
 
   get targetBranch() {
-    return getEnv("CHANGE_TARGET") || undefined;
+    return isTagBuild() ? undefined : getEnv("CHANGE_TARGET") || undefined;
   },
 
   get pullRequest() {

--- a/packages/ci/src/detectors/local.ts
+++ b/packages/ci/src/detectors/local.ts
@@ -3,6 +3,24 @@ import { basename } from "node:path";
 
 import { type CiDescriptor, CiType } from "@allurereport/core-api";
 
+import { resolveRepositoryFromGitUrl } from "../helpers/gitProvider.js";
+
+const readGitRemoteUrl = (): string => {
+  const output = spawnSync("git", ["remote", "get-url", "origin"]);
+
+  if (output.error) {
+    return "";
+  }
+
+  return output.stdout.toString().trim();
+};
+
+const getRepository = () => {
+  const remoteUrl = readGitRemoteUrl();
+
+  return remoteUrl ? resolveRepositoryFromGitUrl(remoteUrl) : undefined;
+};
+
 export const local: CiDescriptor = {
   type: CiType.Local,
 
@@ -60,6 +78,25 @@ export const local: CiDescriptor = {
 
   get pullRequestName(): string {
     return "";
+  },
+
+  get provider() {
+    return getRepository()?.provider;
+  },
+
+  get repository() {
+    const repository = getRepository();
+
+    return repository
+      ? {
+          slug: repository.slug,
+          url: repository.url,
+        }
+      : undefined;
+  },
+
+  get sourceBranch() {
+    return this.jobRunBranch || undefined;
   },
 };
 

--- a/packages/ci/src/helpers/gitProvider.ts
+++ b/packages/ci/src/helpers/gitProvider.ts
@@ -1,0 +1,164 @@
+import { GitProvider } from "@allurereport/core-api";
+
+const stripGitSuffix = (url: string): string => url.replace(/\.git\/?$/i, "");
+
+/** Strips `refs/heads/` from Azure/Git ref strings. */
+export const stripRefsHeads = (ref: string): string => ref.replace(/^refs\/heads\//, "");
+
+/** Extracts PR number from GitHub/GitLab/Bitbucket pull-request URLs (e.g. CircleCI `CIRCLE_PULL_REQUEST`). */
+export const parsePullRequestNumberFromUrl = (pullRequestUrl: string): string | undefined => {
+  const trimmed = pullRequestUrl.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const match =
+    trimmed.match(/\/pull\/(\d+)\/?$/i) ??
+    trimmed.match(/\/merge_requests\/(\d+)\/?$/i) ??
+    trimmed.match(/\/pull-requests\/(\d+)\/?$/i);
+
+  return match?.[1];
+};
+
+export const hostMatchesProvider = (host: string, provider: GitProvider): boolean => {
+  const normalizedHost = host.toLowerCase();
+
+  switch (provider) {
+    case GitProvider.Github:
+      return (
+        normalizedHost === "github.com" ||
+        normalizedHost.endsWith(".github.com") ||
+        normalizedHost.startsWith("github.")
+      );
+    case GitProvider.Gitlab:
+      return (
+        normalizedHost === "gitlab.com" ||
+        normalizedHost.endsWith(".gitlab.com") ||
+        normalizedHost.startsWith("gitlab.")
+      );
+    case GitProvider.Bitbucket:
+      return (
+        normalizedHost === "bitbucket.org" ||
+        normalizedHost.endsWith(".bitbucket.org") ||
+        normalizedHost.startsWith("bitbucket.")
+      );
+    default:
+      return false;
+  }
+};
+
+/** Normalizes https and scp-style remotes into an https URL suitable for parsing. */
+export const normalizeGitRemoteUrl = (remote: string): string | undefined => {
+  const trimmed = remote.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("ssh://")) {
+    try {
+      const parsed = new URL(trimmed);
+
+      return `https://${parsed.hostname}${parsed.pathname}`;
+    } catch {
+      return undefined;
+    }
+  }
+
+  const scpMatch = /^[^@]+@([^:]+):(.+)$/.exec(trimmed);
+
+  if (scpMatch) {
+    return `https://${scpMatch[1]}/${scpMatch[2].replace(/^\//, "")}`;
+  }
+
+  return undefined;
+};
+
+export const inferGitProviderFromUrl = (remote: string): GitProvider | undefined => {
+  const normalized = normalizeGitRemoteUrl(remote);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  try {
+    const host = new URL(normalized).hostname.toLowerCase();
+
+    for (const provider of [GitProvider.Github, GitProvider.Gitlab, GitProvider.Bitbucket] as const) {
+      if (hostMatchesProvider(host, provider)) {
+        return provider;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};
+
+export const parseRepositorySlugFromUrl = (remote: string, provider: GitProvider): string | undefined => {
+  const normalized = normalizeGitRemoteUrl(remote);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  try {
+    const pathname = new URL(normalized).pathname.replace(/^\/+/, "").replace(/\.git\/?$/i, "");
+
+    if (!pathname) {
+      return undefined;
+    }
+
+    const segments = pathname.split("/").filter(Boolean);
+
+    if (provider === GitProvider.Github || provider === GitProvider.Bitbucket) {
+      if (segments.length < 2) {
+        return undefined;
+      }
+
+      return `${segments[0]}/${segments[1]}`;
+    }
+
+    return pathname;
+  } catch {
+    return undefined;
+  }
+};
+
+export type ResolvedGitRepository = {
+  provider: GitProvider;
+  slug: string;
+  url: string;
+};
+
+export const resolveRepositoryFromGitUrl = (remote: string): ResolvedGitRepository | undefined => {
+  const provider = inferGitProviderFromUrl(remote);
+
+  if (!provider) {
+    return undefined;
+  }
+
+  const slug = parseRepositorySlugFromUrl(remote, provider);
+
+  if (!slug) {
+    return undefined;
+  }
+
+  const normalized = normalizeGitRemoteUrl(remote);
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  return {
+    provider,
+    slug,
+    url: stripGitSuffix(normalized),
+  };
+};

--- a/packages/ci/src/helpers/github.ts
+++ b/packages/ci/src/helpers/github.ts
@@ -2,19 +2,29 @@ import { readFileSync } from "node:fs";
 
 import { getEnv } from "../utils.js";
 
-const pullRequestRefNameRe = /^(\d+)\/merge$/;
-const pullRequestMergeRefRe = /^refs\/pull\/(\d+)\/merge$/;
+const PULL_REQUEST_REF_NAME_RE = /^(\d+)\/merge$/;
+const PULL_REQUEST_MERGE_REF_RE = /^refs\/pull\/(\d+)\/merge$/;
+
+type GithubPullRequestEvent = {
+  number?: number | string;
+  pull_request?: {
+    number?: number | string;
+  };
+};
+
+const normalizePullRequestNumber = (value: number | string | undefined): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  return String(value);
+};
 
 export const parsePullRequestNumberFromEventJson = (content: string): string => {
   try {
-    const event = JSON.parse(content) as { pull_request?: { number?: number } };
-    const number = event?.pull_request?.number;
+    const event = JSON.parse(content) as GithubPullRequestEvent;
 
-    if (number === undefined || number === null) {
-      return "";
-    }
-
-    return String(number);
+    return normalizePullRequestNumber(event?.number ?? event?.pull_request?.number);
   } catch {
     return "";
   }
@@ -38,14 +48,14 @@ const readPullRequestNumberFromEventPath = (): string => {
 
 export const resolveGithubPullRequestNumber = (): string => {
   const refName = getEnv("GITHUB_REF_NAME") || "";
-  const refNameMatch = refName.match(pullRequestRefNameRe);
+  const refNameMatch = refName.match(PULL_REQUEST_REF_NAME_RE);
 
   if (refNameMatch) {
     return refNameMatch[1];
   }
 
   const githubRef = getEnv("GITHUB_REF") || "";
-  const mergeRefMatch = githubRef.match(pullRequestMergeRefRe);
+  const mergeRefMatch = githubRef.match(PULL_REQUEST_MERGE_REF_RE);
 
   if (mergeRefMatch) {
     return mergeRefMatch[1];

--- a/packages/ci/src/helpers/github.ts
+++ b/packages/ci/src/helpers/github.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+
+import { getEnv } from "../utils.js";
+
+const pullRequestRefNameRe = /^(\d+)\/merge$/;
+const pullRequestMergeRefRe = /^refs\/pull\/(\d+)\/merge$/;
+
+export const parsePullRequestNumberFromEventJson = (content: string): string => {
+  try {
+    const event = JSON.parse(content) as { pull_request?: { number?: number } };
+    const number = event?.pull_request?.number;
+
+    if (number === undefined || number === null) {
+      return "";
+    }
+
+    return String(number);
+  } catch {
+    return "";
+  }
+};
+
+const readPullRequestNumberFromEventPath = (): string => {
+  const eventPath = getEnv("GITHUB_EVENT_PATH");
+
+  if (!eventPath) {
+    return "";
+  }
+
+  try {
+    const content = readFileSync(eventPath, "utf-8");
+
+    return parsePullRequestNumberFromEventJson(content);
+  } catch {
+    return "";
+  }
+};
+
+export const resolveGithubPullRequestNumber = (): string => {
+  const refName = getEnv("GITHUB_REF_NAME") || "";
+  const refNameMatch = refName.match(pullRequestRefNameRe);
+
+  if (refNameMatch) {
+    return refNameMatch[1];
+  }
+
+  const githubRef = getEnv("GITHUB_REF") || "";
+  const mergeRefMatch = githubRef.match(pullRequestMergeRefRe);
+
+  if (mergeRefMatch) {
+    return mergeRefMatch[1];
+  }
+
+  const headRef = getEnv("GITHUB_HEAD_REF");
+  const baseRef = getEnv("GITHUB_BASE_REF");
+
+  if (headRef && baseRef) {
+    return readPullRequestNumberFromEventPath();
+  }
+
+  return "";
+};

--- a/packages/ci/test/detectors/amazon.test.ts
+++ b/packages/ci/test/detectors/amazon.test.ts
@@ -409,10 +409,20 @@ describe("amazon", () => {
       expect(amazon.jobRunBranch).toBe("feature/branch-name");
     });
 
-    it("should return empty string when source version doesn't match pattern", () => {
+    it("should return branch name when source version is an unqualified branch", () => {
       (getEnv as Mock).mockImplementation((key: string) => {
         if (key === "CODEBUILD_SOURCE_VERSION") {
-          return "some-other-format";
+          return "feature/branch-name";
+        }
+      });
+
+      expect(amazon.jobRunBranch).toBe("feature/branch-name");
+    });
+
+    it("should return empty string when source version is a commit hash", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "CODEBUILD_SOURCE_VERSION") {
+          return "1234567890abcdef1234567890abcdef12345678";
         }
       });
 

--- a/packages/ci/test/detectors/azure.test.ts
+++ b/packages/ci/test/detectors/azure.test.ts
@@ -260,6 +260,34 @@ describe("azure", () => {
 
       expect(azure.jobRunBranch).toBe("main");
     });
+
+    it("should return the full branch path from Build.SourceBranch", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "BUILD_SOURCEBRANCH") {
+          return "refs/heads/feature/tools";
+        }
+
+        if (key === "BUILD_SOURCEBRANCHNAME") {
+          return "tools";
+        }
+      });
+
+      expect(azure.jobRunBranch).toBe("feature/tools");
+    });
+
+    it("should not return tag refs as a job run branch", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "BUILD_SOURCEBRANCH") {
+          return "refs/tags/v1.0.0";
+        }
+
+        if (key === "BUILD_SOURCEBRANCHNAME") {
+          return "v1.0.0";
+        }
+      });
+
+      expect(azure.jobRunBranch).toBe("");
+    });
   });
 
   describe("pullRequestUrl", () => {
@@ -297,6 +325,24 @@ describe("azure", () => {
       });
 
       expect(azure.pullRequestUrl).toBe("https://dev.azure.com/organization/project/_git/repo/pullrequest/456");
+    });
+
+    it("should return the correct pull request URL for TfsGit using pull request ID", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "BUILD_REPOSITORY_PROVIDER") {
+          return "TfsGit";
+        }
+
+        if (key === "SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI") {
+          return "https://dev.azure.com/organization/project/_git/repo";
+        }
+
+        if (key === "SYSTEM_PULLREQUEST_PULLREQUESTID") {
+          return "457";
+        }
+      });
+
+      expect(azure.pullRequestUrl).toBe("https://dev.azure.com/organization/project/_git/repo/pullrequest/457");
     });
 
     it("should return the correct pull request URL for TfsVersionControl", () => {

--- a/packages/ci/test/detectors/bitbucket.test.ts
+++ b/packages/ci/test/detectors/bitbucket.test.ts
@@ -15,6 +15,10 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const mockEnv = (vars: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => vars[key] ?? "");
+};
+
 describe("bitbucket", () => {
   describe("getJobURL", () => {
     it("should return the correct job URL", () => {
@@ -201,6 +205,31 @@ describe("bitbucket", () => {
       });
 
       expect(bitbucket.pullRequestUrl).toBe("");
+    });
+  });
+
+  describe("git fields", () => {
+    it("should normalize repository URLs from BITBUCKET_GIT_HTTP_ORIGIN", () => {
+      mockEnv({
+        BITBUCKET_REPO_FULL_NAME: "myorg/myrepo",
+        BITBUCKET_GIT_HTTP_ORIGIN: " https://x-token-auth:secret@bitbucket.org/myorg/myrepo.git/ ",
+        BITBUCKET_PR_ID: "123",
+      });
+
+      expect(bitbucket.repository).toEqual({
+        slug: "myorg/myrepo",
+        url: "https://bitbucket.org/myorg/myrepo",
+      });
+      expect(bitbucket.pullRequestUrl).toBe("https://bitbucket.org/myorg/myrepo/pull-requests/123");
+    });
+
+    it("should not map tag builds to branch fields", () => {
+      mockEnv({
+        BITBUCKET_TAG: "v1.0.0",
+      });
+
+      expect(bitbucket.jobRunBranch).toBe("");
+      expect(bitbucket.sourceBranch).toBeUndefined();
     });
   });
 });

--- a/packages/ci/test/detectors/circle.test.ts
+++ b/packages/ci/test/detectors/circle.test.ts
@@ -16,6 +16,10 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const mockEnv = (env: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => env[key] ?? "");
+};
+
 describe("circle", () => {
   describe("getBuildNumber", () => {
     it("should return the correct build number", () => {
@@ -169,16 +173,22 @@ describe("circle", () => {
 
   describe("jobName", () => {
     it("should return the correct job name", () => {
-      (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "CIRCLE_USERNAME") {
-          return "myorg";
-        }
-        if (key === "CIRCLE_PROJECT_REPONAME") {
-          return "myrepo";
-        }
+      mockEnv({
+        CIRCLE_PROJECT_USERNAME: "myorg",
+        CIRCLE_USERNAME: "trigger-user",
+        CIRCLE_PROJECT_REPONAME: "myrepo",
       });
 
       expect(circle.jobName).toBe("myorg/myrepo");
+    });
+
+    it("should fall back to trigger username when project username is not set", () => {
+      mockEnv({
+        CIRCLE_USERNAME: "trigger-user",
+        CIRCLE_PROJECT_REPONAME: "myrepo",
+      });
+
+      expect(circle.jobName).toBe("trigger-user/myrepo");
     });
   });
 
@@ -220,13 +230,54 @@ describe("circle", () => {
 
   describe("jobRunBranch", () => {
     it("should return the correct job run branch", () => {
-      (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "CIRCLE_BRANCH") {
-          return "main";
-        }
+      mockEnv({
+        CIRCLE_BRANCH: "main",
       });
 
       expect(circle.jobRunBranch).toBe("main");
+    });
+
+    it("should not map tag builds as branch runs", () => {
+      mockEnv({
+        CIRCLE_TAG: "v1.0.0",
+      });
+
+      expect(circle.jobRunBranch).toBe("");
+      expect(circle.sourceBranch).toBeUndefined();
+    });
+  });
+
+  describe("pullRequestUrl", () => {
+    it("should return the associated pull request URL", () => {
+      mockEnv({
+        CIRCLE_PULL_REQUEST: "https://github.com/myorg/myrepo/pull/123",
+      });
+
+      expect(circle.pullRequestUrl).toBe("https://github.com/myorg/myrepo/pull/123");
+    });
+
+    it("should fall back to the first associated pull request URL", () => {
+      mockEnv({
+        CIRCLE_PULL_REQUESTS: "https://github.com/myorg/myrepo/pull/123, https://github.com/myorg/myrepo/pull/124",
+      });
+
+      expect(circle.pullRequestUrl).toBe("https://github.com/myorg/myrepo/pull/123");
+      expect(circle.pullRequest).toMatchObject({
+        id: "123",
+        url: "https://github.com/myorg/myrepo/pull/123",
+      });
+    });
+  });
+
+  describe("pullRequest", () => {
+    it("should fall back to fork pull request number", () => {
+      mockEnv({
+        CIRCLE_PR_NUMBER: "123",
+      });
+
+      expect(circle.pullRequest).toMatchObject({
+        id: "123",
+      });
     });
   });
 });

--- a/packages/ci/test/detectors/drone.test.ts
+++ b/packages/ci/test/detectors/drone.test.ts
@@ -11,6 +11,10 @@ vi.mock("../../src/utils.js", () => ({
   getEnv: vi.fn(),
 }));
 
+const mockEnv = (env: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => env[key] ?? "");
+};
+
 describe("drone", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -19,7 +23,7 @@ describe("drone", () => {
   describe("getJobRunUID", () => {
     it("should return the correct job run UID", () => {
       (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "CI_BUILD_NUMBER") {
+        if (key === "DRONE_BUILD_NUMBER") {
           return "12345";
         }
       });
@@ -29,7 +33,7 @@ describe("drone", () => {
 
     it("should return empty string when environment variable is not set", () => {
       (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "CI_BUILD_NUMBER") {
+        if (key === "DRONE_BUILD_NUMBER") {
           return "";
         }
       });
@@ -132,7 +136,7 @@ describe("drone", () => {
         if (key === "DRONE_BUILD_LINK") {
           return "https://drone.example.com/myorg/myrepo/12345";
         }
-        if (key === "CI_BUILD_NUMBER") {
+        if (key === "DRONE_BUILD_NUMBER") {
           return "12345";
         }
       });
@@ -156,7 +160,7 @@ describe("drone", () => {
   describe("jobRunUID", () => {
     it("should return the correct job run UID", () => {
       (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "CI_BUILD_NUMBER") {
+        if (key === "DRONE_BUILD_NUMBER") {
           return "12345";
         }
       });
@@ -199,65 +203,121 @@ describe("drone", () => {
 
       expect(drone.jobRunBranch).toBe("main");
     });
+
+    it("should return empty string for tag builds", () => {
+      mockEnv({
+        DRONE_BRANCH: "v1.0.0",
+        DRONE_TAG: "v1.0.0",
+      });
+
+      expect(drone.jobRunBranch).toBe("");
+    });
   });
 
   describe("pullRequestUrl", () => {
-    it("should return the correct pull request URL for GitHub", () => {
-      (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "DRONE_GITHUB_SERVER") {
-          return "https://github.com";
-        }
-
-        if (key === "DRONE_REPO_LINK") {
-          return "https://github.com/owner/repo";
-        }
-
-        if (key === "DRONE_PULL_REQUEST") {
-          return "123";
-        }
+    it("should return the correct pull request URL for GitHub from repository link", () => {
+      mockEnv({
+        DRONE_REPO_LINK: "https://github.com/owner/repo",
+        DRONE_PULL_REQUEST: "123",
       });
 
       expect(drone.pullRequestUrl).toBe("https://github.com/owner/repo/pull/123");
     });
 
-    it("should return the correct pull request URL for GitLab", () => {
-      (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "DRONE_GITLAB_SERVER") {
-          return "https://gitlab.com";
-        }
-
-        if (key === "DRONE_REPO_LINK") {
-          return "https://gitlab.com/owner/repo";
-        }
-
-        if (key === "DRONE_PULL_REQUEST") {
-          return "456";
-        }
+    it("should return the correct pull request URL for GitLab from repository link", () => {
+      mockEnv({
+        DRONE_REPO_LINK: "https://gitlab.com/owner/repo",
+        DRONE_PULL_REQUEST: "456",
       });
 
       expect(drone.pullRequestUrl).toBe("https://gitlab.com/owner/repo/-/merge_requests/456");
     });
 
-    it("should return empty string for other repository providers", () => {
-      (getEnv as Mock).mockImplementation((key: string) => {
-        if (key === "DRONE_GITHUB_SERVER") {
-          return "https://github.com";
-        }
+    it("should return the correct pull request URL for Bitbucket from repository link", () => {
+      mockEnv({
+        DRONE_REPO_LINK: "https://bitbucket.org/owner/repo",
+        DRONE_PULL_REQUEST: "789",
+      });
 
-        if (key === "DRONE_GITLAB_SERVER") {
-          return "https://gitlab.com";
-        }
+      expect(drone.pullRequestUrl).toBe("https://bitbucket.org/owner/repo/pull-requests/789");
+    });
 
-        if (key === "DRONE_REPO_LINK") {
-          return "https://bitbucket.org/owner/repo";
-        }
-
-        if (key === "DRONE_PULL_REQUEST") {
-          return "789";
-        }
+    it("should return empty string for unsupported repository providers", () => {
+      mockEnv({
+        DRONE_REPO_LINK: "https://example.com/owner/repo",
+        DRONE_PULL_REQUEST: "789",
       });
 
       expect(drone.pullRequestUrl).toBe("");
+    });
+  });
+
+  describe("sourceBranch", () => {
+    it("should return the source branch for pull requests", () => {
+      mockEnv({
+        DRONE_PULL_REQUEST: "123",
+        DRONE_SOURCE_BRANCH: "feature/foo",
+        DRONE_BRANCH: "main",
+      });
+
+      expect(drone.sourceBranch).toBe("feature/foo");
+    });
+
+    it("should return undefined when pull request source branch is unavailable", () => {
+      mockEnv({
+        DRONE_PULL_REQUEST: "123",
+        DRONE_BRANCH: "main",
+      });
+
+      expect(drone.sourceBranch).toBeUndefined();
+    });
+
+    it("should return the branch for push builds", () => {
+      mockEnv({
+        DRONE_BRANCH: "feature/foo",
+      });
+
+      expect(drone.sourceBranch).toBe("feature/foo");
+    });
+
+    it("should return undefined for tag builds", () => {
+      mockEnv({
+        DRONE_BRANCH: "v1.0.0",
+        DRONE_TAG: "v1.0.0",
+      });
+
+      expect(drone.sourceBranch).toBeUndefined();
+    });
+  });
+
+  describe("targetBranch", () => {
+    it("should return the target branch for pull requests", () => {
+      mockEnv({
+        DRONE_PULL_REQUEST: "123",
+        DRONE_BRANCH: "main",
+        DRONE_TARGET_BRANCH: "main",
+      });
+
+      expect(drone.targetBranch).toBe("main");
+    });
+
+    it("should fall back to DRONE_BRANCH for pull request target branch", () => {
+      mockEnv({
+        DRONE_PULL_REQUEST: "123",
+        DRONE_BRANCH: "main",
+      });
+
+      expect(drone.targetBranch).toBe("main");
+    });
+
+    it("should return undefined for tag builds", () => {
+      mockEnv({
+        DRONE_BRANCH: "v1.0.0",
+        DRONE_TARGET_BRANCH: "v1.0.0",
+        DRONE_TAG: "v1.0.0",
+      });
+
+      expect(drone.targetBranch).toBeUndefined();
     });
   });
 

--- a/packages/ci/test/detectors/gitFields.test.ts
+++ b/packages/ci/test/detectors/gitFields.test.ts
@@ -1,0 +1,288 @@
+import { spawnSync } from "node:child_process";
+
+import { GitProvider } from "@allurereport/core-api";
+import { story } from "allure-js-commons";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { amazon } from "../../src/detectors/amazon.js";
+import { azure } from "../../src/detectors/azure.js";
+import { bitbucket } from "../../src/detectors/bitbucket.js";
+import { circle } from "../../src/detectors/circle.js";
+import { drone } from "../../src/detectors/drone.js";
+import { github } from "../../src/detectors/github.js";
+import { gitlab } from "../../src/detectors/gitlab.js";
+import { jenkins } from "../../src/detectors/jenkins.js";
+import { local } from "../../src/detectors/local.js";
+import { getEnv } from "../../src/utils.js";
+
+vi.mock("../../src/utils.js", () => ({
+  getEnv: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+const mockEnv = (env: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => env[key] ?? "");
+};
+
+beforeEach(async () => {
+  await story("git fields");
+  vi.clearAllMocks();
+});
+
+describe("CI descriptor git fields", () => {
+  it("maps CodeBuild github source", () => {
+    mockEnv({
+      CODEBUILD_SOURCE_REPO_URL: "https://github.com/myorg/myrepo.git",
+      CODEBUILD_SOURCE_VERSION: "pr/12",
+      CODEBUILD_WEBHOOK_TRIGGER: "pr/12",
+      CODEBUILD_WEBHOOK_HEAD_REF: "feature/foo",
+      CODEBUILD_WEBHOOK_BASE_REF: "main",
+    });
+
+    expect(amazon.provider).toBe(GitProvider.Github);
+    expect(amazon.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(amazon.sourceBranch).toBe("feature/foo");
+    expect(amazon.targetBranch).toBe("main");
+    expect(amazon.pullRequest).toMatchObject({ id: "12" });
+  });
+
+  it("maps CodeBuild branch source version with slashes", () => {
+    mockEnv({
+      CODEBUILD_SOURCE_REPO_URL: "https://github.com/myorg/myrepo.git",
+      CODEBUILD_SOURCE_VERSION: "refs/heads/feature/foo",
+    });
+
+    expect(amazon.sourceBranch).toBe("feature/foo");
+  });
+
+  it("maps CodeBuild branch source version with commit suffix", () => {
+    mockEnv({
+      CODEBUILD_SOURCE_REPO_URL: "https://github.com/myorg/myrepo.git",
+      CODEBUILD_SOURCE_VERSION: "refs/heads/feature/foo^{abc123}",
+    });
+
+    expect(amazon.sourceBranch).toBe("feature/foo");
+  });
+
+  it("maps github-backed Azure pipeline", () => {
+    mockEnv({
+      BUILD_REPOSITORY_PROVIDER: "GitHub",
+      BUILD_REPOSITORY_URI: "https://github.com/myorg/myrepo",
+      BUILD_REPOSITORY_NAME: "myrepo",
+      SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: "9",
+      SYSTEM_PULLREQUEST_SOURCEBRANCH: "refs/heads/feature/foo",
+      SYSTEM_PULLREQUEST_TARGETBRANCH: "refs/heads/main",
+    });
+
+    expect(azure.provider).toBe(GitProvider.Github);
+    expect(azure.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(azure.sourceBranch).toBe("feature/foo");
+    expect(azure.targetBranch).toBe("main");
+    expect(azure.pullRequest).toMatchObject({
+      id: "9",
+      url: "https://github.com/myorg/myrepo/pull/9",
+    });
+  });
+
+  it("omits Azure Repos git fields for unsupported host", () => {
+    mockEnv({
+      BUILD_REPOSITORY_PROVIDER: "TfsGit",
+      BUILD_REPOSITORY_URI: "https://dev.azure.com/myorg/myproject/_git/myrepo",
+      BUILD_SOURCEBRANCHNAME: "main",
+    });
+
+    expect(azure.provider).toBeUndefined();
+    expect(azure.repository).toBeUndefined();
+  });
+
+  it("maps Bitbucket repository, branches, and pull request", () => {
+    mockEnv({
+      BITBUCKET_REPO_FULL_NAME: "myorg/myrepo",
+      BITBUCKET_GIT_HTTP_ORIGIN: "https://bitbucket.org/myorg/myrepo",
+      BITBUCKET_BRANCH: "feature/foo",
+      BITBUCKET_PR_DESTINATION_BRANCH: "main",
+      BITBUCKET_PR_ID: "15",
+    });
+
+    expect(bitbucket.provider).toBe(GitProvider.Bitbucket);
+    expect(bitbucket.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://bitbucket.org/myorg/myrepo",
+    });
+    expect(bitbucket.sourceBranch).toBe("feature/foo");
+    expect(bitbucket.targetBranch).toBe("main");
+    expect(bitbucket.pullRequest).toMatchObject({
+      id: "15",
+      url: "https://bitbucket.org/myorg/myrepo/pull-requests/15",
+    });
+  });
+
+  it("maps CircleCI github repository metadata", () => {
+    mockEnv({
+      CIRCLE_REPOSITORY_URL: "https://github.com/myorg/myrepo",
+      CIRCLE_BRANCH: "feature/foo",
+      CIRCLE_PULL_REQUEST: "https://github.com/myorg/myrepo/pull/55",
+    });
+
+    expect(circle.provider).toBe(GitProvider.Github);
+    expect(circle.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(circle.sourceBranch).toBe("feature/foo");
+    expect(circle.pullRequest).toMatchObject({
+      id: "55",
+      url: "https://github.com/myorg/myrepo/pull/55",
+    });
+  });
+
+  it("maps Drone github pull request metadata", () => {
+    mockEnv({
+      DRONE_GITHUB_SERVER: "https://github.com",
+      DRONE_REPO_LINK: "https://github.com/myorg/myrepo",
+      DRONE_PULL_REQUEST: "3",
+      DRONE_BRANCH: "feature/foo",
+      DRONE_TARGET_BRANCH: "main",
+      DRONE_PULL_REQUEST_TITLE: "Drone PR",
+    });
+
+    expect(drone.provider).toBe(GitProvider.Github);
+    expect(drone.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(drone.sourceBranch).toBe("feature/foo");
+    expect(drone.targetBranch).toBe("main");
+    expect(drone.pullRequest).toEqual({
+      id: "3",
+      url: "https://github.com/myorg/myrepo/pull/3",
+      title: "Drone PR",
+    });
+  });
+
+  it("maps GitHub repository, branches, and pull request", () => {
+    mockEnv({
+      GITHUB_REPOSITORY: "myorg/myrepo",
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_HEAD_REF: "feature/foo",
+      GITHUB_BASE_REF: "main",
+      GITHUB_REF_NAME: "42/merge",
+      GITHUB_REF: "refs/heads/feature/foo",
+    });
+
+    expect(github.provider).toBe(GitProvider.Github);
+    expect(github.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(github.sourceBranch).toBe("feature/foo");
+    expect(github.targetBranch).toBe("main");
+    expect(github.pullRequest).toEqual({
+      id: "42",
+      url: "https://github.com/myorg/myrepo/pull/42",
+      title: "Pull request #42",
+    });
+  });
+
+  it("does not treat GitHub branch ending with merge as pull request", () => {
+    mockEnv({
+      GITHUB_REPOSITORY: "myorg/myrepo",
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_REF_NAME: "release/merge",
+      GITHUB_REF: "refs/heads/release/merge",
+    });
+
+    expect(github.sourceBranch).toBe("release/merge");
+    expect(github.pullRequest).toBeUndefined();
+  });
+
+  it("maps GitLab merge request metadata and branches", () => {
+    mockEnv({
+      CI_PROJECT_PATH: "myorg/myrepo",
+      CI_PROJECT_URL: "https://gitlab.com/myorg/myrepo",
+      CI_MERGE_REQUEST_SOURCE_BRANCH_NAME: "feature/foo",
+      CI_MERGE_REQUEST_TARGET_BRANCH_NAME: "main",
+      CI_MERGE_REQUEST_IID: "7",
+      CI_MERGE_REQUEST_TITLE: "Fix things",
+      CI_COMMIT_REF_NAME: "feature/foo",
+    });
+
+    expect(gitlab.provider).toBe(GitProvider.Gitlab);
+    expect(gitlab.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://gitlab.com/myorg/myrepo",
+    });
+    expect(gitlab.sourceBranch).toBe("feature/foo");
+    expect(gitlab.targetBranch).toBe("main");
+    expect(gitlab.pullRequest).toEqual({
+      id: "7",
+      url: "https://gitlab.com/myorg/myrepo/-/merge_requests/7",
+      title: "Fix things",
+    });
+  });
+
+  it("maps Jenkins github repository and pull request", () => {
+    mockEnv({
+      GIT_URL: "https://github.com/myorg/myrepo.git",
+      CHANGE_ID: "15",
+      CHANGE_BRANCH: "feature/foo",
+      CHANGE_TARGET: "main",
+      CHANGE_URL: "https://github.com/myorg/myrepo/pull/15",
+      CHANGE_TITLE: "Fix things",
+    });
+
+    expect(jenkins.provider).toBe(GitProvider.Github);
+    expect(jenkins.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(jenkins.sourceBranch).toBe("feature/foo");
+    expect(jenkins.targetBranch).toBe("main");
+    expect(jenkins.pullRequest).toEqual({
+      id: "15",
+      url: "https://github.com/myorg/myrepo/pull/15",
+      title: "Fix things",
+    });
+  });
+
+  it("omits Jenkins git fields for unsupported host", () => {
+    mockEnv({
+      GIT_URL: "https://dev.azure.com/org/project/_git/repo",
+    });
+
+    expect(jenkins.provider).toBeUndefined();
+    expect(jenkins.repository).toBeUndefined();
+  });
+
+  it("maps local origin remote to supported git provider fields", () => {
+    (spawnSync as Mock).mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === "remote") {
+        return {
+          error: undefined,
+          stdout: Buffer.from("git@github.com:myorg/myrepo.git\n"),
+        };
+      }
+
+      return {
+        error: undefined,
+        stdout: Buffer.from("main\n"),
+      };
+    });
+
+    expect(local.provider).toBe(GitProvider.Github);
+    expect(local.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+    expect(local.sourceBranch).toBe("main");
+  });
+});

--- a/packages/ci/test/detectors/gitFields.test.ts
+++ b/packages/ci/test/detectors/gitFields.test.ts
@@ -70,6 +70,26 @@ describe("CI descriptor git fields", () => {
     expect(amazon.sourceBranch).toBe("feature/foo");
   });
 
+  it("maps CodeBuild unqualified branch source version", () => {
+    mockEnv({
+      CODEBUILD_SOURCE_REPO_URL: "https://github.com/myorg/myrepo.git",
+      CODEBUILD_SOURCE_VERSION: "feature/foo",
+    });
+
+    expect(amazon.sourceBranch).toBe("feature/foo");
+  });
+
+  it("does not map CodeBuild tag webhook as source branch", () => {
+    mockEnv({
+      CODEBUILD_SOURCE_REPO_URL: "https://github.com/myorg/myrepo.git",
+      CODEBUILD_SOURCE_VERSION: "v1.0.0",
+      CODEBUILD_WEBHOOK_TRIGGER: "tag/v1.0.0",
+      CODEBUILD_WEBHOOK_HEAD_REF: "refs/tags/v1.0.0",
+    });
+
+    expect(amazon.sourceBranch).toBeUndefined();
+  });
+
   it("maps github-backed Azure pipeline", () => {
     mockEnv({
       BUILD_REPOSITORY_PROVIDER: "GitHub",
@@ -91,6 +111,32 @@ describe("CI descriptor git fields", () => {
       id: "9",
       url: "https://github.com/myorg/myrepo/pull/9",
     });
+  });
+
+  it("maps Azure branch source ref with slashes", () => {
+    mockEnv({
+      BUILD_REPOSITORY_PROVIDER: "GitHub",
+      BUILD_REPOSITORY_URI: "https://github.com/myorg/myrepo",
+      BUILD_REPOSITORY_NAME: "myrepo",
+      BUILD_SOURCEBRANCH: "refs/heads/feature/foo",
+      BUILD_SOURCEBRANCHNAME: "foo",
+    });
+
+    expect(azure.sourceBranch).toBe("feature/foo");
+    expect(azure.jobRunBranch).toBe("feature/foo");
+  });
+
+  it("does not map Azure tag refs as source branch", () => {
+    mockEnv({
+      BUILD_REPOSITORY_PROVIDER: "GitHub",
+      BUILD_REPOSITORY_URI: "https://github.com/myorg/myrepo",
+      BUILD_REPOSITORY_NAME: "myrepo",
+      BUILD_SOURCEBRANCH: "refs/tags/v1.0.0",
+      BUILD_SOURCEBRANCHNAME: "v1.0.0",
+    });
+
+    expect(azure.sourceBranch).toBeUndefined();
+    expect(azure.jobRunBranch).toBe("");
   });
 
   it("omits Azure Repos git fields for unsupported host", () => {
@@ -126,6 +172,36 @@ describe("CI descriptor git fields", () => {
     });
   });
 
+  it("normalizes Bitbucket origin URLs before mapping git fields", () => {
+    mockEnv({
+      BITBUCKET_REPO_FULL_NAME: "myorg/myrepo",
+      BITBUCKET_GIT_HTTP_ORIGIN: "https://x-token-auth:secret@bitbucket.org/myorg/myrepo.git/",
+      BITBUCKET_BRANCH: "feature/foo",
+      BITBUCKET_PR_DESTINATION_BRANCH: "main",
+      BITBUCKET_PR_ID: "15",
+    });
+
+    expect(bitbucket.repository).toEqual({
+      slug: "myorg/myrepo",
+      url: "https://bitbucket.org/myorg/myrepo",
+    });
+    expect(bitbucket.pullRequest).toMatchObject({
+      id: "15",
+      url: "https://bitbucket.org/myorg/myrepo/pull-requests/15",
+    });
+  });
+
+  it("does not map Bitbucket tag builds as branch git fields", () => {
+    mockEnv({
+      BITBUCKET_REPO_FULL_NAME: "myorg/myrepo",
+      BITBUCKET_GIT_HTTP_ORIGIN: "https://bitbucket.org/myorg/myrepo",
+      BITBUCKET_TAG: "v1.0.0",
+    });
+
+    expect(bitbucket.sourceBranch).toBeUndefined();
+    expect(bitbucket.jobRunBranch).toBe("");
+  });
+
   it("maps CircleCI github repository metadata", () => {
     mockEnv({
       CIRCLE_REPOSITORY_URL: "https://github.com/myorg/myrepo",
@@ -145,12 +221,36 @@ describe("CI descriptor git fields", () => {
     });
   });
 
+  it("maps CircleCI pull request list fallback", () => {
+    mockEnv({
+      CIRCLE_REPOSITORY_URL: "https://github.com/myorg/myrepo",
+      CIRCLE_BRANCH: "feature/foo",
+      CIRCLE_PULL_REQUESTS: "https://github.com/myorg/myrepo/pull/55,https://github.com/myorg/myrepo/pull/56",
+    });
+
+    expect(circle.pullRequestUrl).toBe("https://github.com/myorg/myrepo/pull/55");
+    expect(circle.pullRequest).toMatchObject({
+      id: "55",
+      url: "https://github.com/myorg/myrepo/pull/55",
+    });
+  });
+
+  it("does not map CircleCI tag builds as branch git fields", () => {
+    mockEnv({
+      CIRCLE_REPOSITORY_URL: "https://github.com/myorg/myrepo",
+      CIRCLE_TAG: "v1.0.0",
+    });
+
+    expect(circle.sourceBranch).toBeUndefined();
+    expect(circle.jobRunBranch).toBe("");
+  });
+
   it("maps Drone github pull request metadata", () => {
     mockEnv({
-      DRONE_GITHUB_SERVER: "https://github.com",
       DRONE_REPO_LINK: "https://github.com/myorg/myrepo",
       DRONE_PULL_REQUEST: "3",
-      DRONE_BRANCH: "feature/foo",
+      DRONE_SOURCE_BRANCH: "feature/foo",
+      DRONE_BRANCH: "main",
       DRONE_TARGET_BRANCH: "main",
       DRONE_PULL_REQUEST_TITLE: "Drone PR",
     });
@@ -167,6 +267,28 @@ describe("CI descriptor git fields", () => {
       url: "https://github.com/myorg/myrepo/pull/3",
       title: "Drone PR",
     });
+  });
+
+  it("does not map Drone pull request target branch as source branch", () => {
+    mockEnv({
+      DRONE_REPO_LINK: "https://github.com/myorg/myrepo",
+      DRONE_PULL_REQUEST: "3",
+      DRONE_BRANCH: "main",
+    });
+
+    expect(drone.sourceBranch).toBeUndefined();
+    expect(drone.targetBranch).toBe("main");
+  });
+
+  it("does not map Drone tag builds as branch git fields", () => {
+    mockEnv({
+      DRONE_REPO_LINK: "https://github.com/myorg/myrepo",
+      DRONE_BRANCH: "v1.0.0",
+      DRONE_TAG: "v1.0.0",
+    });
+
+    expect(drone.sourceBranch).toBeUndefined();
+    expect(drone.jobRunBranch).toBe("");
   });
 
   it("maps GitHub repository, branches, and pull request", () => {
@@ -205,6 +327,19 @@ describe("CI descriptor git fields", () => {
     expect(github.pullRequest).toBeUndefined();
   });
 
+  it("does not map GitHub tag refs as branch git fields", () => {
+    mockEnv({
+      GITHUB_REPOSITORY: "myorg/myrepo",
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_REF: "refs/tags/v1.0.0",
+      GITHUB_REF_NAME: "v1.0.0",
+      GITHUB_REF_TYPE: "tag",
+    });
+
+    expect(github.sourceBranch).toBeUndefined();
+    expect(github.jobRunBranch).toBe("");
+  });
+
   it("maps GitLab merge request metadata and branches", () => {
     mockEnv({
       CI_PROJECT_PATH: "myorg/myrepo",
@@ -230,6 +365,30 @@ describe("CI descriptor git fields", () => {
     });
   });
 
+  it("maps GitLab branch pipeline branch", () => {
+    mockEnv({
+      CI_PROJECT_PATH: "myorg/myrepo",
+      CI_PROJECT_URL: "https://gitlab.com/myorg/myrepo",
+      CI_COMMIT_BRANCH: "feature/foo",
+      CI_COMMIT_REF_NAME: "feature/foo",
+    });
+
+    expect(gitlab.sourceBranch).toBe("feature/foo");
+    expect(gitlab.jobRunBranch).toBe("feature/foo");
+  });
+
+  it("does not map GitLab tag pipelines as branch git fields", () => {
+    mockEnv({
+      CI_PROJECT_PATH: "myorg/myrepo",
+      CI_PROJECT_URL: "https://gitlab.com/myorg/myrepo",
+      CI_COMMIT_REF_NAME: "v1.0.0",
+      CI_COMMIT_TAG: "v1.0.0",
+    });
+
+    expect(gitlab.sourceBranch).toBeUndefined();
+    expect(gitlab.jobRunBranch).toBe("");
+  });
+
   it("maps Jenkins github repository and pull request", () => {
     mockEnv({
       GIT_URL: "https://github.com/myorg/myrepo.git",
@@ -252,6 +411,29 @@ describe("CI descriptor git fields", () => {
       url: "https://github.com/myorg/myrepo/pull/15",
       title: "Fix things",
     });
+  });
+
+  it("maps Jenkins Git plugin branch fallback", () => {
+    mockEnv({
+      GIT_URL: "https://github.com/myorg/myrepo.git",
+      GIT_BRANCH: "origin/feature/foo",
+      GIT_LOCAL_BRANCH: "feature/foo",
+    });
+
+    expect(jenkins.sourceBranch).toBe("feature/foo");
+    expect(jenkins.jobRunBranch).toBe("feature/foo");
+  });
+
+  it("does not map Jenkins tag builds as branch git fields", () => {
+    mockEnv({
+      GIT_URL: "https://github.com/myorg/myrepo.git",
+      BRANCH_NAME: "v1.0.0",
+      GIT_BRANCH: "origin/v1.0.0",
+      TAG_NAME: "v1.0.0",
+    });
+
+    expect(jenkins.sourceBranch).toBeUndefined();
+    expect(jenkins.jobRunBranch).toBe("");
   });
 
   it("omits Jenkins git fields for unsupported host", () => {

--- a/packages/ci/test/detectors/github.test.ts
+++ b/packages/ci/test/detectors/github.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
+
 import { story } from "allure-js-commons";
-import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { github } from "../../src/detectors/github.js";
 import { getEnv } from "../../src/utils.js";
@@ -7,8 +9,13 @@ import { getEnv } from "../../src/utils.js";
 beforeEach(async () => {
   await story("github");
 });
+
 vi.mock("../../src/utils.js", () => ({
   getEnv: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
 }));
 
 beforeEach(() => {
@@ -226,6 +233,21 @@ describe("github", () => {
       expect(github.jobRunBranch).toBe("feature-branch");
     });
 
+    it("should keep slashes in branch names from GITHUB_REF variable", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "GITHUB_HEAD_REF") {
+          return "";
+        }
+
+        if (key === "GITHUB_REF") {
+          return "refs/heads/feature/foo";
+        }
+      });
+
+      expect(github.jobRunBranch).toBe("feature/foo");
+      expect(github.sourceBranch).toBe("feature/foo");
+    });
+
     it("should return empty string when neither environment variable is set", () => {
       (getEnv as Mock).mockImplementation((key: string) => {
         if (key === "GITHUB_HEAD_REF" || key === "GITHUB_REF") {
@@ -266,6 +288,19 @@ describe("github", () => {
       expect(github.pullRequestUrl).toBe("");
     });
 
+    it("should return empty string when branch name ends with /merge", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "GITHUB_REF_NAME") {
+          return "release/merge";
+        }
+
+        return "";
+      });
+
+      expect(github.pullRequestUrl).toBe("");
+      expect(github.pullRequest).toBeUndefined();
+    });
+
     it("should return empty string when ref name is empty", () => {
       (getEnv as Mock).mockImplementation((key: string) => {
         if (key === "GITHUB_REF_NAME") {
@@ -274,6 +309,25 @@ describe("github", () => {
       });
 
       expect(github.pullRequestUrl).toBe("");
+    });
+
+    it("should resolve pull request URL from GITHUB_EVENT_PATH for pull_request_target workflows", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        const env: Record<string, string> = {
+          GITHUB_HEAD_REF: "feature/foo",
+          GITHUB_BASE_REF: "main",
+          GITHUB_REF: "refs/heads/main",
+          GITHUB_REF_NAME: "main",
+          GITHUB_EVENT_PATH: "/tmp/event.json",
+          GITHUB_SERVER_URL: "https://github.com",
+          GITHUB_REPOSITORY: "myorg/myrepo",
+        };
+
+        return env[key] ?? "";
+      });
+      (readFileSync as Mock).mockReturnValue(JSON.stringify({ pull_request: { number: 123 } }));
+
+      expect(github.pullRequestUrl).toBe("https://github.com/myorg/myrepo/pull/123");
     });
   });
 
@@ -306,6 +360,23 @@ describe("github", () => {
       });
 
       expect(github.pullRequestName).toBe("");
+    });
+
+    it("should resolve pull request name from GITHUB_EVENT_PATH for pull_request_target workflows", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        const env: Record<string, string> = {
+          GITHUB_HEAD_REF: "feature/foo",
+          GITHUB_BASE_REF: "main",
+          GITHUB_REF: "refs/heads/main",
+          GITHUB_REF_NAME: "main",
+          GITHUB_EVENT_PATH: "/tmp/event.json",
+        };
+
+        return env[key] ?? "";
+      });
+      (readFileSync as Mock).mockReturnValue(JSON.stringify({ pull_request: { number: 123 } }));
+
+      expect(github.pullRequestName).toBe("Pull request #123");
     });
   });
 });

--- a/packages/ci/test/detectors/github.test.ts
+++ b/packages/ci/test/detectors/github.test.ts
@@ -22,6 +22,10 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const mockEnv = (env: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => env[key] ?? "");
+};
+
 describe("github", () => {
   describe("detected", () => {
     it("should be true when GITHUB_ACTIONS is set", () => {
@@ -256,6 +260,27 @@ describe("github", () => {
       });
 
       expect(github.jobRunBranch).toBe("");
+    });
+
+    it("should return empty string for tag refs when ref type is tag", () => {
+      mockEnv({
+        GITHUB_REF: "refs/tags/v1.0.0",
+        GITHUB_REF_NAME: "v1.0.0",
+        GITHUB_REF_TYPE: "tag",
+      });
+
+      expect(github.jobRunBranch).toBe("");
+      expect(github.sourceBranch).toBeUndefined();
+    });
+
+    it("should return empty string for tag refs when ref type is unavailable", () => {
+      mockEnv({
+        GITHUB_REF: "refs/tags/v1.0.0",
+        GITHUB_REF_NAME: "v1.0.0",
+      });
+
+      expect(github.jobRunBranch).toBe("");
+      expect(github.sourceBranch).toBeUndefined();
     });
   });
 

--- a/packages/ci/test/detectors/gitlab.test.ts
+++ b/packages/ci/test/detectors/gitlab.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { gitlab } from "../../src/detectors/gitlab.js";
 import { getEnv } from "../../src/utils.js";
 
+const mockEnv = (env: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => env[key] ?? "");
+};
+
 beforeEach(async () => {
   await story("gitlab");
 });
@@ -212,6 +216,53 @@ describe("gitlab", () => {
 
       expect(gitlab.jobRunBranch).toBe("");
     });
+
+    it("should prefer CI_COMMIT_BRANCH for branch pipelines", () => {
+      mockEnv({
+        CI_COMMIT_BRANCH: "feature/foo",
+        CI_COMMIT_REF_NAME: "feature/foo",
+      });
+
+      expect(gitlab.jobRunBranch).toBe("feature/foo");
+    });
+
+    it("should not return tag name as job run branch", () => {
+      mockEnv({
+        CI_COMMIT_REF_NAME: "v1.0.0",
+        CI_COMMIT_TAG: "v1.0.0",
+      });
+
+      expect(gitlab.jobRunBranch).toBe("");
+    });
+  });
+
+  describe("sourceBranch", () => {
+    it("should return merge request source branch", () => {
+      mockEnv({
+        CI_MERGE_REQUEST_SOURCE_BRANCH_NAME: "feature/foo",
+        CI_COMMIT_REF_NAME: "refs/merge-requests/7/head",
+      });
+
+      expect(gitlab.sourceBranch).toBe("feature/foo");
+    });
+
+    it("should return branch pipeline branch", () => {
+      mockEnv({
+        CI_COMMIT_BRANCH: "feature/bar",
+        CI_COMMIT_REF_NAME: "feature/bar",
+      });
+
+      expect(gitlab.sourceBranch).toBe("feature/bar");
+    });
+
+    it("should not return tag name as source branch", () => {
+      mockEnv({
+        CI_COMMIT_REF_NAME: "v1.0.0",
+        CI_COMMIT_TAG: "v1.0.0",
+      });
+
+      expect(gitlab.sourceBranch).toBeUndefined();
+    });
   });
 
   describe("pullRequestUrl", () => {
@@ -251,6 +302,24 @@ describe("gitlab", () => {
       });
 
       expect(gitlab.pullRequestUrl).toBe("https://gitlab.example.com/myorg/myrepo/-/merge_requests/123");
+    });
+
+    it("should prefer merge request project URL", () => {
+      mockEnv({
+        CI_MERGE_REQUEST_IID: "123",
+        CI_MERGE_REQUEST_PROJECT_URL: "https://gitlab.com/parent/repo",
+        CI_PROJECT_URL: "https://gitlab.com/fork/repo",
+      });
+
+      expect(gitlab.pullRequestUrl).toBe("https://gitlab.com/parent/repo/-/merge_requests/123");
+    });
+
+    it("should return empty string when project URL is missing", () => {
+      mockEnv({
+        CI_MERGE_REQUEST_IID: "123",
+      });
+
+      expect(gitlab.pullRequestUrl).toBe("");
     });
   });
 });

--- a/packages/ci/test/detectors/jenkins.test.ts
+++ b/packages/ci/test/detectors/jenkins.test.ts
@@ -20,6 +20,10 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const mockEnv = (env: Record<string, string>) => {
+  (getEnv as Mock).mockImplementation((key: string) => env[key] ?? "");
+};
+
 describe("jenkins", () => {
   describe("detected", () => {
     it("should be true when JENKINS_URL is set", () => {
@@ -226,6 +230,72 @@ describe("jenkins", () => {
       });
 
       expect(jenkins.jobRunBranch).toBe("");
+    });
+
+    it("should fall back to GIT_LOCAL_BRANCH", () => {
+      mockEnv({
+        GIT_BRANCH: "origin/feature/my-branch",
+        GIT_LOCAL_BRANCH: "feature/my-branch",
+      });
+
+      expect(jenkins.jobRunBranch).toBe("feature/my-branch");
+    });
+
+    it("should normalize remote-prefixed GIT_BRANCH", () => {
+      mockEnv({
+        GIT_BRANCH: "origin/feature/my-branch",
+      });
+
+      expect(jenkins.jobRunBranch).toBe("feature/my-branch");
+    });
+
+    it("should return empty string for tag builds", () => {
+      mockEnv({
+        BRANCH_NAME: "v1.0.0",
+        TAG_NAME: "v1.0.0",
+      });
+
+      expect(jenkins.jobRunBranch).toBe("");
+    });
+  });
+
+  describe("sourceBranch", () => {
+    it("should prefer pull request source branch", () => {
+      mockEnv({
+        BRANCH_NAME: "PR-123",
+        CHANGE_BRANCH: "feature/my-branch",
+      });
+
+      expect(jenkins.sourceBranch).toBe("feature/my-branch");
+    });
+
+    it("should fall back to Git plugin branch", () => {
+      mockEnv({
+        GIT_BRANCH: "origin/feature/my-branch",
+      });
+
+      expect(jenkins.sourceBranch).toBe("feature/my-branch");
+    });
+
+    it("should return undefined for tag builds", () => {
+      mockEnv({
+        BRANCH_NAME: "v1.0.0",
+        GIT_BRANCH: "origin/v1.0.0",
+        TAG_NAME: "v1.0.0",
+      });
+
+      expect(jenkins.sourceBranch).toBeUndefined();
+    });
+  });
+
+  describe("targetBranch", () => {
+    it("should return undefined for tag builds", () => {
+      mockEnv({
+        CHANGE_TARGET: "main",
+        TAG_NAME: "v1.0.0",
+      });
+
+      expect(jenkins.targetBranch).toBeUndefined();
     });
   });
 

--- a/packages/ci/test/githubPullRequest.test.ts
+++ b/packages/ci/test/githubPullRequest.test.ts
@@ -1,0 +1,161 @@
+import { readFileSync } from "node:fs";
+
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parsePullRequestNumberFromEventJson, resolveGithubPullRequestNumber } from "../src/helpers/github.js";
+import { getEnv } from "../src/utils.js";
+
+vi.mock("../src/utils.js", () => ({
+  getEnv: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parsePullRequestNumberFromEventJson", () => {
+  it("returns pull request number from event payload", () => {
+    expect(
+      parsePullRequestNumberFromEventJson(JSON.stringify({ pull_request: { number: 77, title: "Fix things" } })),
+    ).toBe("77");
+  });
+
+  it("returns empty string for invalid JSON", () => {
+    expect(parsePullRequestNumberFromEventJson("{not-json")).toBe("");
+  });
+
+  it("returns empty string when pull_request is missing", () => {
+    expect(parsePullRequestNumberFromEventJson(JSON.stringify({ action: "opened" }))).toBe("");
+  });
+
+  it("returns empty string when pull_request.number is missing", () => {
+    expect(parsePullRequestNumberFromEventJson(JSON.stringify({ pull_request: { title: "No number" } }))).toBe("");
+  });
+});
+
+describe("resolveGithubPullRequestNumber", () => {
+  it("resolves pull request id from GITHUB_REF_NAME merge suffix", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      if (key === "GITHUB_REF_NAME") {
+        return "42/merge";
+      }
+
+      return "";
+    });
+
+    expect(resolveGithubPullRequestNumber()).toBe("42");
+  });
+
+  it("does not resolve pull request id from non-numeric GITHUB_REF_NAME merge suffix", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      if (key === "GITHUB_REF_NAME") {
+        return "release/merge";
+      }
+
+      return "";
+    });
+
+    expect(resolveGithubPullRequestNumber()).toBe("");
+  });
+
+  it("resolves pull request id from GITHUB_REF merge ref", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      const env: Record<string, string> = {
+        GITHUB_REF: "refs/pull/99/merge",
+        GITHUB_REF_NAME: "99",
+      };
+
+      return env[key] ?? "";
+    });
+
+    expect(resolveGithubPullRequestNumber()).toBe("99");
+  });
+
+  it("resolves pull request id from GITHUB_EVENT_PATH for pull_request_target workflows", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      const env: Record<string, string> = {
+        GITHUB_HEAD_REF: "feature/foo",
+        GITHUB_BASE_REF: "main",
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_REF_NAME: "main",
+        GITHUB_EVENT_PATH: "/tmp/event.json",
+      };
+
+      return env[key] ?? "";
+    });
+    (readFileSync as Mock).mockReturnValue(JSON.stringify({ pull_request: { number: 77 } }));
+
+    expect(resolveGithubPullRequestNumber()).toBe("77");
+    expect(readFileSync).toHaveBeenCalledWith("/tmp/event.json", "utf-8");
+  });
+
+  it("does not read event file when ref-based detection succeeds", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      const env: Record<string, string> = {
+        GITHUB_HEAD_REF: "feature/foo",
+        GITHUB_BASE_REF: "main",
+        GITHUB_REF_NAME: "55/merge",
+        GITHUB_EVENT_PATH: "/tmp/event.json",
+      };
+
+      return env[key] ?? "";
+    });
+
+    expect(resolveGithubPullRequestNumber()).toBe("55");
+    expect(readFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns empty string when event file is missing", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      const env: Record<string, string> = {
+        GITHUB_HEAD_REF: "feature/foo",
+        GITHUB_BASE_REF: "main",
+        GITHUB_EVENT_PATH: "/tmp/missing-event.json",
+      };
+
+      return env[key] ?? "";
+    });
+    (readFileSync as Mock).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(resolveGithubPullRequestNumber()).toBe("");
+  });
+
+  it("returns empty string when event JSON has no pull request number", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      const env: Record<string, string> = {
+        GITHUB_HEAD_REF: "feature/foo",
+        GITHUB_BASE_REF: "main",
+        GITHUB_EVENT_PATH: "/tmp/event.json",
+      };
+
+      return env[key] ?? "";
+    });
+    (readFileSync as Mock).mockReturnValue(JSON.stringify({ action: "push" }));
+
+    expect(resolveGithubPullRequestNumber()).toBe("");
+  });
+
+  it("returns empty string when only one of head/base refs is set", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      if (key === "GITHUB_HEAD_REF") {
+        return "feature/foo";
+      }
+
+      if (key === "GITHUB_EVENT_PATH") {
+        return "/tmp/event.json";
+      }
+
+      return "";
+    });
+    (readFileSync as Mock).mockReturnValue(JSON.stringify({ pull_request: { number: 77 } }));
+
+    expect(resolveGithubPullRequestNumber()).toBe("");
+    expect(readFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ci/test/githubPullRequest.test.ts
+++ b/packages/ci/test/githubPullRequest.test.ts
@@ -24,6 +24,12 @@ describe("parsePullRequestNumberFromEventJson", () => {
     ).toBe("77");
   });
 
+  it("returns pull request number from top-level event payload number", () => {
+    expect(
+      parsePullRequestNumberFromEventJson(JSON.stringify({ number: 78, pull_request: { title: "Fix things" } })),
+    ).toBe("78");
+  });
+
   it("returns empty string for invalid JSON", () => {
     expect(parsePullRequestNumberFromEventJson("{not-json")).toBe("");
   });
@@ -91,6 +97,23 @@ describe("resolveGithubPullRequestNumber", () => {
 
     expect(resolveGithubPullRequestNumber()).toBe("77");
     expect(readFileSync).toHaveBeenCalledWith("/tmp/event.json", "utf-8");
+  });
+
+  it("resolves pull request id from top-level event payload number", () => {
+    (getEnv as Mock).mockImplementation((key: string) => {
+      const env: Record<string, string> = {
+        GITHUB_HEAD_REF: "feature/foo",
+        GITHUB_BASE_REF: "main",
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_REF_NAME: "main",
+        GITHUB_EVENT_PATH: "/tmp/event.json",
+      };
+
+      return env[key] ?? "";
+    });
+    (readFileSync as Mock).mockReturnValue(JSON.stringify({ number: 78, pull_request: { title: "Fix things" } }));
+
+    expect(resolveGithubPullRequestNumber()).toBe("78");
   });
 
   it("does not read event file when ref-based detection succeeds", () => {

--- a/packages/ci/test/helpers/gitProvider.test.ts
+++ b/packages/ci/test/helpers/gitProvider.test.ts
@@ -1,0 +1,45 @@
+import { GitProvider } from "@allurereport/core-api";
+import { describe, expect, it } from "vitest";
+
+import {
+  inferGitProviderFromUrl,
+  normalizeGitRemoteUrl,
+  parsePullRequestNumberFromUrl,
+  parseRepositorySlugFromUrl,
+  resolveRepositoryFromGitUrl,
+  stripRefsHeads,
+} from "../../src/helpers/gitProvider.js";
+
+describe("gitProvider helpers", () => {
+  it("normalizes scp-style remotes", () => {
+    expect(normalizeGitRemoteUrl("git@github.com:myorg/myrepo.git")).toBe("https://github.com/myorg/myrepo.git");
+  });
+
+  it("infers github provider and slug from https remote", () => {
+    expect(resolveRepositoryFromGitUrl("https://github.com/myorg/myrepo.git")).toEqual({
+      provider: GitProvider.Github,
+      slug: "myorg/myrepo",
+      url: "https://github.com/myorg/myrepo",
+    });
+  });
+
+  it("infers gitlab provider with nested group slug", () => {
+    expect(inferGitProviderFromUrl("https://gitlab.com/my/group/myrepo")).toBe(GitProvider.Gitlab);
+    expect(parseRepositorySlugFromUrl("https://gitlab.com/my/group/myrepo", GitProvider.Gitlab)).toBe(
+      "my/group/myrepo",
+    );
+  });
+
+  it("returns undefined for unsupported hosts", () => {
+    expect(inferGitProviderFromUrl("https://dev.azure.com/org/project/_git/repo")).toBeUndefined();
+  });
+
+  it("strips refs/heads prefix", () => {
+    expect(stripRefsHeads("refs/heads/feature/foo")).toBe("feature/foo");
+  });
+
+  it("parses pull request number from PR URLs", () => {
+    expect(parsePullRequestNumberFromUrl("https://github.com/org/repo/pull/55")).toBe("55");
+    expect(parsePullRequestNumberFromUrl("https://gitlab.com/org/repo/-/merge_requests/7")).toBe("7");
+  });
+});

--- a/packages/core-api/src/ci.ts
+++ b/packages/core-api/src/ci.ts
@@ -1,3 +1,5 @@
+import type { GitProvider, GitPullRequestRef, GitRepositoryRef } from "./gitFlow.js";
+
 export enum CiType {
   Amazon = "amazon",
   Azure = "azure",
@@ -23,4 +25,9 @@ export interface CiDescriptor {
   jobRunBranch: string;
   pullRequestName: string;
   pullRequestUrl: string;
+  provider?: GitProvider;
+  repository?: GitRepositoryRef;
+  sourceBranch?: string;
+  targetBranch?: string;
+  pullRequest?: GitPullRequestRef;
 }

--- a/packages/core-api/src/gitFlow.ts
+++ b/packages/core-api/src/gitFlow.ts
@@ -1,0 +1,39 @@
+/**
+ * Git Flow client contracts (Allure 3 → TestOps upload).
+ * Wire field names on TestOps API may change; types stay stable in monorepo.
+ */
+
+export enum GitProvider {
+  Github = "github",
+  Gitlab = "gitlab",
+  Bitbucket = "bitbucket",
+  Other = "other",
+}
+
+export interface GitRepositoryRef {
+  slug: string;
+  url?: string;
+}
+
+export interface GitPullRequestRef {
+  id: string;
+  url?: string;
+  title?: string;
+}
+
+/** Working-tree signals from `git` CLI (also used in merged upload payload). */
+export interface GitLocalState {
+  uncommittedChanges: boolean;
+  unpublishedCommit: boolean;
+  unpublishedBranch: boolean;
+  detachedHead: boolean;
+}
+
+/** Output of `@allurereport/git` — facts from repository, not CI env. */
+export interface GitFacts {
+  commit: string;
+  branch?: string;
+  /** First-parent ancestors of `commit`, newest first; does not include `commit` (HEAD). */
+  firstParentAncestors: string[];
+  localState?: GitLocalState;
+}

--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -1,6 +1,7 @@
 export type * from "./aggregate.js";
 export * from "./constants.js";
 export * from "./ci.js";
+export * from "./gitFlow.js";
 export type * from "./environment.js";
 export type * from "./history.js";
 export type * from "./known.js";

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@allurereport/git",
+  "version": "3.9.0",
+  "description": "Git metadata collection for Allure Git Flow",
+  "keywords": [
+    "allure",
+    "git",
+    "report",
+    "testing"
+  ],
+  "license": "Apache-2.0",
+  "author": "Qameta Software",
+  "repository": "https://github.com/allure-framework/allure3",
+  "files": [
+    "./dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "run clean && tsc --project ./tsconfig.json",
+    "clean": "rimraf ./dist",
+    "test": "rimraf ./out && vitest run",
+    "lint": "oxlint --import-plugin src test",
+    "lint:fix": "oxlint --import-plugin --fix src test"
+  },
+  "dependencies": {
+    "@allurereport/core-api": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@vitest/runner": "^2",
+    "@vitest/snapshot": "^2",
+    "allure-vitest": "^3",
+    "rimraf": "^6",
+    "typescript": "^5",
+    "vitest": "^4"
+  }
+}

--- a/packages/git/src/collectGitFacts.ts
+++ b/packages/git/src/collectGitFacts.ts
@@ -9,16 +9,39 @@ export type CollectGitFactsOptions = {
   ancestorLimit?: number;
 };
 
+const stripRemotePrefix = (upstreamRef: string): string => {
+  const slashIndex = upstreamRef.indexOf("/");
+
+  return slashIndex >= 0 ? upstreamRef.slice(slashIndex + 1) : upstreamRef;
+};
+
+const resolveBranch = (cwd?: string): string | undefined => {
+  const branchRaw = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+
+  if (!branchRaw || branchRaw === "HEAD") {
+    return undefined;
+  }
+
+  const upstreamBranch = runGit(["rev-parse", "--abbrev-ref", "@{u}"], cwd);
+
+  if (upstreamBranch) {
+    return stripRemotePrefix(upstreamBranch);
+  }
+
+  return branchRaw;
+};
+
 const collectLocalState = (cwd?: string): GitLocalState => {
   const statusPorcelain = runGit(["status", "--porcelain"], cwd) ?? "";
   const branchRaw = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
   const detachedHead = branchRaw === "HEAD";
+  const headCommit = runGit(["rev-parse", "--verify", "HEAD"], cwd);
   const upstreamCommit = runGit(["rev-parse", "--verify", "@{u}"], cwd);
   const upstreamBranch = runGit(["rev-parse", "--abbrev-ref", "@{u}"], cwd);
 
   return {
     uncommittedChanges: statusPorcelain.length > 0,
-    unpublishedCommit: !upstreamCommit,
+    unpublishedCommit: !upstreamCommit || headCommit !== upstreamCommit,
     unpublishedBranch: !upstreamBranch,
     detachedHead,
   };
@@ -37,8 +60,7 @@ export const collectGitFacts = (options: CollectGitFactsOptions = {}): GitFacts 
     return undefined;
   }
 
-  const branchRaw = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
-  const branch = branchRaw && branchRaw !== "HEAD" ? branchRaw : undefined;
+  const branch = resolveBranch(cwd);
 
   const revList = runGit(["rev-list", "--first-parent", commit, `--max-count=${ancestorLimit + 1}`], cwd);
 
@@ -50,7 +72,7 @@ export const collectGitFacts = (options: CollectGitFactsOptions = {}): GitFacts 
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
-    .filter((hash) => hash !== commit);
+    .slice(1);
 
   return {
     commit,

--- a/packages/git/src/collectGitFacts.ts
+++ b/packages/git/src/collectGitFacts.ts
@@ -1,0 +1,61 @@
+import type { GitFacts, GitLocalState } from "@allurereport/core-api";
+
+import { runGit } from "./runGit.js";
+
+export const DEFAULT_ANCESTOR_LIMIT = 100;
+
+export type CollectGitFactsOptions = {
+  cwd?: string;
+  ancestorLimit?: number;
+};
+
+const collectLocalState = (cwd?: string): GitLocalState => {
+  const statusPorcelain = runGit(["status", "--porcelain"], cwd) ?? "";
+  const branchRaw = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  const detachedHead = branchRaw === "HEAD";
+  const upstreamCommit = runGit(["rev-parse", "--verify", "@{u}"], cwd);
+  const upstreamBranch = runGit(["rev-parse", "--abbrev-ref", "@{u}"], cwd);
+
+  return {
+    uncommittedChanges: statusPorcelain.length > 0,
+    unpublishedCommit: !upstreamCommit,
+    unpublishedBranch: !upstreamBranch,
+    detachedHead,
+  };
+};
+
+export const collectGitFacts = (options: CollectGitFactsOptions = {}): GitFacts | undefined => {
+  const { cwd, ancestorLimit = DEFAULT_ANCESTOR_LIMIT } = options;
+
+  if (runGit(["rev-parse", "--is-inside-work-tree"], cwd) !== "true") {
+    return undefined;
+  }
+
+  const commit = runGit(["rev-parse", "HEAD"], cwd);
+
+  if (!commit) {
+    return undefined;
+  }
+
+  const branchRaw = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  const branch = branchRaw && branchRaw !== "HEAD" ? branchRaw : undefined;
+
+  const revList = runGit(["rev-list", "--first-parent", commit, `--max-count=${ancestorLimit + 1}`], cwd);
+
+  if (!revList) {
+    return undefined;
+  }
+
+  const firstParentAncestors = revList
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((hash) => hash !== commit);
+
+  return {
+    commit,
+    branch,
+    firstParentAncestors,
+    localState: collectLocalState(cwd),
+  };
+};

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1,0 +1,2 @@
+export { collectGitFacts, DEFAULT_ANCESTOR_LIMIT, type CollectGitFactsOptions } from "./collectGitFacts.js";
+export { isGitAvailable } from "./isGitAvailable.js";

--- a/packages/git/src/isGitAvailable.ts
+++ b/packages/git/src/isGitAvailable.ts
@@ -1,0 +1,7 @@
+import { spawnSync } from "node:child_process";
+
+export const isGitAvailable = (): boolean => {
+  const result = spawnSync("git", ["--version"], { encoding: "utf-8" });
+
+  return !result.error && result.status === 0;
+};

--- a/packages/git/src/runGit.ts
+++ b/packages/git/src/runGit.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+
+const isGitDebugEnabled = (): boolean => {
+  const value = process.env.ALLURE_DEBUG?.trim().toLowerCase();
+
+  return value === "1" || value === "true";
+};
+
+const hasUnsafeGitArgs = (args: string[]): boolean => {
+  return args.some((arg) => arg === "--upload-pack" || arg.startsWith("--upload-pack="));
+};
+
+export const runGit = (args: string[], cwd?: string): string | undefined => {
+  if (hasUnsafeGitArgs(args)) {
+    if (isGitDebugEnabled()) {
+      process.stderr.write(`[allurereport/git] blocked unsafe git arguments: ${args.join(" ")}\n`);
+    }
+
+    return undefined;
+  }
+
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+  });
+
+  if (result.error || result.status !== 0) {
+    if (isGitDebugEnabled()) {
+      const stderr = result.stderr?.trim();
+      const status = result.status ?? "n/a";
+
+      process.stderr.write(
+        `[allurereport/git] git ${args.join(" ")} failed (status=${status})${stderr ? `: ${stderr}` : ""}\n`,
+      );
+    }
+
+    return undefined;
+  }
+
+  return result.stdout.trim();
+};

--- a/packages/git/test/collectGitFacts.test.ts
+++ b/packages/git/test/collectGitFacts.test.ts
@@ -94,7 +94,7 @@ describe("collectGitFacts", () => {
       firstParentAncestors: [COMMIT_B, COMMIT_A],
       localState: {
         uncommittedChanges: false,
-        unpublishedCommit: false,
+        unpublishedCommit: true,
         unpublishedBranch: false,
         detachedHead: false,
       },
@@ -167,6 +167,92 @@ describe("collectGitFacts", () => {
     });
 
     expect(collectGitFacts()?.localState?.uncommittedChanges).toBe(true);
+  });
+
+  it("marks unpublished commit when HEAD is ahead of upstream", () => {
+    mockHappyGit();
+
+    expect(collectGitFacts()?.localState?.unpublishedCommit).toBe(true);
+  });
+
+  it("marks published commit when HEAD matches upstream", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD" || key === "rev-parse --verify HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    expect(collectGitFacts()?.localState?.unpublishedCommit).toBe(false);
+  });
+
+  it("prefers upstream branch name over local branch name", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "local-feature";
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/feature/foo";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD" || key === "rev-parse --verify HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      return undefined;
+    });
+
+    expect(collectGitFacts()?.branch).toBe("feature/foo");
   });
 
   it("marks unpublished commit and branch when upstream is missing", () => {

--- a/packages/git/test/collectGitFacts.test.ts
+++ b/packages/git/test/collectGitFacts.test.ts
@@ -1,0 +1,219 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { collectGitFacts } from "../src/collectGitFacts.js";
+import * as runGitModule from "../src/runGit.js";
+
+vi.mock("../src/runGit.js", () => ({
+  runGit: vi.fn(),
+}));
+
+const runGit = runGitModule.runGit as Mock;
+
+const COMMIT_A = "a".repeat(40);
+const COMMIT_B = "b".repeat(40);
+const COMMIT_C = "c".repeat(40);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const mockHappyGit = (params?: { branch?: string; ancestors?: string[]; detached?: boolean }) => {
+  const branch = params?.detached ? "HEAD" : (params?.branch ?? "main");
+  const ancestors = params?.ancestors ?? [COMMIT_C, COMMIT_B, COMMIT_A];
+
+  runGit.mockImplementation((args: string[]) => {
+    const key = args.join(" ");
+
+    if (key === "rev-parse --is-inside-work-tree") {
+      return "true";
+    }
+
+    if (key === "rev-parse HEAD") {
+      return COMMIT_C;
+    }
+
+    if (key === "rev-parse --abbrev-ref HEAD") {
+      return branch;
+    }
+
+    if (key.startsWith("rev-list --first-parent")) {
+      return ancestors.join("\n");
+    }
+
+    if (key === "status --porcelain") {
+      return "";
+    }
+
+    if (key === "rev-parse --verify @{u}") {
+      return COMMIT_B;
+    }
+
+    if (key === "rev-parse --abbrev-ref @{u}") {
+      return "origin/main";
+    }
+
+    return undefined;
+  });
+};
+
+describe("collectGitFacts", () => {
+  it("returns undefined when not inside a work tree", () => {
+    runGit.mockImplementation((args: string[]) => {
+      if (args.join(" ") === "rev-parse --is-inside-work-tree") {
+        return undefined;
+      }
+    });
+
+    expect(collectGitFacts()).toBeUndefined();
+  });
+
+  it("returns undefined when HEAD cannot be resolved", () => {
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return undefined;
+      }
+    });
+
+    expect(collectGitFacts()).toBeUndefined();
+  });
+
+  it("collects commit, branch, ancestors newest-first, and local state", () => {
+    mockHappyGit();
+
+    const facts = collectGitFacts({ ancestorLimit: 2 });
+
+    expect(facts).toEqual({
+      commit: COMMIT_C,
+      branch: "main",
+      firstParentAncestors: [COMMIT_B, COMMIT_A],
+      localState: {
+        uncommittedChanges: false,
+        unpublishedCommit: false,
+        unpublishedBranch: false,
+        detachedHead: false,
+      },
+    });
+
+    expect(runGit).toHaveBeenCalledWith(["rev-list", "--first-parent", COMMIT_C, "--max-count=3"], undefined);
+  });
+
+  it("returns empty ancestors when HEAD has no parents", () => {
+    mockHappyGit({ ancestors: [COMMIT_C] });
+
+    const facts = collectGitFacts();
+
+    expect(facts?.firstParentAncestors).toEqual([]);
+    expect(facts?.commit).toBe(COMMIT_C);
+  });
+
+  it("respects ancestorLimit in rev-list max-count", () => {
+    mockHappyGit({ ancestors: [COMMIT_C, COMMIT_B] });
+
+    collectGitFacts({ ancestorLimit: 1 });
+
+    expect(runGit).toHaveBeenCalledWith(["rev-list", "--first-parent", COMMIT_C, "--max-count=2"], undefined);
+  });
+
+  it("omits branch and sets detachedHead when HEAD is detached", () => {
+    mockHappyGit({ detached: true });
+
+    const facts = collectGitFacts();
+
+    expect(facts?.branch).toBeUndefined();
+    expect(facts?.localState?.detachedHead).toBe(true);
+  });
+
+  it("detects uncommitted changes from porcelain status", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "status --porcelain") {
+        return " M file.ts";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_A].join("\n");
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_A;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    expect(collectGitFacts()?.localState?.uncommittedChanges).toBe(true);
+  });
+
+  it("marks unpublished commit and branch when upstream is missing", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --verify @{u}" || key === "rev-parse --abbrev-ref @{u}") {
+        return undefined;
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return COMMIT_C;
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      return undefined;
+    });
+
+    const facts = collectGitFacts();
+
+    expect(facts?.localState?.unpublishedCommit).toBe(true);
+    expect(facts?.localState?.unpublishedBranch).toBe(true);
+  });
+
+  it("passes cwd to git commands", () => {
+    mockHappyGit();
+
+    collectGitFacts({ cwd: "/repo" });
+
+    expect(runGit).toHaveBeenCalledWith(["rev-parse", "--is-inside-work-tree"], "/repo");
+    expect(runGit).toHaveBeenCalledWith(["rev-parse", "HEAD"], "/repo");
+  });
+});

--- a/packages/git/test/isGitAvailable.test.ts
+++ b/packages/git/test/isGitAvailable.test.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+
+import { type Mock, describe, expect, it, vi } from "vitest";
+
+import { isGitAvailable } from "../src/isGitAvailable.js";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+const spawnSyncMock = spawnSync as Mock;
+
+describe("isGitAvailable", () => {
+  it("returns true when git --version succeeds", () => {
+    spawnSyncMock.mockReturnValue({ error: undefined, status: 0 });
+
+    expect(isGitAvailable()).toBe(true);
+    expect(spawnSyncMock).toHaveBeenCalledWith("git", ["--version"], { encoding: "utf-8" });
+  });
+
+  it("returns false when git is missing or fails", () => {
+    spawnSyncMock.mockReturnValue({ error: new Error("ENOENT"), status: 1 });
+
+    expect(isGitAvailable()).toBe(false);
+  });
+});

--- a/packages/git/test/runGit.test.ts
+++ b/packages/git/test/runGit.test.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runGit } from "../src/runGit.js";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+const spawnSyncMock = vi.mocked(spawnSync);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("runGit", () => {
+  it("writes stderr hint when ALLURE_DEBUG is set and git fails", () => {
+    vi.stubEnv("ALLURE_DEBUG", "true");
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    spawnSyncMock.mockReturnValue({
+      status: 128,
+      stdout: "",
+      stderr: "fatal: not a git repository",
+      pid: 1,
+      output: ["", "fatal: not a git repository", ""],
+      signal: null,
+      error: undefined,
+    } as ReturnType<typeof spawnSync>);
+
+    expect(runGit(["rev-parse", "HEAD"])).toBeUndefined();
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[allurereport/git] git rev-parse HEAD failed (status=128): fatal: not a git repository"),
+    );
+  });
+
+  it("blocks --upload-pack and does not spawn git", () => {
+    expect(runGit(["ls-remote", "--upload-pack=evil"])).toBeUndefined();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("writes stderr hint when ALLURE_DEBUG is set and unsafe args are blocked", () => {
+    vi.stubEnv("ALLURE_DEBUG", "true");
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    expect(runGit(["--upload-pack"])).toBeUndefined();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[allurereport/git] blocked unsafe git arguments: --upload-pack"),
+    );
+  });
+
+  it("does not write stderr hint when ALLURE_DEBUG is unset", () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "error",
+      pid: 1,
+      output: ["", "error", ""],
+      signal: null,
+      error: undefined,
+    } as ReturnType<typeof spawnSync>);
+
+    expect(runGit(["status"])).toBeUndefined();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/git/tsconfig.json
+++ b/packages/git/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/packages/git/vitest.config.ts
+++ b/packages/git/vitest.config.ts
@@ -1,0 +1,22 @@
+import { createRequire } from "node:module";
+
+import { defineConfig } from "vitest/config";
+
+const require = createRequire(import.meta.url);
+
+export default defineConfig({
+  test: {
+    include: ["./test/**/*.test.ts"],
+    setupFiles: [require.resolve("allure-vitest/setup")],
+    reporters: [
+      "default",
+      [
+        "allure-vitest/reporter",
+        {
+          resultsDir: "./out/allure-results",
+          globalLabels: [{ name: "module", value: "git" }],
+        },
+      ],
+    ],
+  },
+});

--- a/packages/plugin-testops/README.md
+++ b/packages/plugin-testops/README.md
@@ -78,6 +78,8 @@ The plugin accepts the following options:
 | `endpoint`         | TestOps API endpoint                                                       | `string`  | `undefined`     |
 | `projectId`        | TestOps project ID                                                         | `string`  | `undefined`     |
 | `autocloseLaunch`  | When `true` (default), the launch is closed automatically when the plugin finishes; set to `false` to keep the launch open | `boolean` | `true`          |
+| `gitFlow`          | When `true`, collect Git metadata for TestOps Git Flow on CI uploads (opt-in)                                 | `boolean` | `false`         |
+| `ancestorLimit`    | How many ancestor commits to attach to the launch for history linking in TestOps | `number`  | `100`           |
 
 ### Using options from environment variables
 
@@ -90,5 +92,7 @@ The plugin automatically reads the following environment variables and uses them
 | `ALLURE_ENDPOINT` | `endpoint` |
 | `ALLURE_LAUNCH_NAME` | `launchName` |
 | `ALLURE_LAUNCH_TAGS` | `launchTags` |
+| `ALLURE_GIT_FLOW` | `gitFlow` |
+| `ALLURE_GIT_ANCESTOR_LIMIT` | `ancestorLimit` |
 
 `ALLURE_TESTOPS_ENABLED` and `CI` are not configuration options: they only control whether upload runs when no CI is detected. See [CI and local runs](#ci-and-local-runs).

--- a/packages/plugin-testops/package.json
+++ b/packages/plugin-testops/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@allurereport/ci": "workspace:*",
     "@allurereport/core-api": "workspace:*",
+    "@allurereport/git": "workspace:*",
     "@allurereport/plugin-api": "workspace:*",
     "@allurereport/reader-api": "workspace:*",
     "@allurereport/service": "workspace:*",

--- a/packages/plugin-testops/src/client.ts
+++ b/packages/plugin-testops/src/client.ts
@@ -16,6 +16,7 @@ import { chunk } from "lodash-es";
 import pLimit from "p-limit";
 import { bold } from "yoctocolors";
 
+import type { LaunchGitContextDto } from "./gitFlow/index.js";
 import { Logger } from "./logger.js";
 import type {
   AttachmentForUpload,
@@ -220,7 +221,7 @@ export class TestOpsClient {
     this.#logger.verbose(`CI upload stopped (status: ${status})`);
   }
 
-  async createLaunch(launchName: string, launchTags: string[]) {
+  async createLaunch(launchName: string, launchTags: string[], gitContext?: LaunchGitContextDto) {
     this.#logger.verbose("Creating launch…");
     const data = await this.#client.post<TestOpsLaunch>("/api/launch", {
       body: {
@@ -229,6 +230,7 @@ export class TestOpsClient {
         autoclose: true,
         external: true,
         tags: launchTags.map((tag) => ({ name: tag })),
+        ...(gitContext ? { gitContext } : {}),
       },
     });
 

--- a/packages/plugin-testops/src/gitFlow/LaunchGitFlow.ts
+++ b/packages/plugin-testops/src/gitFlow/LaunchGitFlow.ts
@@ -1,0 +1,100 @@
+import type { CiDescriptor } from "@allurereport/core-api";
+import { collectGitFacts, isGitAvailable } from "@allurereport/git";
+
+import type { Logger } from "../logger.js";
+import { buildGitFlowContext, shouldAttachGitFlow } from "./context.js";
+import { projectLaunchGitContext, type ClassifiedGitFlowContext } from "./projection.js";
+import type { GitFlowContext, LaunchGitContextDto } from "./types.js";
+
+export type LaunchGitFlowParams = {
+  ci: CiDescriptor;
+  gitFlow: boolean;
+  ancestorLimit: number;
+  logger: Logger;
+};
+
+export class LaunchGitFlow {
+  readonly #ci: CiDescriptor;
+  readonly #gitFlow: boolean;
+  readonly #ancestorLimit: number;
+  readonly #logger: Logger;
+
+  constructor(params: LaunchGitFlowParams) {
+    this.#ci = params.ci;
+    this.#gitFlow = params.gitFlow;
+    this.#ancestorLimit = params.ancestorLimit;
+    this.#logger = params.logger;
+  }
+
+  resolve(): LaunchGitContextDto | undefined {
+    if (!shouldAttachGitFlow(this.#gitFlow)) {
+      return undefined;
+    }
+
+    if (!isGitAvailable()) {
+      this.#logger.warn("git CLI is not available; continuing upload without git context");
+      return undefined;
+    }
+
+    const facts = collectGitFacts({ ancestorLimit: this.#ancestorLimit });
+    const gitFlowContext = buildGitFlowContext({
+      ci: this.#ci,
+      facts,
+      ancestorLimit: this.#ancestorLimit,
+    });
+
+    if (!gitFlowContext) {
+      this.#logger.warn("Git Flow metadata could not be collected; continuing upload without git context");
+      return undefined;
+    }
+
+    const classified = this.#classify(gitFlowContext);
+
+    if (!classified) {
+      this.#logger.warn(
+        "Pull request git context is incomplete (missing source or target branch); continuing upload without git context",
+      );
+      return undefined;
+    }
+
+    const launchGitContext = projectLaunchGitContext(classified, this.#ci);
+
+    if (!launchGitContext) {
+      this.#logger.warn("Git provider is not supported by TestOps; continuing upload without git context");
+      return undefined;
+    }
+
+    return launchGitContext;
+  }
+
+  #classify(context: GitFlowContext): ClassifiedGitFlowContext | undefined {
+    if (context.pullRequest) {
+      const sourceBranch = context.branch;
+      const targetBranch = context.targetBranch;
+
+      if (!sourceBranch || !targetBranch) {
+        return undefined;
+      }
+
+      return {
+        kind: "pull_request",
+        context,
+        sourceBranch,
+        targetBranch,
+      };
+    }
+
+    if (context.branch) {
+      return {
+        kind: "branch",
+        context,
+        branch: context.branch,
+      };
+    }
+
+    return {
+      kind: "standalone",
+      context,
+    };
+  }
+}

--- a/packages/plugin-testops/src/gitFlow/context.ts
+++ b/packages/plugin-testops/src/gitFlow/context.ts
@@ -10,6 +10,12 @@ export type BuildGitFlowContextParams = {
 
 export const shouldAttachGitFlow = (gitFlow: boolean): boolean => gitFlow;
 
+const nonBlank = (value?: string): string | undefined => {
+  const trimmed = value?.trim();
+
+  return trimmed || undefined;
+};
+
 /**
  * Merges CI descriptor git fields, git facts, and CiDescriptor fallbacks into one Launch Git Context input.
  * Precedence: repository slug from `ci.repository`, else `ci.repoName`; branch from CI, else git HEAD, else job branch.
@@ -21,22 +27,23 @@ export const buildGitFlowContext = (params: BuildGitFlowContextParams): GitFlowC
     return undefined;
   }
 
-  const repository = ci.repository ?? (ci.repoName ? { slug: ci.repoName } : undefined);
+  const fallbackRepoName = nonBlank(ci.repoName);
+  const repository = ci.repository?.slug ? ci.repository : fallbackRepoName ? { slug: fallbackRepoName } : undefined;
 
   if (!repository?.slug) {
     return undefined;
   }
 
   const provider: GitProvider = ci.provider ?? GitProvider.Other;
-  const branch = ci.sourceBranch ?? facts.branch ?? ci.jobRunBranch ?? undefined;
-  const targetBranch = ci.targetBranch || undefined;
+  const branch = nonBlank(ci.sourceBranch) ?? nonBlank(facts.branch) ?? nonBlank(ci.jobRunBranch);
+  const targetBranch = nonBlank(ci.targetBranch);
   const pullRequest = ci.pullRequest;
 
   return {
     provider,
     repository,
     commit: facts.commit,
-    branch: branch || undefined,
+    branch,
     targetBranch,
     pullRequest,
     firstParentAncestors: facts.firstParentAncestors,

--- a/packages/plugin-testops/src/gitFlow/context.ts
+++ b/packages/plugin-testops/src/gitFlow/context.ts
@@ -1,0 +1,46 @@
+import { GitProvider, type CiDescriptor, type GitFacts } from "@allurereport/core-api";
+
+import type { GitFlowContext } from "./types.js";
+
+export type BuildGitFlowContextParams = {
+  ci: CiDescriptor;
+  facts?: GitFacts;
+  ancestorLimit: number;
+};
+
+export const shouldAttachGitFlow = (gitFlow: boolean): boolean => gitFlow;
+
+/**
+ * Merges CI descriptor git fields, git facts, and CiDescriptor fallbacks into one Launch Git Context input.
+ * Precedence: repository slug from `ci.repository`, else `ci.repoName`; branch from CI, else git HEAD, else job branch.
+ */
+export const buildGitFlowContext = (params: BuildGitFlowContextParams): GitFlowContext | undefined => {
+  const { ci, facts, ancestorLimit } = params;
+
+  if (!facts?.commit) {
+    return undefined;
+  }
+
+  const repository = ci.repository ?? (ci.repoName ? { slug: ci.repoName } : undefined);
+
+  if (!repository?.slug) {
+    return undefined;
+  }
+
+  const provider: GitProvider = ci.provider ?? GitProvider.Other;
+  const branch = ci.sourceBranch ?? facts.branch ?? ci.jobRunBranch ?? undefined;
+  const targetBranch = ci.targetBranch || undefined;
+  const pullRequest = ci.pullRequest;
+
+  return {
+    provider,
+    repository,
+    commit: facts.commit,
+    branch: branch || undefined,
+    targetBranch,
+    pullRequest,
+    firstParentAncestors: facts.firstParentAncestors,
+    ancestorLimit,
+    localState: facts.localState,
+  };
+};

--- a/packages/plugin-testops/src/gitFlow/index.ts
+++ b/packages/plugin-testops/src/gitFlow/index.ts
@@ -1,0 +1,17 @@
+export type {
+  GitFlowContext,
+  GitProviderType,
+  LaunchGitBranchDto,
+  LaunchGitCommitDto,
+  LaunchGitContextDto,
+  LaunchGitContextType,
+  LaunchGitPullRequestDto,
+  LaunchGitRepositoryDto,
+  LaunchPullRequestGitflowMetadata,
+  ResolvedGitFlowOptions,
+  LaunchStandaloneGitflowMetadata,
+} from "./types.js";
+
+export { LaunchGitFlow } from "./LaunchGitFlow.js";
+export type { LaunchGitFlowParams } from "./LaunchGitFlow.js";
+export { resolveGitFlowOptions } from "./options.js";

--- a/packages/plugin-testops/src/gitFlow/options.ts
+++ b/packages/plugin-testops/src/gitFlow/options.ts
@@ -1,0 +1,59 @@
+import { env } from "node:process";
+
+import { DEFAULT_ANCESTOR_LIMIT } from "@allurereport/git";
+
+import type { TestOpsPluginOptions } from "../model.js";
+import type { ResolvedGitFlowOptions } from "./types.js";
+
+const parseEnvBool = (value?: string): boolean | undefined => {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized === "true" || normalized === "1" || normalized === "yes") {
+    return true;
+  }
+
+  if (normalized === "false" || normalized === "0" || normalized === "no") {
+    return false;
+  }
+
+  return undefined;
+};
+
+const resolveGitFlow = (options: TestOpsPluginOptions): boolean => {
+  if (options.gitFlow === true) {
+    return true;
+  }
+
+  if (options.gitFlow === false) {
+    return false;
+  }
+
+  return parseEnvBool(env.ALLURE_GIT_FLOW) ?? false;
+};
+
+const parseAncestorLimit = (value?: string | number): number => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+
+  if (typeof value === "string" && value !== "") {
+    const parsed = Number(value);
+
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed);
+    }
+  }
+
+  return DEFAULT_ANCESTOR_LIMIT;
+};
+
+export const resolveGitFlowOptions = (options: TestOpsPluginOptions): ResolvedGitFlowOptions => {
+  return {
+    gitFlow: resolveGitFlow(options),
+    ancestorLimit: parseAncestorLimit(options.ancestorLimit ?? env.ALLURE_GIT_ANCESTOR_LIMIT),
+  };
+};

--- a/packages/plugin-testops/src/gitFlow/projection.ts
+++ b/packages/plugin-testops/src/gitFlow/projection.ts
@@ -1,0 +1,311 @@
+import { GitProvider, type CiDescriptor } from "@allurereport/core-api";
+
+import type {
+  GitFlowContext,
+  GitProviderType,
+  LaunchGitBranchDto,
+  LaunchGitContextDto,
+  LaunchPullRequestGitflowMetadata,
+  LaunchStandaloneGitflowMetadata,
+} from "./types.js";
+
+export type ClassifiedPullRequestGitFlowContext = {
+  kind: "pull_request";
+  context: GitFlowContext;
+  sourceBranch: string;
+  targetBranch: string;
+};
+
+export type ClassifiedBranchGitFlowContext = {
+  kind: "branch";
+  context: GitFlowContext;
+  branch: string;
+};
+
+export type ClassifiedStandaloneGitFlowContext = {
+  kind: "standalone";
+  context: GitFlowContext;
+};
+
+export type ClassifiedGitFlowContext =
+  | ClassifiedPullRequestGitFlowContext
+  | ClassifiedBranchGitFlowContext
+  | ClassifiedStandaloneGitFlowContext;
+
+// --- Provider resolution (internal adapter) ---
+
+const mapProvider = (provider: GitProvider): GitProviderType | undefined => {
+  switch (provider) {
+    case GitProvider.Github:
+      return "github";
+    case GitProvider.Gitlab:
+      return "gitlab";
+    case GitProvider.Bitbucket:
+      return "bitbucket";
+    default:
+      return undefined;
+  }
+};
+
+const hostMatchesProvider = (host: string, providerType: GitProviderType): boolean => {
+  switch (providerType) {
+    case "github":
+      return host === "github.com" || host.endsWith(".github.com") || host.startsWith("github.");
+    case "gitlab":
+      return host === "gitlab.com" || host.endsWith(".gitlab.com") || host.startsWith("gitlab.");
+    case "bitbucket":
+      return host === "bitbucket.org" || host.endsWith(".bitbucket.org") || host.startsWith("bitbucket.");
+    default:
+      return false;
+  }
+};
+
+const inferProviderTypeFromUrl = (url?: string): GitProviderType | undefined => {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+
+    for (const providerType of ["github", "gitlab", "bitbucket"] as const) {
+      if (hostMatchesProvider(host, providerType)) {
+        return providerType;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+};
+
+const resolveProviderType = (context: GitFlowContext): GitProviderType | undefined =>
+  mapProvider(context.provider) ?? inferProviderTypeFromUrl(context.repository.url);
+
+// --- URL templates (internal adapter) ---
+
+const stripGitSuffix = (url: string): string => url.replace(/\.git\/?$/i, "");
+
+const buildRepositoryUrl = (
+  providerType: GitProviderType,
+  slug: string,
+  repositoryUrl?: string,
+): string | undefined => {
+  if (repositoryUrl) {
+    return repositoryUrl;
+  }
+
+  if (providerType === "github") {
+    return `https://github.com/${slug}.git`;
+  }
+
+  if (providerType === "gitlab") {
+    return `https://gitlab.com/${slug}`;
+  }
+
+  if (providerType === "bitbucket") {
+    return `https://bitbucket.org/${slug}.git`;
+  }
+
+  return undefined;
+};
+
+const buildRepositoryWebUrl = (
+  providerType: GitProviderType,
+  slug: string,
+  repositoryUrl?: string,
+): string | undefined => {
+  if (repositoryUrl) {
+    return stripGitSuffix(repositoryUrl);
+  }
+
+  if (providerType === "github") {
+    return `https://github.com/${slug}`;
+  }
+
+  if (providerType === "gitlab") {
+    return `https://gitlab.com/${slug}`;
+  }
+
+  if (providerType === "bitbucket") {
+    return `https://bitbucket.org/${slug}`;
+  }
+
+  return repositoryUrl;
+};
+
+const buildCommitUrl = (
+  repoWebUrl: string | undefined,
+  hash: string,
+  providerType: GitProviderType,
+): string | undefined => {
+  if (!repoWebUrl) {
+    return undefined;
+  }
+
+  if (providerType === "github") {
+    return `${repoWebUrl}/commit/${hash}`;
+  }
+
+  if (providerType === "gitlab") {
+    return `${repoWebUrl}/-/commit/${hash}`;
+  }
+
+  return `${repoWebUrl}/commits/${hash}`;
+};
+
+const buildBranchUrl = (
+  repoWebUrl: string | undefined,
+  branchName: string,
+  providerType: GitProviderType,
+): string | undefined => {
+  if (!repoWebUrl) {
+    return undefined;
+  }
+
+  if (providerType === "github") {
+    return `${repoWebUrl}/tree/${branchName}`;
+  }
+
+  if (providerType === "gitlab") {
+    return `${repoWebUrl}/-/tree/${branchName}`;
+  }
+
+  return `${repoWebUrl}/branch/${branchName}`;
+};
+
+const buildPullRequestUrl = (
+  repoWebUrl: string | undefined,
+  externalId: string,
+  providerType: GitProviderType,
+  pullRequestUrl?: string,
+): string | undefined => {
+  if (pullRequestUrl) {
+    return pullRequestUrl;
+  }
+
+  if (!repoWebUrl) {
+    return undefined;
+  }
+
+  if (providerType === "github") {
+    return `${repoWebUrl}/pull/${externalId}`;
+  }
+
+  if (providerType === "gitlab") {
+    return `${repoWebUrl}/-/merge_requests/${externalId}`;
+  }
+
+  return `${repoWebUrl}/pull-requests/${externalId}`;
+};
+
+// --- Wire projection (public interface) ---
+
+const toStandaloneMetadata = (
+  localState?: GitFlowContext["localState"],
+): LaunchStandaloneGitflowMetadata | undefined => {
+  if (!localState) {
+    return undefined;
+  }
+
+  return {
+    hasUncommittedChanges: localState.uncommittedChanges,
+    isUnpublishedCommit: localState.unpublishedCommit,
+    isUnpublishedBranch: localState.unpublishedBranch,
+  };
+};
+
+const toPullRequestMetadata = (ci?: CiDescriptor): LaunchPullRequestGitflowMetadata | undefined => {
+  if (!ci?.jobRunUid && !ci?.jobRunName) {
+    return undefined;
+  }
+
+  return {
+    workflowRunId: ci.jobRunUid || undefined,
+    workflowRunName: ci.jobRunName || undefined,
+  };
+};
+
+const toBranchDto = (
+  name: string,
+  providerType: GitProviderType,
+  repoWebUrl: string | undefined,
+): LaunchGitBranchDto => ({
+  name,
+  url: buildBranchUrl(repoWebUrl, name, providerType),
+});
+
+const buildRepositoryAndCommit = (context: GitFlowContext, providerType: GitProviderType) => {
+  const repositoryUrl = buildRepositoryUrl(providerType, context.repository.slug, context.repository.url);
+  const repoWebUrl = buildRepositoryWebUrl(providerType, context.repository.slug, repositoryUrl);
+  const lineage = context.firstParentAncestors.length > 0 ? context.firstParentAncestors : undefined;
+
+  return {
+    repository: {
+      providerType,
+      name: context.repository.slug,
+      url: repositoryUrl,
+    },
+    commit: {
+      hash: context.commit,
+      url: buildCommitUrl(repoWebUrl, context.commit, providerType),
+      lineage,
+    },
+    repoWebUrl,
+  };
+};
+
+/** Maps a classified Git Flow context to the TestOps launch write payload. */
+export const projectLaunchGitContext = (
+  classified: ClassifiedGitFlowContext,
+  ci?: CiDescriptor,
+): LaunchGitContextDto | undefined => {
+  const context = classified.context;
+  const providerType = resolveProviderType(context);
+
+  if (!providerType) {
+    return undefined;
+  }
+
+  const { repository, commit, repoWebUrl } = buildRepositoryAndCommit(context, providerType);
+
+  if (classified.kind === "pull_request") {
+    const { pullRequest } = context;
+
+    if (!pullRequest) {
+      return undefined;
+    }
+
+    return {
+      contextType: "pull_request",
+      repository,
+      commit,
+      pullRequest: {
+        externalId: pullRequest.id,
+        title: pullRequest.title,
+        url: buildPullRequestUrl(repoWebUrl, pullRequest.id, providerType, pullRequest.url),
+        sourceBranch: toBranchDto(classified.sourceBranch, providerType, repoWebUrl),
+        targetBranch: toBranchDto(classified.targetBranch, providerType, repoWebUrl),
+      },
+      metadata: toPullRequestMetadata(ci),
+    };
+  }
+
+  if (classified.kind === "branch") {
+    return {
+      contextType: "branch",
+      repository,
+      commit,
+      branch: toBranchDto(classified.branch, providerType, repoWebUrl),
+      metadata: toStandaloneMetadata(context.localState),
+    };
+  }
+
+  return {
+    contextType: "standalone",
+    repository,
+    commit,
+    metadata: toStandaloneMetadata(context.localState),
+  };
+};

--- a/packages/plugin-testops/src/gitFlow/projection.ts
+++ b/packages/plugin-testops/src/gitFlow/projection.ts
@@ -298,7 +298,6 @@ export const projectLaunchGitContext = (
       repository,
       commit,
       branch: toBranchDto(classified.branch, providerType, repoWebUrl),
-      metadata: toStandaloneMetadata(context.localState),
     };
   }
 

--- a/packages/plugin-testops/src/gitFlow/types.ts
+++ b/packages/plugin-testops/src/gitFlow/types.ts
@@ -1,0 +1,72 @@
+import type { GitLocalState, GitProvider, GitPullRequestRef, GitRepositoryRef } from "@allurereport/core-api";
+
+export type LaunchGitContextType = "branch" | "standalone" | "pull_request";
+
+/** Matches TestOps {@code GitProviderType} — no {@code other}. */
+export type GitProviderType = "github" | "gitlab" | "bitbucket";
+
+export type ResolvedGitFlowOptions = {
+  gitFlow: boolean;
+  ancestorLimit: number;
+};
+
+export interface LaunchGitRepositoryDto {
+  providerType: GitProviderType;
+  name: string;
+  url?: string;
+}
+
+export interface LaunchGitCommitDto {
+  hash: string;
+  url?: string;
+  /** First-parent ancestors, newest first; excludes current {@link hash}. */
+  lineage?: string[];
+}
+
+export interface LaunchGitBranchDto {
+  name: string;
+  url?: string;
+}
+
+export interface LaunchGitPullRequestDto {
+  externalId: string;
+  title?: string;
+  url?: string;
+  sourceBranch: LaunchGitBranchDto;
+  targetBranch: LaunchGitBranchDto;
+}
+
+export interface LaunchStandaloneGitflowMetadata {
+  hasUncommittedChanges?: boolean;
+  isUnpublishedCommit?: boolean;
+  isUnpublishedBranch?: boolean;
+}
+
+export interface LaunchPullRequestGitflowMetadata {
+  workflowRunId?: string;
+  workflowRunName?: string;
+}
+
+/** `gitContext` on `POST /api/launch` — mirrors TestOps {@code LaunchGitContextDto}. */
+export interface LaunchGitContextDto {
+  contextType: LaunchGitContextType;
+  repository: LaunchGitRepositoryDto;
+  commit: LaunchGitCommitDto;
+  branch?: LaunchGitBranchDto;
+  pullRequest?: LaunchGitPullRequestDto;
+  metadata?: LaunchStandaloneGitflowMetadata | LaunchPullRequestGitflowMetadata;
+}
+
+/** CI hints + git facts before mapping to {@link LaunchGitContextDto}. */
+export interface GitFlowContext {
+  provider: GitProvider;
+  repository: GitRepositoryRef;
+  commit: string;
+  branch?: string;
+  targetBranch?: string;
+  pullRequest?: GitPullRequestRef;
+  /** First-parent ancestors of `commit`, newest first; does not include `commit`. */
+  firstParentAncestors: string[];
+  ancestorLimit: number;
+  localState?: GitLocalState;
+}

--- a/packages/plugin-testops/src/model.ts
+++ b/packages/plugin-testops/src/model.ts
@@ -233,6 +233,10 @@ export type TestOpsUploaderOptions = {
   launchName: string;
   launchTags: string[];
   autocloseLaunch?: boolean;
+  /** When false, Git Flow metadata is never collected or sent. Default: false */
+  gitFlow?: boolean;
+  /** First-parent ancestor limit (server N). Default: 100 */
+  ancestorLimit?: number;
   filter?: (testResult: TestResult) => boolean;
   limit?: number;
 };

--- a/packages/plugin-testops/src/plugin.ts
+++ b/packages/plugin-testops/src/plugin.ts
@@ -8,6 +8,7 @@ import { uniqBy, stubTrue } from "lodash-es";
 import { bold } from "yoctocolors";
 
 import { TestOpsClient } from "./client.js";
+import { LaunchGitFlow, resolveGitFlowOptions } from "./gitFlow/index.js";
 import { Logger } from "./logger.js";
 import type { TestOpsPluginTestResult, TestOpsPluginOptions, UploadCategory } from "./model.js";
 import {
@@ -31,6 +32,8 @@ export class TestOpsPlugin implements Plugin {
   #launchTags: string[] = [];
   #uploadedTestResultsIds: Set<string> = new Set();
   #autocloseLaunch: boolean = false;
+  // @ts-expect-error - if gitFlow is not initialized it will not be used
+  #gitFlow: LaunchGitFlow;
 
   constructor(readonly options: TestOpsPluginOptions) {
     if (isLocalCiDescriptor(this.#ci) && !this.isOverridenByEnv) {
@@ -62,6 +65,14 @@ export class TestOpsPlugin implements Plugin {
     }
 
     this.#autocloseLaunch = autocloseLaunch;
+    const gitFlowOptions = resolveGitFlowOptions(options);
+
+    this.#gitFlow = new LaunchGitFlow({
+      ci: this.#ci,
+      gitFlow: gitFlowOptions.gitFlow,
+      ancestorLimit: gitFlowOptions.ancestorLimit,
+      logger: this.#logger,
+    });
 
     if (!accessToken) {
       this.#logger.warn(
@@ -438,7 +449,9 @@ export class TestOpsPlugin implements Plugin {
   }
 
   async #startUpload() {
-    await this.#client.createLaunch(this.#launchName, this.#launchTags);
+    const launchGitContext = this.#gitFlow.resolve();
+
+    await this.#client.createLaunch(this.#launchName, this.#launchTags, launchGitContext);
 
     await this.#client.startUpload(this.#ci!);
   }

--- a/packages/plugin-testops/test/client.test.ts
+++ b/packages/plugin-testops/test/client.test.ts
@@ -181,10 +181,6 @@ describe("testops http client", () => {
 
     it("should return launch url when launch is created", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -207,10 +203,6 @@ describe("testops http client", () => {
   describe("startUpload", () => {
     it("should throw an error when launch hasn't been created before", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         return Promise.resolve({ data: {} });
       });
 
@@ -226,10 +218,6 @@ describe("testops http client", () => {
 
     it("should call /api/upload/start with ci metadata", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -269,9 +257,6 @@ describe("testops http client", () => {
   describe("stopUpload", () => {
     it("should throw an error when upload hasn't been started before", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
         return Promise.resolve({ data: {} });
       });
 
@@ -286,10 +271,6 @@ describe("testops http client", () => {
 
     it("should call /api/upload/stop after startUpload", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -333,10 +314,6 @@ describe("testops http client", () => {
   describe("createLaunch", () => {
     it("should create launch using direct access token auth", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -368,6 +345,45 @@ describe("testops http client", () => {
         }),
       );
     });
+
+    it("should include gitContext on /api/launch when provided", async () => {
+      const gitContext = {
+        contextType: "standalone" as const,
+        repository: { providerType: "github" as const, name: "org/repo" },
+        commit: { hash: "a".repeat(40) },
+      };
+
+      AxiosMock.post.mockImplementation((url: string) => {
+        if (url === "/api/launch") {
+          return Promise.resolve({ data: fixtures.launch });
+        }
+
+        return Promise.resolve({ data: {} });
+      });
+
+      const client = new TestOpsClient({
+        accessToken: fixtures.accessToken,
+        projectId: fixtures.projectId,
+        baseUrl: fixtures.endpoint,
+      });
+
+      await client.createLaunch(fixtures.launchName, fixtures.launchTags, gitContext);
+
+      expect(AxiosMock.post).toHaveBeenCalledWith(
+        "/api/launch",
+        expect.objectContaining({
+          name: fixtures.launchName,
+          projectId: fixtures.projectId,
+          autoclose: true,
+          external: true,
+          tags: fixtures.launchTags.map((tag) => ({ name: tag })),
+          gitContext,
+        }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: `api-token ${fixtures.accessToken}` }),
+        }),
+      );
+    });
   });
 
   describe("createSession", () => {
@@ -384,10 +400,6 @@ describe("testops http client", () => {
 
     it("should create a session for a current launch with empty environment by default", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -424,10 +436,6 @@ describe("testops http client", () => {
 
     it("should pass environment variables as key-value pairs to the session", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -481,10 +489,6 @@ describe("testops http client", () => {
 
     it("should throw an error when launch hasn't been created before", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         return Promise.resolve({ data: {} });
       });
 
@@ -510,10 +514,6 @@ describe("testops http client", () => {
       ];
 
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -581,10 +581,6 @@ describe("testops http client", () => {
 
     it("should throw an error when launch hasn't been created before", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         return Promise.resolve({ data: {} });
       });
 
@@ -605,10 +601,6 @@ describe("testops http client", () => {
 
     it("should upload attachments to /api/launch/attachment", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -650,10 +642,6 @@ describe("testops http client", () => {
 
     it("should skip attachments when resolver returns null", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -704,10 +692,6 @@ describe("testops http client", () => {
 
     it("should throw an error when launch hasn't been created before", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         return Promise.resolve({ data: {} });
       });
 
@@ -722,10 +706,6 @@ describe("testops http client", () => {
 
     it("should post errors to /api/launch/error/bulk", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -783,10 +763,6 @@ describe("testops http client", () => {
 
     it("should resolve attachments and upload them", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -837,10 +813,6 @@ describe("testops http client", () => {
 
     it("should post test results using uploader DTO shape (with environment, normalized category externalId)", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -935,10 +907,6 @@ describe("testops http client", () => {
       const limit = 2;
 
       AxiosMock.post.mockImplementation(async (url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return { data: fixtures.launch };
         }
@@ -999,10 +967,6 @@ describe("testops http client", () => {
       ];
 
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -1094,10 +1058,6 @@ describe("testops http client", () => {
       ];
 
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -1175,10 +1135,6 @@ describe("testops http client", () => {
 
     it("should not create named environments when test results have no environment", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -1220,10 +1176,6 @@ describe("testops http client", () => {
       ];
 
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }
@@ -1282,10 +1234,6 @@ describe("testops http client", () => {
 
     it("should resolve fixtures and upload them", async () => {
       AxiosMock.post.mockImplementation((url: string) => {
-        if (url === "/api/uaa/oauth/token") {
-          throw new Error("Unexpected OAuth token exchange request");
-        }
-
         if (url === "/api/launch") {
           return Promise.resolve({ data: fixtures.launch });
         }

--- a/packages/plugin-testops/test/features/helpers.ts
+++ b/packages/plugin-testops/test/features/helpers.ts
@@ -82,10 +82,6 @@ export const mockRequests = () => {
       return createLaunchCategoriesBulkRequest(url, data, config);
     }
 
-    if (url === "/api/uaa/oauth/token") {
-      throw new Error("Unexpected OAuth token request: direct access token auth should be used");
-    }
-
     if (url === "/api/upload/start") {
       return startUploadRequest(url, data, config);
     }

--- a/packages/plugin-testops/test/features/launch-git-flow.test.ts
+++ b/packages/plugin-testops/test/features/launch-git-flow.test.ts
@@ -1,7 +1,8 @@
 import { detect } from "@allurereport/ci";
-import { GitProvider, type CiDescriptor } from "@allurereport/core-api";
+import { CiType, GitProvider, type CiDescriptor } from "@allurereport/core-api";
 import { collectGitFacts, isGitAvailable } from "@allurereport/git";
 import type { AllureStore, PluginContext } from "@allurereport/plugin-api";
+import { attachment, step } from "allure-js-commons";
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -52,7 +53,7 @@ const fixtures = {
 };
 
 const githubCi = {
-  type: "github",
+  type: CiType.Github,
   repoName: "myrepo",
   jobRunBranch: "feature",
   jobUid: "job",
@@ -155,6 +156,35 @@ describe("Launch git flow", () => {
     });
   });
 
+  it("does not send standalone metadata on branch context", async () => {
+    const commit = "a".repeat(40);
+
+    (detect as Mock).mockReturnValue({
+      ...githubCi,
+      provider: GitProvider.Github,
+      repository: { slug: "myorg/myrepo" },
+      sourceBranch: "feature",
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      firstParentAncestors: [],
+      localState: {
+        uncommittedChanges: true,
+        unpublishedCommit: false,
+        unpublishedBranch: false,
+        detachedHead: false,
+      },
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch.mock.calls[0][2]).toMatchObject({
+      contextType: "branch",
+      branch: { name: "feature" },
+    });
+    expect(TestOpsClientMock.prototype.createLaunch.mock.calls[0][2]?.metadata).toBeUndefined();
+  });
+
   it("posts pull request git context with workflow metadata", async () => {
     const commit = "f".repeat(40);
 
@@ -231,6 +261,12 @@ describe("Launch git flow", () => {
     vi.mocked(collectGitFacts).mockReturnValue({
       commit,
       firstParentAncestors: [],
+      localState: {
+        uncommittedChanges: true,
+        unpublishedCommit: false,
+        unpublishedBranch: true,
+        detachedHead: true,
+      },
     });
 
     await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
@@ -240,8 +276,37 @@ describe("Launch git flow", () => {
     expect(gitContext).toMatchObject({
       contextType: "standalone",
       commit: { hash: commit },
+      metadata: {
+        hasUncommittedChanges: true,
+        isUnpublishedCommit: false,
+        isUnpublishedBranch: true,
+      },
     });
     expect(gitContext?.branch).toBeUndefined();
+  });
+
+  it("falls back to git facts branch when CI source branch is blank", async () => {
+    const commit = "d".repeat(40);
+
+    (detect as Mock).mockReturnValue({
+      ...githubCi,
+      provider: GitProvider.Github,
+      repository: { slug: "myorg/myrepo" },
+      sourceBranch: "",
+      jobRunBranch: "",
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      branch: "feature/from-git",
+      firstParentAncestors: [],
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch.mock.calls[0][2]).toMatchObject({
+      contextType: "branch",
+      branch: { name: "feature/from-git" },
+    });
   });
 
   it("infers gitlab provider from repository url", async () => {
@@ -260,5 +325,172 @@ describe("Launch git flow", () => {
     await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
 
     expect(TestOpsClientMock.prototype.createLaunch.mock.calls[0][2]?.repository.providerType).toBe("gitlab");
+  });
+
+  it.each([
+    {
+      name: "Amazon CodeBuild",
+      ci: {
+        ...githubCi,
+        type: CiType.Amazon,
+        provider: undefined,
+        repository: { slug: "org/amazon-repo", url: "https://github.com/org/amazon-repo" },
+        sourceBranch: "feature/amazon",
+        targetBranch: "main",
+        pullRequest: { id: "11", url: "https://github.com/org/amazon-repo/pull/11", title: "Amazon PR" },
+      },
+      expectedProviderType: "github",
+      expectedContextType: "pull_request",
+    },
+    {
+      name: "Azure Pipelines",
+      ci: {
+        ...githubCi,
+        type: CiType.Azure,
+        provider: GitProvider.Github,
+        repository: { slug: "org/azure-repo", url: "https://github.com/org/azure-repo" },
+        sourceBranch: "feature/azure",
+        targetBranch: "main",
+        pullRequest: { id: "12", url: "https://github.com/org/azure-repo/pull/12", title: "Azure PR" },
+      },
+      expectedProviderType: "github",
+      expectedContextType: "pull_request",
+    },
+    {
+      name: "Bitbucket Pipelines",
+      ci: {
+        ...githubCi,
+        type: CiType.Bitbucket,
+        provider: GitProvider.Bitbucket,
+        repository: { slug: "org/bitbucket-repo", url: "https://bitbucket.org/org/bitbucket-repo" },
+        sourceBranch: "feature/bitbucket",
+        targetBranch: "main",
+        pullRequest: {
+          id: "13",
+          url: "https://bitbucket.org/org/bitbucket-repo/pull-requests/13",
+          title: "Bitbucket PR",
+        },
+      },
+      expectedProviderType: "bitbucket",
+      expectedContextType: "pull_request",
+    },
+    {
+      name: "CircleCI",
+      ci: {
+        ...githubCi,
+        type: CiType.Circle,
+        provider: undefined,
+        repository: { slug: "org/circle-repo", url: "https://github.com/org/circle-repo" },
+        sourceBranch: "feature/circle",
+      },
+      expectedProviderType: "github",
+      expectedContextType: "branch",
+    },
+    {
+      name: "Drone",
+      ci: {
+        ...githubCi,
+        type: CiType.Drone,
+        provider: GitProvider.Gitlab,
+        repository: { slug: "org/drone-repo", url: "https://gitlab.com/org/drone-repo" },
+        sourceBranch: "feature/drone",
+        targetBranch: "main",
+        pullRequest: {
+          id: "14",
+          url: "https://gitlab.com/org/drone-repo/-/merge_requests/14",
+          title: "Drone MR",
+        },
+      },
+      expectedProviderType: "gitlab",
+      expectedContextType: "pull_request",
+    },
+    {
+      name: "GitHub Actions",
+      ci: {
+        ...githubCi,
+        type: CiType.Github,
+        provider: GitProvider.Github,
+        repository: { slug: "org/github-repo", url: "https://github.com/org/github-repo" },
+        sourceBranch: "feature/github",
+        targetBranch: "main",
+        pullRequest: { id: "15", url: "https://github.com/org/github-repo/pull/15", title: "GitHub PR" },
+      },
+      expectedProviderType: "github",
+      expectedContextType: "pull_request",
+    },
+    {
+      name: "GitLab CI/CD",
+      ci: {
+        ...githubCi,
+        type: CiType.Gitlab,
+        provider: GitProvider.Gitlab,
+        repository: { slug: "org/gitlab-repo", url: "https://gitlab.com/org/gitlab-repo" },
+        sourceBranch: "feature/gitlab",
+        targetBranch: "main",
+        pullRequest: {
+          id: "16",
+          url: "https://gitlab.com/org/gitlab-repo/-/merge_requests/16",
+          title: "GitLab MR",
+        },
+      },
+      expectedProviderType: "gitlab",
+      expectedContextType: "pull_request",
+    },
+    {
+      name: "Jenkins",
+      ci: {
+        ...githubCi,
+        type: CiType.Jenkins,
+        provider: undefined,
+        repository: { slug: "org/jenkins-repo", url: "https://github.com/org/jenkins-repo" },
+        sourceBranch: "feature/jenkins",
+        targetBranch: "main",
+        pullRequest: { id: "17", url: "https://github.com/org/jenkins-repo/pull/17", title: "Jenkins PR" },
+      },
+      expectedProviderType: "github",
+      expectedContextType: "pull_request",
+    },
+  ] as const)("projects TestOps git context for $name", async ({ ci, expectedProviderType, expectedContextType }) => {
+    const commit = "e".repeat(40);
+    const ciDescriptor = ci as CiDescriptor;
+
+    (detect as Mock).mockReturnValue(ciDescriptor);
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      firstParentAncestors: ["f".repeat(40)],
+    });
+
+    const gitContext = await step(`project ${ciDescriptor.type} CI descriptor to TestOps git context`, async () => {
+      await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+      const projected = TestOpsClientMock.prototype.createLaunch.mock.calls[0][2];
+
+      await attachment(
+        "projected git context",
+        JSON.stringify({ ci: ciDescriptor, gitContext: projected }, null, 2),
+        "application/json",
+      );
+
+      return projected;
+    });
+
+    await step("verify TestOps launch git context DTO shape", async () => {
+      expect(gitContext).toMatchObject({
+        contextType: expectedContextType,
+        repository: { providerType: expectedProviderType },
+        commit: { hash: commit, lineage: ["f".repeat(40)] },
+      });
+
+      if (expectedContextType === "pull_request") {
+        expect(gitContext?.pullRequest).toMatchObject({
+          externalId: ciDescriptor.pullRequest?.id,
+          sourceBranch: { name: ciDescriptor.sourceBranch },
+          targetBranch: { name: ciDescriptor.targetBranch },
+        });
+      } else {
+        expect(gitContext?.branch).toMatchObject({ name: ciDescriptor.sourceBranch });
+        expect(gitContext?.pullRequest).toBeUndefined();
+      }
+    });
   });
 });

--- a/packages/plugin-testops/test/features/launch-git-flow.test.ts
+++ b/packages/plugin-testops/test/features/launch-git-flow.test.ts
@@ -1,0 +1,264 @@
+import { detect } from "@allurereport/ci";
+import { GitProvider, type CiDescriptor } from "@allurereport/core-api";
+import { collectGitFacts, isGitAvailable } from "@allurereport/git";
+import type { AllureStore, PluginContext } from "@allurereport/plugin-api";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TestOpsPluginOptions } from "../../src/model.js";
+import { TestOpsPlugin } from "../../src/plugin.js";
+import { resolvePluginOptions } from "../../src/utils/index.js";
+import { AllureStoreMock, TestOpsClientMock } from "../utils.js";
+
+vi.mock("@allurereport/ci", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@allurereport/ci")>()),
+  detect: vi.fn(),
+}));
+
+vi.mock("@allurereport/git", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@allurereport/git")>();
+
+  return {
+    ...actual,
+    collectGitFacts: vi.fn(() => undefined),
+    isGitAvailable: vi.fn(() => true),
+  };
+});
+
+vi.mock("../../src/client.js", async () => {
+  const utils = await import("../utils.js");
+
+  return {
+    TestOpsClient: utils.TestOpsClientMock,
+  };
+});
+
+vi.mock("../../src/utils/index.js", async (importOriginal) => {
+  return {
+    ...(await importOriginal()),
+    resolvePluginOptions: vi.fn(),
+  };
+});
+
+const fixtures = {
+  accessToken: "test",
+  endpoint: "http://example.com",
+  projectId: "12345",
+  launchName: "Allure Report",
+  launchTags: ["t1"],
+  attachmentContent: {
+    asBuffer: async () => Buffer.from("test"),
+  },
+};
+
+const githubCi = {
+  type: "github",
+  repoName: "myrepo",
+  jobRunBranch: "feature",
+  jobUid: "job",
+  jobRunUid: "run-1",
+  jobRunName: "build",
+} as CiDescriptor;
+
+const setupPluginOptions = () => {
+  (resolvePluginOptions as Mock).mockReturnValue({
+    accessToken: fixtures.accessToken,
+    endpoint: fixtures.endpoint,
+    projectId: fixtures.projectId,
+    launchName: fixtures.launchName,
+    launchTags: fixtures.launchTags,
+  });
+};
+
+const startPlugin = async (pluginOptions: TestOpsPluginOptions) => {
+  setupPluginOptions();
+  const store = new AllureStoreMock() as unknown as AllureStore;
+  AllureStoreMock.prototype.allTestResults.mockResolvedValue([]);
+  AllureStoreMock.prototype.attachmentsByTrId.mockResolvedValue([]);
+  AllureStoreMock.prototype.attachmentContentById.mockResolvedValue(fixtures.attachmentContent);
+  AllureStoreMock.prototype.fixturesByTrId.mockResolvedValue([]);
+
+  const plugin = new TestOpsPlugin(pluginOptions);
+  await plugin.start({ reportUuid: "test-uuid" } as PluginContext, store);
+
+  return plugin;
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Launch git flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (detect as Mock).mockReturnValue(githubCi);
+    vi.mocked(isGitAvailable).mockReturnValue(true);
+  });
+
+  it("does not collect git facts when gitFlow is disabled", async () => {
+    await startPlugin({ gitFlow: false } as TestOpsPluginOptions);
+
+    expect(collectGitFacts).not.toHaveBeenCalled();
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(
+      fixtures.launchName,
+      fixtures.launchTags,
+      undefined,
+    );
+  });
+
+  it("does not attach git context when git CLI is unavailable", async () => {
+    vi.mocked(isGitAvailable).mockReturnValue(false);
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(collectGitFacts).not.toHaveBeenCalled();
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(
+      fixtures.launchName,
+      fixtures.launchTags,
+      undefined,
+    );
+  });
+
+  it("posts branch git context on createLaunch", async () => {
+    const commit = "a".repeat(40);
+    const parent = "b".repeat(40);
+
+    (detect as Mock).mockReturnValue({
+      ...githubCi,
+      provider: GitProvider.Github,
+      repository: { slug: "myorg/myrepo" },
+      sourceBranch: "feature",
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      firstParentAncestors: [parent],
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(fixtures.launchName, fixtures.launchTags, {
+      contextType: "branch",
+      repository: {
+        providerType: "github",
+        name: "myorg/myrepo",
+        url: "https://github.com/myorg/myrepo.git",
+      },
+      commit: {
+        hash: commit,
+        url: `https://github.com/myorg/myrepo/commit/${commit}`,
+        lineage: [parent],
+      },
+      branch: {
+        name: "feature",
+        url: "https://github.com/myorg/myrepo/tree/feature",
+      },
+    });
+  });
+
+  it("posts pull request git context with workflow metadata", async () => {
+    const commit = "f".repeat(40);
+
+    (detect as Mock).mockReturnValue({
+      ...githubCi,
+      jobRunUid: "run-42",
+      jobRunName: "PR CI Build",
+      provider: GitProvider.Github,
+      repository: { slug: "myorg/myrepo", url: "https://github.com/myorg/myrepo" },
+      sourceBranch: "feature/x",
+      targetBranch: "main",
+      pullRequest: { id: "7", title: "Fix things", url: "https://github.com/myorg/myrepo/pull/7" },
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      firstParentAncestors: ["a".repeat(40)],
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(
+      fixtures.launchName,
+      fixtures.launchTags,
+      expect.any(Object),
+    );
+
+    expect(TestOpsClientMock.prototype.createLaunch.mock.calls[0][2]).toMatchObject({
+      contextType: "pull_request",
+      metadata: {
+        workflowRunId: "run-42",
+        workflowRunName: "PR CI Build",
+      },
+      pullRequest: {
+        externalId: "7",
+        title: "Fix things",
+        sourceBranch: { name: "feature/x" },
+        targetBranch: { name: "main" },
+      },
+    });
+  });
+
+  it("omits git context when pull request branches are incomplete", async () => {
+    (detect as Mock).mockReturnValue({
+      ...githubCi,
+      provider: GitProvider.Github,
+      repository: { slug: "org/repo" },
+      sourceBranch: "feature",
+      pullRequest: { id: "9" },
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit: "c".repeat(40),
+      firstParentAncestors: [],
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(
+      fixtures.launchName,
+      fixtures.launchTags,
+      undefined,
+    );
+  });
+
+  it("posts standalone git context when branch and pull request are absent", async () => {
+    const commit = "c".repeat(40);
+
+    (detect as Mock).mockReturnValue({
+      type: "github",
+      repoName: "myrepo",
+      jobRunBranch: "",
+      provider: GitProvider.Github,
+      repository: { slug: "org/repo", url: "https://github.com/org/repo" },
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      firstParentAncestors: [],
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    const gitContext = TestOpsClientMock.prototype.createLaunch.mock.calls[0][2];
+
+    expect(gitContext).toMatchObject({
+      contextType: "standalone",
+      commit: { hash: commit },
+    });
+    expect(gitContext?.branch).toBeUndefined();
+  });
+
+  it("infers gitlab provider from repository url", async () => {
+    const commit = "c".repeat(40);
+
+    (detect as Mock).mockReturnValue({
+      ...githubCi,
+      repository: { slug: "org/repo", url: "https://gitlab.com/org/repo" },
+      sourceBranch: "develop",
+    });
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit,
+      firstParentAncestors: [],
+    });
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch.mock.calls[0][2]?.repository.providerType).toBe("gitlab");
+  });
+});

--- a/packages/plugin-testops/test/plugin.test.ts
+++ b/packages/plugin-testops/test/plugin.test.ts
@@ -22,6 +22,16 @@ vi.mock("@allurereport/ci", async (importOriginal) => {
   };
 });
 
+vi.mock("@allurereport/git", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@allurereport/git")>();
+
+  return {
+    ...actual,
+    collectGitFacts: vi.fn(() => undefined),
+    isGitAvailable: vi.fn(() => true),
+  };
+});
+
 vi.mock("../src/client.js", async () => {
   const utils = await import("./utils.js");
 
@@ -308,7 +318,7 @@ describe("testops plugin", () => {
 
       await plugin.start({ reportName: "Test Launch" } as PluginContext, store);
 
-      expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith("Allure Report", []);
+      expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith("Allure Report", [], undefined);
       expect(TestOpsClientMock.prototype.createSession).toHaveBeenCalledTimes(1);
       expect(TestOpsClientMock.prototype.createSession).toHaveBeenCalledWith(env);
     });
@@ -331,7 +341,11 @@ describe("testops plugin", () => {
 
       await plugin.start({} as PluginContext, store);
 
-      expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith("Custom Launch", fixtures.launchTags);
+      expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(
+        "Custom Launch",
+        fixtures.launchTags,
+        undefined,
+      );
     });
 
     it("should create direct-token upload session when called from start", async () => {

--- a/packages/web-classic/src/components/Behaviors/BehaviorsList.tsx
+++ b/packages/web-classic/src/components/Behaviors/BehaviorsList.tsx
@@ -21,6 +21,7 @@ export const BehaviorsList = () => {
 
   useEffect(() => {
     setBehaviorsStatus(currentTab.value as ClassicStatus);
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
   }, [currentTab.value]);
 
   return (

--- a/packages/web-classic/src/components/Categories/CategoriesList.tsx
+++ b/packages/web-classic/src/components/Categories/CategoriesList.tsx
@@ -21,6 +21,7 @@ export const CategoriesList = () => {
 
   useEffect(() => {
     setCategoriesStatus(currentTab.value as ClassicStatus);
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
   }, [currentTab.value]);
 
   return (

--- a/packages/web-classic/src/components/Packages/PackagesList.tsx
+++ b/packages/web-classic/src/components/Packages/PackagesList.tsx
@@ -21,6 +21,7 @@ export const PackagesList = () => {
 
   useEffect(() => {
     setPackagesStatus(currentTab.value as ClassicStatus);
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
   }, [currentTab.value]);
 
   return (

--- a/packages/web-classic/src/components/Tree/index.tsx
+++ b/packages/web-classic/src/components/Tree/index.tsx
@@ -14,6 +14,7 @@ export const TreeList = () => {
 
   useEffect(() => {
     setTreeStatus(currentTab.value as ClassicStatus);
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
   }, [currentTab.value]);
 
   return (

--- a/packages/web-classic/src/index.tsx
+++ b/packages/web-classic/src/index.tsx
@@ -42,7 +42,11 @@ const App = () => {
     };
   }, []);
 
-  const ActiveComponent = useMemo(() => tabComponents[route.value.tabName] || (() => null), [route.value.tabName]);
+  const ActiveComponent = useMemo(
+    () => tabComponents[route.value.tabName] || (() => null),
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+    [route.value.tabName],
+  );
 
   if (!currentLocale.value) {
     return <PageLoader />;

--- a/packages/web-components/src/components/Menu/index.tsx
+++ b/packages/web-components/src/components/Menu/index.tsx
@@ -112,6 +112,7 @@ export const Menu = (props: {
     updatePosition();
     // @ts-ignore
     return autoUpdate(triggerRef.current, menuRef.current, updatePosition);
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
   }, [menuRef.current, triggerRef.current]);
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,6 +161,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@allurereport/git@workspace:*, @allurereport/git@workspace:packages/git":
+  version: 0.0.0-use.local
+  resolution: "@allurereport/git@workspace:packages/git"
+  dependencies:
+    "@allurereport/core-api": "workspace:*"
+    "@types/node": "npm:^20"
+    "@vitest/runner": "npm:^2"
+    "@vitest/snapshot": "npm:^2"
+    allure-vitest: "npm:^3"
+    rimraf: "npm:^6"
+    typescript: "npm:^5"
+    vitest: "npm:^4"
+  languageName: unknown
+  linkType: soft
+
 "@allurereport/monorepo@workspace:.":
   version: 0.0.0-use.local
   resolution: "@allurereport/monorepo@workspace:."
@@ -409,6 +424,7 @@ __metadata:
   dependencies:
     "@allurereport/ci": "workspace:*"
     "@allurereport/core-api": "workspace:*"
+    "@allurereport/git": "workspace:*"
     "@allurereport/plugin-api": "workspace:*"
     "@allurereport/reader-api": "workspace:*"
     "@allurereport/service": "workspace:*"
@@ -18307,7 +18323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:*, vitest@npm:^4.1.0":
+"vitest@npm:*, vitest@npm:^4, vitest@npm:^4.1.0":
   version: 4.1.8
   resolution: "vitest@npm:4.1.8"
   dependencies:


### PR DESCRIPTION
## Summary

When an Allure report is uploaded to TestOps from CI, the launch can now carry git context — repo, commit, branch, and PR when the pipeline provides it

Collection runs only in CI and only if turned it on