### PR TITLE
Disable running Allure TestOps plugin in non-CI environments by default

### DIFF
--- a/packages/plugin-testops/README.md
+++ b/packages/plugin-testops/README.md
@@ -14,6 +14,25 @@
 
 The plugin creates a new launch in Allure TestOps with all the tests data from the current report.
 
+## CI and local runs
+
+The plugin is intended to run in a **CI environment**. When a supported CI is detected, upload to TestOps starts automatically (as long as `accessToken`, `endpoint`, and `projectId` are configured).
+
+On a **local machine** (no CI detected), upload is disabled by default.
+
+To upload from your machine anyway, opt in with one of these environment variables set to a truthy value (`true` or `1`):
+
+| Environment variable       | Purpose |
+|----------------------------|---------|
+| `ALLURE_TESTOPS_ENABLED`   | Explicitly enable TestOps upload outside CI |
+| `CI`                       | Same effect; useful if your tooling already sets `CI` in non-CI workflows |
+
+Example:
+
+```shell
+ALLURE_TESTOPS_ENABLED=true allure run ...
+```
+
 ## Install
 
 Use your favorite package manager to install the package:
@@ -71,3 +90,5 @@ The plugin automatically reads the following environment variables and uses them
 | `ALLURE_ENDPOINT` | `endpoint` |
 | `ALLURE_LAUNCH_NAME` | `launchName` |
 | `ALLURE_LAUNCH_TAGS` | `launchTags` |
+
+`ALLURE_TESTOPS_ENABLED` and `CI` are not configuration options: they only control whether upload runs when no CI is detected. See [CI and local runs](#ci-and-local-runs).

--- a/packages/plugin-testops/src/plugin.ts
+++ b/packages/plugin-testops/src/plugin.ts
@@ -28,15 +28,24 @@ export class TestOpsPlugin implements Plugin {
   // @ts-expect-error - if client is not initialized it will not be used
   #client: TestOpsClient;
   /**
-   * If the plugin is enabled
+   * If the client is configured
    */
-  #enabled: boolean = false;
+  #clientConfigured: boolean = false;
   #launchName: string = "";
   #launchTags: string[] = [];
   #uploadedTestResultsIds: Set<string> = new Set();
-  #autocloseLaunch: boolean;
+  #autocloseLaunch: boolean = false;
 
   constructor(readonly options: TestOpsPluginOptions) {
+    this.#ci = detect();
+
+    if (!this.#ci || this.#ci.type === "local") {
+      this.#logger.info(
+        `plugin is disabled - no CI environment detected. To enable, set ${bold("ALLURE_TESTOPS_ENABLED")}=true or ${bold("CI")}=true.`,
+      );
+      return;
+    }
+
     const {
       accessToken,
       endpoint,
@@ -46,12 +55,10 @@ export class TestOpsPlugin implements Plugin {
       autocloseLaunch = true,
     } = resolvePluginOptions(options);
 
-    this.#ci = detect();
-
     // don't initialize the client when some options are missing
     // we can' throw an error here because it would break the report execution flow
     if ([accessToken, endpoint, projectId].every(Boolean)) {
-      this.#enabled = true;
+      this.#clientConfigured = true;
       this.#client = new TestOpsClient({
         baseUrl: endpoint,
         accessToken,
@@ -82,8 +89,32 @@ export class TestOpsPlugin implements Plugin {
     }
   }
 
-  get ciMode() {
-    return this.#ci && this.#ci.type !== "local";
+  get isOverridenByEnv(): boolean {
+    const isEnabled = (value: string | undefined) => {
+      if (!value) {
+        return false;
+      }
+
+      return ["true", "1"].includes(value);
+    };
+
+    return isEnabled(env.ALLURE_TESTOPS_ENABLED) || isEnabled(env.CI);
+  }
+
+  get enabled(): boolean {
+    if (!this.#clientConfigured) {
+      return false;
+    }
+
+    if (this.isOverridenByEnv) {
+      return true;
+    }
+
+    if (!this.#ci || this.#ci.type === "local") {
+      return false;
+    }
+
+    return true;
   }
 
   async #uploadQualityGateResults(store: AllureStore) {
@@ -423,23 +454,15 @@ export class TestOpsPlugin implements Plugin {
     await this.#client.issueOauthToken();
     await this.#client.createLaunch(this.#launchName, this.#launchTags);
 
-    if (!this.ciMode) {
-      return;
-    }
-
     await this.#client.startUpload(this.#ci!);
   }
 
   async #stopUpload(status: TestStatus) {
-    if (!this.ciMode) {
-      return;
-    }
-
     await this.#client.stopUpload(this.#ci!, status);
   }
 
   async start(context: PluginContext, store: AllureStore) {
-    if (!this.#enabled) {
+    if (!this.enabled) {
       return;
     }
 
@@ -452,7 +475,7 @@ export class TestOpsPlugin implements Plugin {
   }
 
   async update(context: PluginContext, store: AllureStore) {
-    if (!this.#enabled) {
+    if (!this.enabled) {
       return;
     }
 
@@ -462,7 +485,7 @@ export class TestOpsPlugin implements Plugin {
   }
 
   async done(context: PluginContext, store: AllureStore) {
-    if (!this.#enabled) {
+    if (!this.enabled) {
       return;
     }
 
@@ -503,7 +526,7 @@ export class TestOpsPlugin implements Plugin {
   }
 
   async info(context: PluginContext, store: AllureStore) {
-    if (!this.#enabled) {
+    if (!this.enabled) {
       return undefined;
     }
 

--- a/packages/plugin-testops/test/features/helpers.ts
+++ b/packages/plugin-testops/test/features/helpers.ts
@@ -160,5 +160,6 @@ export const mockRequests = () => {
 
 export const handleBeforeEach = () => {
   vi.stubEnv("ALLURE_LOG_LEVEL", "silent");
+  vi.stubEnv("ALLURE_TESTOPS_ENABLED", "true");
   vi.clearAllMocks();
 };

--- a/packages/plugin-testops/test/features/quality-gate.test.ts
+++ b/packages/plugin-testops/test/features/quality-gate.test.ts
@@ -1,9 +1,14 @@
+import type { CiDescriptor } from "@allurereport/core-api";
 import { TestResult } from "@allurereport/core-api";
 import type { AllureStore, PluginState, QualityGateValidationResult } from "@allurereport/plugin-api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { TestOpsPlugin } from "../../src/plugin.js";
 import { handleBeforeEach, mockAllureStore, mockRequests } from "./helpers.js";
+
+vi.mock("@allurereport/ci", () => ({
+  detect: vi.fn(() => ({ type: "github" }) as CiDescriptor),
+}));
 
 beforeEach(() => {
   handleBeforeEach();

--- a/packages/plugin-testops/test/plugin.test.ts
+++ b/packages/plugin-testops/test/plugin.test.ts
@@ -88,8 +88,9 @@ const fixtures = {
 
 beforeEach(() => {
   vi.stubEnv("ALLURE_LOG_LEVEL", "silent");
+  vi.stubEnv("ALLURE_TESTOPS_ENABLED", "true");
   vi.clearAllMocks();
-  (detect as unknown as Mock).mockReturnValue({ type: "local" } as CiDescriptor);
+  (detect as unknown as Mock).mockReturnValue({ type: "github" } as CiDescriptor);
   AllureStoreMock.prototype.allEnvironmentIdentities.mockResolvedValue([]);
   AllureStoreMock.prototype.environmentIdByTrId.mockResolvedValue(undefined);
   AllureStoreMock.prototype.allGlobalErrors.mockResolvedValue([]);
@@ -188,7 +189,7 @@ describe("testops plugin", () => {
 
   describe("start", () => {
     describe("ci mode", () => {
-      it("should return true from ciMode getter when ci is detected and not local", () => {
+      it("should return true from enabled getter when ci is detected and not local", () => {
         (detect as unknown as Mock).mockReturnValue({ type: "github" } as CiDescriptor);
         (resolvePluginOptions as Mock).mockReturnValue({
           accessToken: fixtures.accessToken,
@@ -200,7 +201,7 @@ describe("testops plugin", () => {
 
         plugin = new TestOpsPlugin({} as TestOpsPluginOptions);
 
-        expect(plugin.ciMode).toBe(true);
+        expect(plugin.enabled).toBe(true);
       });
 
       it("should start upload when ci is detected (non-local)", async () => {
@@ -230,7 +231,7 @@ describe("testops plugin", () => {
     });
 
     describe("outside ci mode", () => {
-      it("should return false from ciMode getter when ci is local", () => {
+      it("should return false from enabled getter when ci is local", () => {
         (detect as unknown as Mock).mockReturnValue({ type: "local" } as CiDescriptor);
         (resolvePluginOptions as Mock).mockReturnValue({
           accessToken: fixtures.accessToken,
@@ -242,7 +243,7 @@ describe("testops plugin", () => {
 
         plugin = new TestOpsPlugin({} as TestOpsPluginOptions);
 
-        expect(plugin.ciMode).toBe(false);
+        expect(plugin.enabled).toBe(false);
       });
 
       it("should not start upload when ci is local", async () => {


### PR DESCRIPTION
Disable running Allure TestOps plugin in non-CI environment by default.
Opt-in with env variables