### PR TITLE
Fix missing nested Allure result attachments on Node 20

### DIFF
--- a/packages/directory-watcher/src/watcher.ts
+++ b/packages/directory-watcher/src/watcher.ts
@@ -72,8 +72,9 @@ const findFiles = async (
   existingResults: Set<string>,
   onNewFile: (file: string, dirent: Dirent) => Promise<void>,
   recursive: boolean,
+  maximumDepth: number = 10,
 ) => {
-  const scanDirectory = async (directory: string, isRoot: boolean): Promise<void> => {
+  const scanDirectory = async (directory: string, isRoot: boolean, remainingDepth: number): Promise<void> => {
     try {
       const dir = await opendir(directory);
 
@@ -81,8 +82,8 @@ const findFiles = async (
         const path = join(dirent.parentPath ?? dirent.path, dirent.name);
 
         if (dirent.isDirectory()) {
-          if (recursive) {
-            await scanDirectory(path, false);
+          if (recursive && remainingDepth > 0) {
+            await scanDirectory(path, false, remainingDepth - 1);
           }
           continue;
         }
@@ -111,7 +112,7 @@ const findFiles = async (
     }
   };
 
-  await scanDirectory(watchDirectory, true);
+  await scanDirectory(watchDirectory, true, maximumDepth);
 };
 
 const singleIteration = async (callback: () => Promise<void>, ...ac: AbortController[]): Promise<void> => {
@@ -188,6 +189,7 @@ const watch = (
 
 interface WatchNewFilesOptions extends WatchOptions {
   recursive?: boolean;
+  maximumDepth?: number;
   indexDelay?: number;
   ignoreInitial?: boolean;
   abortController?: AbortController;
@@ -198,14 +200,14 @@ export const newFilesInDirectoryWatcher = (
   onNewFile: (file: string, dirent: Dirent) => Promise<void>,
   options: WatchNewFilesOptions = {},
 ): Watcher => {
-  const { recursive = true, ignoreInitial = false, ...rest } = options;
+  const { recursive = true, maximumDepth = 10, ignoreInitial = false, ...rest } = options;
   const indexedFiles: Set<string> = new Set();
 
   const initialCallback = async () => {
-    await findFiles(directory, indexedFiles, ignoreInitial ? noop : onNewFile, recursive);
+    await findFiles(directory, indexedFiles, ignoreInitial ? noop : onNewFile, recursive, maximumDepth);
   };
   const iterationCallback = async () => {
-    await findFiles(directory, indexedFiles, onNewFile, recursive);
+    await findFiles(directory, indexedFiles, onNewFile, recursive, maximumDepth);
   };
 
   return watch(initialCallback, iterationCallback, iterationCallback, rest);

--- a/packages/directory-watcher/src/watcher.ts
+++ b/packages/directory-watcher/src/watcher.ts
@@ -73,34 +73,45 @@ const findFiles = async (
   onNewFile: (file: string, dirent: Dirent) => Promise<void>,
   recursive: boolean,
 ) => {
-  try {
-    const dir = await opendir(watchDirectory, { recursive });
-    for await (const dirent of dir) {
-      if (dirent.isDirectory()) {
-        continue;
-      }
+  const scanDirectory = async (directory: string, isRoot: boolean): Promise<void> => {
+    try {
+      const dir = await opendir(directory);
 
-      const path = join(dirent.parentPath ?? dirent.path, dirent.name);
-      if (existingResults.has(path)) {
-        continue;
-      }
+      for await (const dirent of dir) {
+        const path = join(dirent.parentPath ?? dirent.path, dirent.name);
 
-      try {
-        await onNewFile(path, dirent);
-        existingResults.add(path);
-      } catch (e) {
-        if (!isFileNotFoundError(e)) {
-          console.error("can't process file", path, e);
+        if (dirent.isDirectory()) {
+          if (recursive) {
+            await scanDirectory(path, false);
+          }
+          continue;
+        }
+
+        if (existingResults.has(path)) {
+          continue;
+        }
+
+        try {
+          await onNewFile(path, dirent);
+          existingResults.add(path);
+        } catch (e) {
+          if (!isFileNotFoundError(e)) {
+            console.error("can't process file", path, e);
+          }
         }
       }
+    } catch (e) {
+      if (isFileNotFoundError(e)) {
+        if (isRoot) {
+          existingResults.clear();
+        }
+        return;
+      }
+      console.error("can't read directory", e);
     }
-  } catch (e) {
-    if (isFileNotFoundError(e)) {
-      existingResults.clear();
-      return;
-    }
-    console.error("can't read directory", e);
-  }
+  };
+
+  await scanDirectory(watchDirectory, true);
 };
 
 const singleIteration = async (callback: () => Promise<void>, ...ac: AbortController[]): Promise<void> => {
@@ -273,7 +284,12 @@ const waitUntilFileStopChanging = async (
     }
     const sinceChange = now - prev.timestamp;
     if (sinceChange < minWait) {
-      await setTimeout(Math.min(0, maxWait, minWait - sinceChange + 1));
+      const maxDelay = maxWait - (now - start);
+      if (maxDelay <= 0) {
+        return false;
+      }
+      await setTimeout(Math.min(maxDelay, minWait - sinceChange + 1));
+      continue;
     }
     const current = await calculateInfo(file);
     if (!current) {

--- a/packages/directory-watcher/test/watcher.test.ts
+++ b/packages/directory-watcher/test/watcher.test.ts
@@ -272,6 +272,39 @@ describe("newFilesInDirectoryWatcher", () => {
     expect(handler).toBeCalledWith(file2, expect.any(Dirent));
     expect(handler).toBeCalledTimes(2);
   });
+
+  it("should discover every file under nested result directories during initial scan", async () => {
+    const expectedFiles: string[] = [];
+
+    for (let groupIndex = 0; groupIndex < 12; groupIndex++) {
+      const groupDirectory = join(fixturesDir, "build", "allure-results", `matrix-${groupIndex}`, "attachments");
+      await mkdir(groupDirectory, { recursive: true });
+
+      for (let fileIndex = 0; fileIndex < 25; fileIndex++) {
+        const file = join(groupDirectory, `${groupIndex}-${fileIndex}-attachment.txt`);
+        expectedFiles.push(file);
+        await writeFile(file, `attachment ${groupIndex}:${fileIndex}`, "utf8");
+      }
+    }
+
+    const seenFiles = new Set<string>();
+    const handler = vi.fn(async (file: string) => {
+      seenFiles.add(file);
+    });
+    const watcher = newFilesInDirectoryWatcher(fixturesDir, handler, {
+      indexDelay: 10_000,
+      abortController,
+    });
+
+    await watcher.initialScan();
+    await watcher.abort();
+
+    expect(handler).toBeCalledTimes(expectedFiles.length);
+    expect(seenFiles).toHaveLength(expectedFiles.length);
+    for (const file of expectedFiles) {
+      expect(seenFiles).toContain(file);
+    }
+  });
 });
 
 describe("findMatching", () => {
@@ -415,6 +448,28 @@ describe("delayedFileProcessingWatcher", () => {
     writeStream.end();
     await watcher.abort();
 
+    expect(handler).toBeCalledTimes(1);
+    const expectedPath = await realpath(file);
+    expect(handler).toBeCalledWith(expectedPath);
+  });
+
+  it("should honor processing delay on abort for stable files", async () => {
+    const handler = vi.fn();
+    const watcher = delayedFileProcessingWatcher(handler, {
+      indexDelay: 10_000,
+      minProcessingDelay: 200,
+      maxProcessingDelay: 1_000,
+      abortController,
+    });
+    const file = join(fixturesDir, "stable-file.txt");
+    await writeFile(file, "content", "utf8");
+    await watcher.addFile(file);
+
+    const startedAt = Date.now();
+    await watcher.abort();
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeGreaterThanOrEqual(100);
     expect(handler).toBeCalledTimes(1);
     const expectedPath = await realpath(file);
     expect(handler).toBeCalledWith(expectedPath);

--- a/packages/directory-watcher/test/watcher.test.ts
+++ b/packages/directory-watcher/test/watcher.test.ts
@@ -305,6 +305,58 @@ describe("newFilesInDirectoryWatcher", () => {
       expect(seenFiles).toContain(file);
     }
   });
+
+  it("should limit recursive discovery by maximum depth", async () => {
+    const firstLevelDirectory = await randomDirectory(fixturesDir, "first");
+    const secondLevelDirectory = await randomDirectory(firstLevelDirectory, "second");
+    const rootFile = await randomFile(fixturesDir, "root.txt");
+    const firstLevelFile = await randomFile(firstLevelDirectory, "first.txt");
+    const secondLevelFile = await randomFile(secondLevelDirectory, "second.txt");
+
+    const seenFiles = new Set<string>();
+    const handler = vi.fn(async (file: string) => {
+      seenFiles.add(file);
+    });
+    const watcher = newFilesInDirectoryWatcher(fixturesDir, handler, {
+      indexDelay: 10_000,
+      maximumDepth: 1,
+      abortController,
+    });
+
+    await watcher.initialScan();
+    await watcher.abort();
+
+    expect(handler).toBeCalledTimes(2);
+    expect(seenFiles).toContain(rootFile);
+    expect(seenFiles).toContain(firstLevelFile);
+    expect(seenFiles).not.toContain(secondLevelFile);
+  });
+
+  it("should use a default maximum depth of 10", async () => {
+    let currentDirectory = fixturesDir;
+    for (let depth = 1; depth <= 10; depth++) {
+      currentDirectory = await randomDirectory(currentDirectory, `level-${depth}`);
+    }
+    const depth10File = await randomFile(currentDirectory, "depth-10.txt");
+    const depth11Directory = await randomDirectory(currentDirectory, "level-11");
+    const depth11File = await randomFile(depth11Directory, "depth-11.txt");
+
+    const seenFiles = new Set<string>();
+    const handler = vi.fn(async (file: string) => {
+      seenFiles.add(file);
+    });
+    const watcher = newFilesInDirectoryWatcher(fixturesDir, handler, {
+      indexDelay: 10_000,
+      abortController,
+    });
+
+    await watcher.initialScan();
+    await watcher.abort();
+
+    expect(handler).toBeCalledTimes(1);
+    expect(seenFiles).toContain(depth10File);
+    expect(seenFiles).not.toContain(depth11File);
+  });
 });
 
 describe("findMatching", () => {


### PR DESCRIPTION
Allure dump/report generation now reliably includes attachments from nested `allure-results` directories, including layouts like `build/allure-results/<matrix-id>/...`, when running on Node 20. Previously, some existing attachment files could be skipped during directory watching and later appear as missed in the final output.

This also improves shutdown-time processing for recently written files, so stable files are given the intended processing delay before the run completes.