### PR TITLE
fix ui issues

### DIFF
--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -45,8 +45,10 @@ import {
 } from "@allurereport/plugin-api";
 import type {
   AwesomeCategory,
+  AwesomeExecutorInfo,
   AwesomeFixtureResult,
   AwesomeReportOptions,
+  AwesomeRunSummary,
   AwesomeSearchDocument,
   AwesomeTestResult,
   AwesomeTreeGroup,
@@ -271,6 +273,22 @@ export const generateSearchIndex = async (
   const searchDocuments = trs.filter(({ isRetry }) => !isRetry).map(searchDocumentFactory);
 
   await writer.writeWidget(filename, searchDocuments);
+};
+
+export const getRunSummary = (testResults: Pick<TestResult, "start" | "stop">[]): AwesomeRunSummary | undefined => {
+  let start = Infinity;
+  let stop = -Infinity;
+
+  for (const { start: s, stop: e } of testResults) {
+    if (typeof s === "number" && Number.isFinite(s) && typeof e === "number" && Number.isFinite(e)) {
+      start = Math.min(start, s);
+      stop = Math.max(stop, e);
+    }
+  }
+
+  return Number.isFinite(start) && Number.isFinite(stop)
+    ? { start, stop, duration: Math.max(0, stop - start) }
+    : undefined;
 };
 
 export const generateTree = async (
@@ -609,6 +627,8 @@ export const generateStaticFiles = async (
     reportDataFiles: ReportFile[];
     reportUuid: string;
     reportName: string;
+    executor?: AwesomeExecutorInfo;
+    runSummary?: AwesomeRunSummary;
   },
 ) => {
   const {
@@ -626,6 +646,8 @@ export const generateStaticFiles = async (
     layout = "base",
     defaultSection = "",
     ci,
+    executor,
+    runSummary,
     stepTreeExpansion,
   } = payload;
   const manifest = await readTemplateManifest(payload.singleFile);
@@ -685,6 +707,8 @@ export const generateStaticFiles = async (
     groupBy: groupBy?.length ? groupBy : [],
     cacheKey: now.toString(),
     ci,
+    executor,
+    runSummary,
     layout,
     allureVersion,
     sections,

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   createPluginSummary,
 } from "@allurereport/plugin-api";
 import { preciseTreeLabels } from "@allurereport/plugin-api";
+import type { AwesomeExecutorInfo } from "@allurereport/web-awesome";
 
 import { applyCategoriesToTestResults, generateCategories } from "./categories.js";
 import { generateTimeline } from "./generateTimeline.js";
@@ -28,6 +29,7 @@ import {
   generateTree,
   generateTreeFilters,
   generateVariables,
+  getRunSummary,
 } from "./generators.js";
 import type { AwesomePluginOptions } from "./model.js";
 import { type AwesomeDataWriter, InMemoryReportDataWriter, ReportFileDataWriter } from "./writer.js";
@@ -72,8 +74,10 @@ export class AwesomePlugin implements Plugin {
     const hideLabels = context.hideLabels;
     const categories = context.categories ?? [];
     const environmentItems = await store.metadataByKey<EnvironmentItem[]>("allure_environment");
+    const executor = await store.metadataByKey<AwesomeExecutorInfo>("allure2_executor");
     const attachments = await store.allAttachments();
     const allTrs = await store.allTestResults({ includeRetries: true, filter });
+    const runSummary = getRunSummary(allTrs);
     const statistics = await store.testsStatistic(filter);
     const environments = await store.allEnvironmentIdentities();
     const envStatistics = new Map<string, Statistic>();
@@ -197,6 +201,8 @@ export class AwesomePlugin implements Plugin {
       reportUuid: context.reportUuid,
       reportName: context.reportName,
       ci: context.ci,
+      executor,
+      runSummary,
       reportDataFiles,
     });
   };

--- a/packages/plugin-awesome/test/generators.test.ts
+++ b/packages/plugin-awesome/test/generators.test.ts
@@ -12,6 +12,7 @@ import {
   generateAttachmentsFiles,
   generateGlobals,
   generateSearchIndex,
+  getRunSummary,
 } from "../src/generators.js";
 
 beforeEach(async () => {
@@ -36,6 +37,35 @@ const getTestResultsStats = (trs: TestResult[], filter: (tr: TestResult) => bool
     { total: trsToProcess.length } as Record<string, number>,
   );
 };
+
+describe("getRunSummary", () => {
+  it("should return undefined for empty result input", () => {
+    expect(getRunSummary([])).toBeUndefined();
+  });
+
+  it("should derive launch interval from valid result timings", () => {
+    expect(
+      getRunSummary([
+        { start: 1000, stop: 2000 },
+        { start: 500, stop: 2500 },
+        { start: 1500, stop: 1800 },
+      ]),
+    ).toEqual({
+      start: 500,
+      stop: 2500,
+      duration: 2000,
+    });
+  });
+
+  it("should ignore results without valid timing data", () => {
+    expect(
+      getRunSummary([
+        { start: undefined, stop: 2000 },
+        { start: 1000, stop: undefined },
+      ]),
+    ).toBeUndefined();
+  });
+});
 
 const mockTestResult = (id: string, name: string, status: TestResult["status"]): TestResult =>
   ({

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -696,9 +696,9 @@ describe("plugin", () => {
   });
 
   describe("report assets", () => {
-    const makeSingleFileStore = (testResults: TestResult[]): AllureStore =>
+    const makeSingleFileStore = (testResults: TestResult[], metadata: Record<string, unknown> = {}): AllureStore =>
       ({
-        metadataByKey: vi.fn().mockResolvedValue(undefined),
+        metadataByKey: vi.fn(async (key: string) => metadata[key]),
         allEnvironments: vi.fn().mockResolvedValue(["default"]),
         allEnvironmentIdentities: vi
           .fn()
@@ -757,6 +757,14 @@ describe("plugin", () => {
       }
 
       return data;
+    };
+
+    const extractReportOptions = (html: string) => {
+      const match = html.match(/window\.allureReportOptions = (\{.*?\})\s*<\/script>/s);
+
+      expect(match, "index.html must include report options").not.toBeNull();
+
+      return JSON.parse(match![1]);
     };
 
     it("should copy every emitted multi-file asset", async () => {
@@ -865,6 +873,61 @@ describe("plugin", () => {
 
       // data test results file for the test must be present
       expect(Object.keys(embeddedData).some((k) => k.startsWith("data/test-results/"))).toBe(true);
+    });
+
+    it("should include launch timing and allure2 executor metadata in report options", async () => {
+      const testResults: TestResult[] = [
+        {
+          id: "tr-1",
+          name: "passed test",
+          status: "passed",
+          environment: "default",
+          start: 1000,
+          stop: 2000,
+          labels: [],
+        },
+        {
+          id: "tr-retry",
+          name: "failed retry",
+          status: "failed",
+          environment: "default",
+          isRetry: true,
+          start: 500,
+          stop: 2500,
+          labels: [],
+        },
+      ] as TestResult[];
+      const executor = {
+        name: "TeamCity",
+        type: "teamcity",
+        buildName: "Wrike #123",
+        buildUrl: "https://teamcity.example/build/123",
+        reportUrl: "https://teamcity.example/report/123",
+      };
+      const addedFiles = new Map<string, Buffer>();
+      const reportFiles: ReportFiles = {
+        addFile: vi.fn(async (path: string, data: Buffer) => {
+          addedFiles.set(path, data);
+          return path;
+        }),
+      };
+      const plugin = new AwesomePlugin({ singleFile: true });
+
+      await plugin.start(makeSingleFileContext(reportFiles));
+      await plugin.done(
+        makeSingleFileContext(reportFiles),
+        makeSingleFileStore(testResults, { allure2_executor: executor }),
+      );
+
+      const indexHtml = addedFiles.get("index.html")?.toString("utf-8") ?? "";
+      const reportOptions = extractReportOptions(indexHtml);
+
+      expect(reportOptions.runSummary).toEqual({
+        start: 500,
+        stop: 2500,
+        duration: 2000,
+      });
+      expect(reportOptions.executor).toEqual(executor);
     });
   });
 });

--- a/packages/web-awesome/src/components/Footer/FooterVersion.tsx
+++ b/packages/web-awesome/src/components/Footer/FooterVersion.tsx
@@ -3,11 +3,13 @@ import { Text } from "@allurereport/web-components";
 import { useState } from "preact/hooks";
 import type { AwesomeReportOptions } from "types";
 
-import { currentLocaleIso } from "@/stores";
+import { useI18n } from "@/stores";
+import { timestampToDate } from "@/utils/time";
 
 import * as styles from "./styles.scss";
 
 export const FooterVersion = () => {
+  const { t } = useI18n("ui");
   const [createdAt] = useState(() => {
     const reportOptions = getReportOptions<AwesomeReportOptions>();
     if (reportOptions?.createdAt) {
@@ -27,18 +29,11 @@ export const FooterVersion = () => {
     return undefined;
   });
 
-  const formattedCreatedAt = new Date(createdAt as number).toLocaleDateString(currentLocaleIso.value as string, {
-    month: "numeric",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-  });
+  const formattedCreatedAt = timestampToDate(createdAt as number);
 
   return (
     <Text type="paragraph" size="m" className={styles.version}>
-      {formattedCreatedAt}
+      {t("generated")} {formattedCreatedAt}
       {currentVersion && <span> Ver: {currentVersion}</span>}
     </Text>
   );

--- a/packages/web-awesome/src/components/Footer/index.tsx
+++ b/packages/web-awesome/src/components/Footer/index.tsx
@@ -1,10 +1,13 @@
+import { LanguagePicker } from "@allurereport/web-components";
 import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 
 import { FooterLogo } from "@/components/Footer/FooterLogo";
 import { FooterVersion } from "@/components/Footer/FooterVersion";
+import { currentLocale, setLocale } from "@/stores/locale";
 
 import * as styles from "@/components/BaseLayout/styles.scss";
+import * as footerStyles from "@/components/Footer/styles.scss";
 
 interface FooterProps {
   className?: ClassValue;
@@ -13,7 +16,10 @@ export const Footer = ({ className }: FooterProps) => {
   return (
     <div className={clsx(styles.below, className)}>
       <FooterLogo />
-      <FooterVersion />
+      <div className={footerStyles["footer-controls"]}>
+        <LanguagePicker locale={currentLocale.value} setLocale={setLocale} />
+        <FooterVersion />
+      </div>
     </div>
   );
 };

--- a/packages/web-awesome/src/components/Footer/styles.scss
+++ b/packages/web-awesome/src/components/Footer/styles.scss
@@ -12,3 +12,9 @@
 .version {
   color: var(--color-text-muted);
 }
+
+.footer-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/packages/web-awesome/src/components/Header/CiInfo/index.tsx
+++ b/packages/web-awesome/src/components/Header/CiInfo/index.tsx
@@ -13,7 +13,7 @@ interface CiInfoProps {
 }
 
 interface CiIconProps {
-  type: CiDescriptor["type"];
+  type?: CiDescriptor["type"];
 }
 
 export const CiIcon = ({ type }: CiIconProps) => {
@@ -47,24 +47,20 @@ export const CiIcon = ({ type }: CiIconProps) => {
 export const CiInfo = ({ className }: CiInfoProps) => {
   const { ci } = getReportOptions<AwesomeReportOptions>();
 
-  if (!ci) {
-    return null;
-  }
+  const ciLink = ci ? ci.pullRequestUrl || ci.jobRunUrl || ci.jobUrl : undefined;
+  const ciLabel = getCiLabel(ci, ciLink);
+  const safeLink = sanitizeExternalUrl(ciLink);
 
-  const link = ci.pullRequestUrl || ci.jobRunUrl || ci.jobUrl;
-  const safeLink = sanitizeExternalUrl(link);
-  const label = ci.pullRequestName || ci.jobRunName || ci.jobName || link;
-
-  if (!link) {
+  if (!ciLabel) {
     return null;
   }
 
   if (!safeLink) {
     return (
       <span className={clsx(styles["ci-info"], className)}>
-        <CiIcon type={ci.type} />
+        <CiIcon type={ci?.type} />
         <Text type="paragraph" size="m" bold>
-          {label}
+          {ciLabel}
         </Text>
       </span>
     );
@@ -72,10 +68,18 @@ export const CiInfo = ({ className }: CiInfoProps) => {
 
   return (
     <a className={clsx(styles["ci-info"], className)} href={safeLink} target="_blank" rel="noopener noreferrer">
-      <CiIcon type={ci.type} />
+      <CiIcon type={ci?.type} />
       <Text type="paragraph" size="m" bold>
-        {label}
+        {ciLabel}
       </Text>
     </a>
   );
+};
+
+const getCiLabel = (ci?: CiDescriptor, link?: string) => {
+  if (!ci) {
+    return undefined;
+  }
+
+  return ci.pullRequestName || ci.jobRunName || ci.jobName || link;
 };

--- a/packages/web-awesome/src/components/HeaderControls/index.tsx
+++ b/packages/web-awesome/src/components/HeaderControls/index.tsx
@@ -1,10 +1,9 @@
 import { themeStore, toggleUserTheme } from "@allurereport/web-commons";
-import { LanguagePicker, ThemeButton } from "@allurereport/web-components";
+import { ThemeButton } from "@allurereport/web-components";
 import { computed } from "@preact/signals";
 
 import { EnvironmentPicker } from "@/components/EnvironmentPicker";
 import ToggleLayout from "@/components/ToggleLayout";
-import { currentLocale, setLocale } from "@/stores/locale";
 
 interface HeaderControlsProps {
   className?: string;
@@ -16,7 +15,6 @@ export const HeaderControls = ({ className }: HeaderControlsProps) => {
   return (
     <div className={className}>
       <EnvironmentPicker />
-      <LanguagePicker locale={currentLocale.value} setLocale={setLocale} />
       <ToggleLayout />
       <ThemeButton theme={selectedTheme.value} toggleTheme={toggleUserTheme} />
     </div>

--- a/packages/web-awesome/src/components/Metadata/index.tsx
+++ b/packages/web-awesome/src/components/Metadata/index.tsx
@@ -1,4 +1,5 @@
-import { Button, ButtonLink, Menu, Text, allureIcons } from "@allurereport/web-components";
+import { sanitizeExternalUrl } from "@allurereport/core-api";
+import { Button, ButtonLink, Menu, SvgIcon, Text, allureIcons } from "@allurereport/web-components";
 import clsx from "clsx";
 import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
@@ -23,8 +24,8 @@ export const MetadataList: FunctionalComponent<MetadataProps & { columns?: numbe
       style={{ gridTemplateColumns: `repeat(${columns}, ${100 / columns - 5}%)` }}
       data-testid={"metadata-list"}
     >
-      {envInfo?.map(({ name, values, value }) => (
-        <MetadataKeyValue key={name} size={size} title={name} value={value} values={values} />
+      {envInfo?.map(({ name, values, value, url }, index) => (
+        <MetadataKeyValue key={`${name}-${index}`} size={size} title={name} value={value} values={values} url={url} />
       ))}
     </div>
   );
@@ -160,10 +161,29 @@ const MetaDataOwnerLabel: FunctionalComponent<{
 const MetaDataKeyLabel: FunctionalComponent<{
   name: string;
   size?: "s" | "m";
+  url?: string;
   value: string;
-}> = ({ name, size = "s", value }) => {
+}> = ({ name, size = "s", url, value }) => {
   if (name === "owner") {
     return <MetaDataOwnerLabel value={value} size={size} />;
+  }
+
+  const safeUrl = sanitizeExternalUrl(url);
+
+  if (safeUrl) {
+    return (
+      <a
+        className={clsx(styles["report-metadata-keyvalue-wrapper"], styles["report-metadata-keyvalue-link"])}
+        href={safeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Text type={"ui"} size={size} bold className={styles["report-metadata-keyvalue-value"]}>
+          {value}
+        </Text>
+        <SvgIcon id={allureIcons.lineGeneralLinkExternal} size="s" />
+      </a>
+    );
   }
 
   return (
@@ -186,10 +206,11 @@ const MetaDataKeyLabel: FunctionalComponent<{
 
 const MetadataKeyValue: FunctionalComponent<{
   title: string;
+  url?: string;
   value?: string;
   values?: string[];
   size?: "s" | "m";
-}> = ({ title, value, values, size = "m" }) => {
+}> = ({ title, url, value, values, size = "m" }) => {
   return (
     <div className={styles["report-metadata-keyvalue"]} data-testid={"metadata-item"}>
       <Text
@@ -208,7 +229,7 @@ const MetadataKeyValue: FunctionalComponent<{
         </div>
       ) : (
         <div className={styles["report-metadata-values"]} data-testid={"metadata-item-value"}>
-          <MetaDataKeyLabel value={value ?? ""} name={title} />
+          <MetaDataKeyLabel value={value ?? ""} name={title} url={url} />
         </div>
       )}
     </div>

--- a/packages/web-awesome/src/components/Metadata/styles.scss
+++ b/packages/web-awesome/src/components/Metadata/styles.scss
@@ -85,6 +85,18 @@
   line-height: 16px;
 }
 
+.report-metadata-keyvalue-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .report-metadata-keyvalue-value {
   width: max-content;
   height: max-content;

--- a/packages/web-awesome/src/components/ReportHeader/index.tsx
+++ b/packages/web-awesome/src/components/ReportHeader/index.tsx
@@ -1,3 +1,4 @@
+import { formatDuration } from "@allurereport/core-api";
 import { getReportOptions } from "@allurereport/web-commons";
 import { Heading, Loadable, Text, TooltipWrapper } from "@allurereport/web-components";
 import type { AwesomeReportOptions } from "types";
@@ -5,22 +6,28 @@ import type { AwesomeReportOptions } from "types";
 import { ReportHeaderLogo } from "@/components/ReportHeader/ReportHeaderLogo";
 import { ReportHeaderPie } from "@/components/ReportHeader/ReportHeaderPie";
 import { TrStatus } from "@/components/TestResult/TrStatus";
-import { currentLocaleIso, useI18n } from "@/stores";
+import { useI18n } from "@/stores";
 import { globalsStore } from "@/stores/globals";
+import { timestampToDate } from "@/utils/time";
 
 import * as styles from "./styles.scss";
 
+const reportDateOptions: Intl.DateTimeFormatOptions = {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+};
+
 export const ReportHeader = () => {
-  const { reportName, createdAt } = getReportOptions<AwesomeReportOptions>() ?? {};
+  const { reportName, createdAt, runSummary } = getReportOptions<AwesomeReportOptions>() ?? {};
   const { t } = useI18n("ui");
-  const formattedCreatedAt = new Date(createdAt as number).toLocaleDateString(currentLocaleIso.value as string, {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-  });
+  const formattedCreatedAt = timestampToDate(createdAt as number, reportDateOptions);
+  const formattedReportTime = runSummary
+    ? `${timestampToDate(runSummary.start, reportDateOptions)} (${formatDuration(runSummary.duration)})`
+    : formattedCreatedAt;
 
   return (
     <div className={styles["report-header"]}>
@@ -41,14 +48,19 @@ export const ReportHeader = () => {
                 </div>
                 <Text type="paragraph" size="m" className={styles["report-date"]} data-testid="report-data">
                   {code === undefined
-                    ? formattedCreatedAt
+                    ? formattedReportTime
                     : exitCode.actual !== undefined
                       ? t("finishedAtBoth", {
-                          formattedCreatedAt,
+                          // Keep the existing i18n parameter name; the value can now be either a timestamp or run interval.
+                          formattedCreatedAt: formattedReportTime,
                           actual: exitCode.actual,
                           original: exitCode.original,
                         })
-                      : t("finishedAtOriginal", { formattedCreatedAt, original: exitCode.original })}
+                      : t("finishedAtOriginal", {
+                          // Keep the existing i18n parameter name; the value can now be either a timestamp or run interval.
+                          formattedCreatedAt: formattedReportTime,
+                          original: exitCode.original,
+                        })}
                 </Text>
               </div>
             );

--- a/packages/web-awesome/src/components/ReportMetadata/index.tsx
+++ b/packages/web-awesome/src/components/ReportMetadata/index.tsx
@@ -1,7 +1,9 @@
 import type { EnvironmentItem } from "@allurereport/core-api";
+import { getReportOptions } from "@allurereport/web-commons";
 import { Button, Loadable } from "@allurereport/web-components";
 import type { FunctionalComponent } from "preact";
 import { useEffect } from "preact/hooks";
+import type { AwesomeExecutorInfo, AwesomeReportOptions } from "types";
 
 import { MetadataList } from "@/components/Metadata";
 import { MetadataButton } from "@/components/MetadataButton";
@@ -19,6 +21,7 @@ const REPORT_VISIBLE_LIMIT = 8;
 
 export interface MetadataItem extends EnvironmentItem {
   value?: string;
+  url?: string;
 }
 
 // TODO: check, where do we use the component and refactor it up to our needs
@@ -39,7 +42,7 @@ const Metadata: FunctionalComponent<MetadataProps> = ({ envInfo = [] }) => {
   const showAllId = `${sectionId}-showAll`;
   const isOpened = !collapsedTrees.value.has(sectionId);
   const showAll = collapsedTrees.value.has(showAllId);
-  const list = envInfo.map((env) => ({ ...env, value: env.values.join(", ") }));
+  const list = envInfo.map((env) => ({ ...env, value: env.value ?? env.values.join(", ") }));
   const totalCount = list.length;
   const visibleList = totalCount <= REPORT_VISIBLE_LIMIT ? list : showAll ? list : list.slice(0, REPORT_VISIBLE_LIMIT);
   const { t } = useI18n("ui");
@@ -109,8 +112,32 @@ const MetadataVariables: FunctionalComponent<MetadataVariablesProps> = (props) =
   );
 };
 
+const getExecutorLabel = (executor?: AwesomeExecutorInfo) => {
+  if (!executor) return undefined;
+  if (executor.name && executor.buildName) return `${executor.name} · ${executor.buildName}`;
+
+  return (
+    executor.buildName ||
+    executor.reportName ||
+    executor.name ||
+    executor.buildUrl ||
+    executor.reportUrl ||
+    executor.url
+  );
+};
+
+const getExecutorMetadata = (executor?: AwesomeExecutorInfo): MetadataItem[] => {
+  const label = getExecutorLabel(executor);
+
+  return label
+    ? [{ name: "executor", values: [], value: label, url: executor?.buildUrl || executor?.reportUrl || executor?.url }]
+    : [];
+};
+
 export const ReportMetadata = () => {
   const envId = currentEnvironment.value;
+  const { executor } = getReportOptions<AwesomeReportOptions>();
+  const executorMetadata = getExecutorMetadata(executor);
   const stats = envId ? statsByEnvStore.value.data[envId] : reportStatsStore.value.data;
 
   useEffect(() => {
@@ -122,13 +149,17 @@ export const ReportMetadata = () => {
       {stats && <MetadataSummary stats={stats} />}
       <Loadable
         source={variables}
-        transformData={(data) => data?.[currentEnvironment.value ?? "default"] ?? {}}
+        transformData={(data) => data?.[envId ?? "default"] ?? {}}
         renderData={(data) => !!Object.keys(data).length && <MetadataVariables variables={data} />}
       />
       <Loadable
         source={envInfoStore}
-        renderError={() => null}
-        renderData={(data) => Boolean(data?.length) && <Metadata envInfo={data} />}
+        renderError={() => Boolean(executorMetadata.length) && <Metadata envInfo={executorMetadata} />}
+        renderData={(data) => {
+          const metadata = [...executorMetadata, ...(data ?? [])];
+
+          return Boolean(metadata.length) && <Metadata envInfo={metadata} />;
+        }}
       />
     </div>
   );

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
@@ -4,6 +4,7 @@ import type { FunctionalComponent } from "preact";
 import { useState } from "preact/hooks";
 import type { AwesomeTestResult } from "types";
 
+import { hasErrorDiff } from "@/components/TestResult/bodyItems";
 import { TrError } from "@/components/TestResult/TrError";
 import { useI18n } from "@/stores/locale";
 import { navigateToTestResult } from "@/stores/router";
@@ -22,13 +23,15 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
   const [isOpened, setIsOpen] = useState(false);
 
   const { t } = useI18n("ui");
+  const { t: controls } = useI18n("controls");
 
   const retryTitlePrefix = t("attempt", { attempt, total: totalAttempts });
   const convertedStop = stop ? timestampToDate(stop) : undefined;
   const retryTitle = convertedStop ? `${retryTitlePrefix} – ${convertedStop}` : retryTitlePrefix;
 
   const formattedDuration = typeof duration === "number" ? formatDuration(duration) : undefined;
-  const hasErrorDetails = Boolean(error?.trace || error?.message);
+  const errorPreview = getErrorPreview(error, controls("comparison"));
+  const hasErrorDetails = Boolean(errorPreview);
 
   return (
     <div data-testid="test-result-retries-item">
@@ -45,6 +48,16 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
           <Text data-testid="test-result-retries-item-text" className={styles["test-result-retries-item-text"]}>
             {retryTitle}
           </Text>
+          {errorPreview && (
+            <Text
+              data-testid="test-result-retries-item-error-preview"
+              type="ui"
+              size="s"
+              className={styles["test-result-retries-item-error-preview"]}
+            >
+              {errorPreview}
+            </Text>
+          )}
           <div className={styles["test-result-retries-item-info"]}>
             {Boolean(formattedDuration) && (
               <Text type="ui" size={"s"} className={styles["item-time"]}>
@@ -69,4 +82,17 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
       )}
     </div>
   );
+};
+
+const getErrorPreview = (error: AwesomeTestResult["error"], diffPreview: string) => {
+  const message = error?.message?.trim();
+  if (message) return message;
+
+  const tracePreview = error?.trace
+    ?.split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (tracePreview) return tracePreview;
+
+  if (hasErrorDiff(error)) return diffPreview;
 };

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/styles.scss
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/styles.scss
@@ -20,13 +20,13 @@
 
 .test-result-retries-item-wrap {
   transition: background-color 300ms;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) max-content;
   gap: 4px;
-  justify-content: space-between;
   border-radius: 6px;
   padding: 4px;
   width: 100%;
-  align-items: flex-start;
+  align-items: center;
 
   &:hover {
     background: var(--color-row-bg-hover);
@@ -34,20 +34,30 @@
 }
 
 .test-result-retries-item-text {
-  padding-top: 2px;
+  flex: 0 0 auto;
+}
+
+.test-result-retries-item-error-preview {
+  flex: 1 1 auto;
+  color: var(--on-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .test-result-retries-item-info {
   display: flex;
   gap: 4px;
   align-items: center;
-  margin-left: auto;
+  justify-content: flex-end;
+  margin-left: 8px;
 }
 
 .item-time {
-  margin-left: auto;
-  line-height: 20px;
   color: var(--color-text-secondary);
+  line-height: 16px;
+  white-space: nowrap;
 }
 
 .test-result-retries-item-content {

--- a/packages/web-awesome/src/locales/ar.json
+++ b/packages/web-awesome/src/locales/ar.json
@@ -151,6 +151,7 @@
     "copy-email": "نسخ البريد الإلكتروني",
     "attempt": "المحاولة {{attempt}} من {{total}}",
     "at": "في",
+    "generated": "تم الإنشاء",
     "variables": "المتغيرات",
     "openPwTrace": "فتح تتبع Playwright",
     "finishedAtOriginal": "{{formattedCreatedAt}}، برمز خروج {{original}}",

--- a/packages/web-awesome/src/locales/az.json
+++ b/packages/web-awesome/src/locales/az.json
@@ -151,6 +151,7 @@
     "copy-email": "E-poçtu kopyala",
     "attempt": "Cəhd {{attempt}} / {{total}}",
     "at": "tarixində",
+    "generated": "Yaradıldı",
     "variables": "Dəyişənlər",
     "openPwTrace": "Playwright Trace-i aç",
     "pwTracePopupBlocked": "Brauzer Playwright Trace Viewer-i açmağı blokladı.",

--- a/packages/web-awesome/src/locales/de.json
+++ b/packages/web-awesome/src/locales/de.json
@@ -151,6 +151,7 @@
     "copy-email": "E-Mail kopieren",
     "attempt": "Versuch {{attempt}} von {{total}}",
     "at": "bei",
+    "generated": "Generiert",
     "variables": "Variablen",
     "openPwTrace": "Playwright Trace öffnen",
     "pwTracePopupBlocked": "Der Browser hat das Öffnen des Playwright Trace Viewer blockiert.",

--- a/packages/web-awesome/src/locales/en.json
+++ b/packages/web-awesome/src/locales/en.json
@@ -151,6 +151,7 @@
     "copy-email": "Copy email",
     "attempt": "Attempt {{attempt}} of {{total}}",
     "at": "at",
+    "generated": "Generated",
     "variables": "Variables",
     "openPwTrace": "Open Playwright Trace",
     "pwTracePopupBlocked": "Browser blocked opening Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/es.json
+++ b/packages/web-awesome/src/locales/es.json
@@ -151,6 +151,7 @@
     "copy-email": "Copiar correo",
     "attempt": "Intento {{attempt}} de {{total}}",
     "at": "a las",
+    "generated": "Generado",
     "variables": "Variables",
     "openPwTrace": "Abrir Playwright Trace",
     "pwTracePopupBlocked": "El navegador bloqueó la apertura de Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/fr.json
+++ b/packages/web-awesome/src/locales/fr.json
@@ -151,6 +151,7 @@
     "copy-email": "Copier l'e-mail",
     "attempt": "Tentative {{attempt}} sur {{total}}",
     "at": "à",
+    "generated": "Généré",
     "variables": "Variables",
     "openPwTrace": "Ouvrir Playwright Trace",
     "pwTracePopupBlocked": "Le navigateur a bloqué l’ouverture de Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/he.json
+++ b/packages/web-awesome/src/locales/he.json
@@ -151,6 +151,7 @@
     "copy-email": "העתק אימייל",
     "attempt": "ניסיון {{attempt}} מתוך {{total}}",
     "at": "ב-",
+    "generated": "נוצר",
     "variables": "משתנים",
     "openPwTrace": "פתח Playwright Trace",
     "pwTracePopupBlocked": "הדפדפן חסם את פתיחת Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/hy.json
+++ b/packages/web-awesome/src/locales/hy.json
@@ -151,6 +151,7 @@
     "copy-email": "Պատճենել էլ. փոստը",
     "attempt": "Փորձ {{attempt}}-ից {{total}}-ը",
     "at": "է",
+    "generated": "Ստեղծվել է",
     "variables": "Փոփոխականներ",
     "openPwTrace": "Բացել Playwright Trace",
     "pwTracePopupBlocked": "Բրաուզերը արգելափակեց Playwright Trace Viewer-ի բացումը։",

--- a/packages/web-awesome/src/locales/it.json
+++ b/packages/web-awesome/src/locales/it.json
@@ -151,6 +151,7 @@
     "copy-email": "Copia email",
     "attempt": "Tentativo {{attempt}} di {{total}}",
     "at": "a",
+    "generated": "Generato",
     "variables": "Variabili",
     "openPwTrace": "Apri Playwright Trace",
     "pwTracePopupBlocked": "Il browser ha bloccato l'apertura di Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/ja.json
+++ b/packages/web-awesome/src/locales/ja.json
@@ -151,6 +151,7 @@
     "copy-email": "メールをコピー",
     "attempt": "試行 {{attempt}} 回目（全 {{total}} 回）",
     "at": "時",
+    "generated": "生成日時",
     "variables": "変数",
     "openPwTrace": "Playwright Traceを開く",
     "pwTracePopupBlocked": "ブラウザーが Playwright Trace Viewer の表示をブロックしました。",

--- a/packages/web-awesome/src/locales/ka.json
+++ b/packages/web-awesome/src/locales/ka.json
@@ -151,6 +151,7 @@
     "copy-email": "ელფოსტის კოპირება",
     "attempt": "მცდელობა {{attempt}} {{total}}-დან",
     "at": "ზე",
+    "generated": "გენერირებულია",
     "variables": "ცვლადები",
     "openPwTrace": "გახსენი Playwright Trace",
     "pwTracePopupBlocked": "ბრაუზერმა დაბლოკა Playwright Trace Viewer-ის გახსნა.",

--- a/packages/web-awesome/src/locales/kr.json
+++ b/packages/web-awesome/src/locales/kr.json
@@ -151,6 +151,7 @@
     "copy-email": "이메일 복사",
     "attempt": "시도 {{attempt}}/{{total}}",
     "at": "에서",
+    "generated": "생성됨",
     "variables": "변수",
     "openPwTrace": "Playwright Trace 열기",
     "pwTracePopupBlocked": "브라우저가 Playwright Trace Viewer 열기를 차단했습니다.",

--- a/packages/web-awesome/src/locales/nl.json
+++ b/packages/web-awesome/src/locales/nl.json
@@ -151,6 +151,7 @@
     "copy-email": "E-mail kopiëren",
     "attempt": "Poging {{attempt}} van {{total}}",
     "at": "om",
+    "generated": "Gegenereerd",
     "variables": "Variabelen",
     "openPwTrace": "Open Playwright Trace",
     "pwTracePopupBlocked": "De browser heeft het openen van Playwright Trace Viewer geblokkeerd.",

--- a/packages/web-awesome/src/locales/pl.json
+++ b/packages/web-awesome/src/locales/pl.json
@@ -151,6 +151,7 @@
     "copy-email": "Kopiuj e-mail",
     "attempt": "Próba {{attempt}} z {{total}}",
     "at": "w",
+    "generated": "Wygenerowano",
     "variables": "Zmienne",
     "openPwTrace": "Otwórz Playwright Trace",
     "pwTracePopupBlocked": "Przeglądarka zablokowała otwarcie Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/pt.json
+++ b/packages/web-awesome/src/locales/pt.json
@@ -151,6 +151,7 @@
     "copy-email": "Copiar e-mail",
     "attempt": "Tentativa {{attempt}} de {{total}}",
     "at": "em",
+    "generated": "Gerado",
     "variables": "Variáveis",
     "openPwTrace": "Abrir Playwright Trace",
     "pwTracePopupBlocked": "O navegador bloqueou a abertura do Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/ru.json
+++ b/packages/web-awesome/src/locales/ru.json
@@ -151,6 +151,7 @@
     "copy-email": "Скопировать email",
     "attempt": "Попытка {{attempt}} из {{total}}",
     "at": "в",
+    "generated": "Сгенерировано",
     "variables": "Переменные",
     "openPwTrace": "Открыть Playwright Trace",
     "pwTracePopupBlocked": "Браузер заблокировал открытие Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/sv.json
+++ b/packages/web-awesome/src/locales/sv.json
@@ -151,6 +151,7 @@
     "copy-email": "Kopiera e-post",
     "attempt": "Försök {{attempt}} av {{total}}",
     "at": "vid",
+    "generated": "Genererad",
     "variables": "Variabler",
     "openPwTrace": "Öppna Playwright Trace",
     "pwTracePopupBlocked": "Webbläsaren blockerade öppning av Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/tr.json
+++ b/packages/web-awesome/src/locales/tr.json
@@ -151,6 +151,7 @@
     "copy-email": "E-postayı kopyala",
     "attempt": "Deneme {{attempt}} / {{total}}",
     "at": "tarihinde",
+    "generated": "Oluşturuldu",
     "variables": "Değişkenler",
     "openPwTrace": "Playwright Trace Aç",
     "pwTracePopupBlocked": "Tarayıcı Playwright Trace Viewer’ın açılmasını engelledi.",

--- a/packages/web-awesome/src/locales/uk.json
+++ b/packages/web-awesome/src/locales/uk.json
@@ -151,6 +151,7 @@
     "copy-email": "Скопіювати email",
     "attempt": "Спроба {{attempt}} з {{total}}",
     "at": "в",
+    "generated": "Згенеровано",
     "variables": "Змінні",
     "openPwTrace": "Відкрити Playwright Trace",
     "pwTracePopupBlocked": "Браузер заблокував відкриття Playwright Trace Viewer.",

--- a/packages/web-awesome/src/locales/zh-TW.json
+++ b/packages/web-awesome/src/locales/zh-TW.json
@@ -151,6 +151,7 @@
     "copy-email": "複製電子郵件",
     "attempt": "第 {{attempt}} 次嘗試，共 {{total}} 次",
     "at": "於",
+    "generated": "已產生",
     "variables": "變數",
     "openPwTrace": "開啟 Playwright Trace",
     "pwTracePopupBlocked": "瀏覽器封鎖了開啟 Playwright Trace Viewer。",

--- a/packages/web-awesome/src/locales/zh.json
+++ b/packages/web-awesome/src/locales/zh.json
@@ -151,6 +151,7 @@
     "copy-email": "复制邮箱",
     "attempt": "第 {{attempt}} 次尝试，共 {{total}} 次",
     "at": "在",
+    "generated": "已生成",
     "variables": "变量",
     "openPwTrace": "打开 Playwright Trace",
     "pwTracePopupBlocked": "浏览器阻止了打开 Playwright Trace Viewer。",

--- a/packages/web-awesome/src/stores/locale.ts
+++ b/packages/web-awesome/src/stores/locale.ts
@@ -10,6 +10,8 @@ import { computed, signal } from "@preact/signals";
 import i18next, { type TOptions } from "i18next";
 import type { AwesomeReportOptions } from "types";
 
+import { ensureAtSeparator } from "@/utils/atSeparator";
+
 const namespaces = [
   "empty",
   "execution",
@@ -112,7 +114,7 @@ export const waitForI18next = i18next
         if (override?.includeAtSeparator === false || override?.stripComma) {
           return formatted.replace(",", "");
         }
-        return formatted.replace(",", ` ${i18next.t("ui:at")}`);
+        return ensureAtSeparator(formatted, i18next.t("ui:at"));
       },
     );
     i18next.services.formatter.add(
@@ -133,7 +135,7 @@ export const waitForI18next = i18next
         if (override?.includeAtSeparator === false || override?.stripComma) {
           return formatted.replace(",", "");
         }
-        return formatted.replace(",", ` ${i18next.t("ui:at")}`);
+        return ensureAtSeparator(formatted, i18next.t("ui:at"));
       },
     );
     i18next.services.formatter.add("format_duration", (value: number) => {

--- a/packages/web-awesome/src/utils/atSeparator.ts
+++ b/packages/web-awesome/src/utils/atSeparator.ts
@@ -1,0 +1,4 @@
+export const ensureAtSeparator = (formatted: string, atWord: string): string => {
+  const atSeparator = ` ${atWord} `;
+  return formatted.includes(atSeparator) ? formatted : formatted.replace(",", ` ${atWord}`);
+};

--- a/packages/web-awesome/src/utils/time.ts
+++ b/packages/web-awesome/src/utils/time.ts
@@ -1,6 +1,7 @@
 import { getLocaleDateTimeOverride } from "@allurereport/web-commons";
 
 import { currentLocale, currentLocaleIso, useI18n } from "@/stores/locale";
+import { ensureAtSeparator } from "@/utils/atSeparator";
 
 const defaultOptions: Intl.DateTimeFormatOptions = {
   month: "numeric",
@@ -29,5 +30,5 @@ export const timestampToDate = (timestamp: number, options = defaultOptions) => 
     return formatted.replace(",", "");
   }
 
-  return formatted.replace(",", ` ${t("at")}`);
+  return ensureAtSeparator(formatted, t("at"));
 };

--- a/packages/web-awesome/test/components/Footer.test.tsx
+++ b/packages/web-awesome/test/components/Footer.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+
+import { Footer } from "@/components/Footer";
+
+vi.mock("@/components/Footer/FooterLogo", () => ({
+  FooterLogo: () => <div data-testid="footer-logo" />,
+}));
+
+vi.mock("@allurereport/web-components", () => ({
+  LanguagePicker: () => <div data-testid="footer-language-picker" />,
+}));
+
+vi.mock("@/components/Footer/FooterVersion", () => ({
+  FooterVersion: () => <div data-testid="footer-version">Generated May 10, 2026 Ver: 3.8.2</div>,
+}));
+
+describe("components > Footer", () => {
+  it("should render language picker near generated time and version", () => {
+    render(<Footer />);
+
+    expect(screen.getByTestId("footer-logo")).toBeInTheDocument();
+    expect(screen.getByTestId("footer-language-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("footer-version")).toHaveTextContent("Generated");
+  });
+});

--- a/packages/web-awesome/test/components/Header/CiInfo.test.tsx
+++ b/packages/web-awesome/test/components/Header/CiInfo.test.tsx
@@ -197,4 +197,52 @@ describe("components > Header > CiInfo", () => {
 
     expect(screen.getByRole("link")).toHaveTextContent(fixtures.jobRunName);
   });
+
+  it("should not render executor metadata in the header", () => {
+    (getReportOptions as Mock).mockReturnValueOnce({
+      executor: {
+        name: "TeamCity",
+        type: "teamcity",
+        buildName: "Wrike #123",
+        buildUrl: "https://teamcity.example/build/123",
+      },
+    });
+
+    render(<CiInfo />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByText("TeamCity · Wrike #123")).not.toBeInTheDocument();
+  });
+
+  it("should render ci label as plain text when ci has a name but no link", () => {
+    (getReportOptions as Mock).mockReturnValueOnce({
+      ci: {
+        jobName: "Nightly Build",
+      },
+    });
+
+    render(<CiInfo />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Nightly Build")).toBeInTheDocument();
+  });
+
+  it("should ignore executor metadata when ci has no link", () => {
+    (getReportOptions as Mock).mockReturnValueOnce({
+      ci: {
+        jobName: "Nightly Build",
+      },
+      executor: {
+        name: "TeamCity",
+        buildName: "Wrike #123",
+        buildUrl: "https://teamcity.example/build/123",
+      },
+    });
+
+    render(<CiInfo />);
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Nightly Build")).toBeInTheDocument();
+    expect(screen.queryByText("TeamCity · Wrike #123")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web-awesome/test/components/HeaderControls.test.tsx
+++ b/packages/web-awesome/test/components/HeaderControls.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+
+import { HeaderControls } from "@/components/HeaderControls";
+
+vi.mock("@/components/EnvironmentPicker", () => ({
+  EnvironmentPicker: () => <div data-testid="environment-picker" />,
+}));
+
+vi.mock("@/components/ToggleLayout", () => ({
+  default: () => <div data-testid="toggle-layout" />,
+}));
+
+vi.mock("@allurereport/web-components", () => ({
+  ThemeButton: () => <button data-testid="theme-button" type="button" />,
+  LanguagePicker: () => <button data-testid="language-picker" type="button" />,
+}));
+
+describe("components > HeaderControls", () => {
+  it("should keep frequent controls in header and omit language picker", () => {
+    render(<HeaderControls />);
+
+    expect(screen.getByTestId("environment-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("toggle-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("theme-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("language-picker")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web-awesome/test/components/ReportHeader.test.tsx
+++ b/packages/web-awesome/test/components/ReportHeader.test.tsx
@@ -1,0 +1,77 @@
+import { getReportOptions } from "@allurereport/web-commons";
+import { render, screen } from "@testing-library/preact";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReportHeader } from "@/components/ReportHeader";
+
+vi.mock("@allurereport/web-commons", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getReportOptions: vi.fn(),
+}));
+
+vi.mock("@allurereport/web-components", () => ({
+  Heading: (props: { children: string }) => <h2>{props.children}</h2>,
+  Loadable: (props: { renderData: (data: unknown) => unknown }) => props.renderData({}),
+  Text: (props: { "children": unknown; "data-testid"?: string }) => (
+    <span data-testid={props["data-testid"]}>{props.children}</span>
+  ),
+  TooltipWrapper: (props: { children: unknown }) => props.children,
+}));
+
+vi.mock("@/components/ReportHeader/ReportHeaderLogo", () => ({
+  ReportHeaderLogo: () => <div data-testid="report-logo" />,
+}));
+
+vi.mock("@/components/ReportHeader/ReportHeaderPie", () => ({
+  ReportHeaderPie: () => <div data-testid="report-pie" />,
+}));
+
+vi.mock("@/components/TestResult/TrStatus", () => ({
+  TrStatus: () => <div data-testid="tr-status" />,
+}));
+
+vi.mock("@/stores", () => ({
+  useI18n: () => ({
+    t: (key: string, params: Record<string, unknown>) => `${key}: ${params.formattedCreatedAt}`,
+  }),
+}));
+
+vi.mock("@/utils/time", () => ({
+  timestampToDate: (value: number, options?: Intl.DateTimeFormatOptions) =>
+    `${options?.month === "long" ? "long" : "default"}:${value}`,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("components > ReportHeader", () => {
+  it("should render launch start time and duration when run summary is available", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      reportName: "Wrike report",
+      createdAt: 42,
+      runSummary: {
+        start: 1000,
+        stop: 2500,
+        duration: 1500,
+      },
+    });
+
+    render(<ReportHeader />);
+
+    expect(screen.getByTestId("report-data")).toHaveTextContent("long:1000");
+    expect(screen.getByTestId("report-data")).not.toHaveTextContent("long:2500");
+    expect(screen.getByTestId("report-data")).not.toHaveTextContent("long:42");
+  });
+
+  it("should fall back to generated time when run summary is missing", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      reportName: "Wrike report",
+      createdAt: 10,
+    });
+
+    render(<ReportHeader />);
+
+    expect(screen.getByTestId("report-data")).toHaveTextContent("long:10");
+  });
+});

--- a/packages/web-awesome/test/components/ReportMetadata.test.tsx
+++ b/packages/web-awesome/test/components/ReportMetadata.test.tsx
@@ -1,0 +1,131 @@
+import { getReportOptions } from "@allurereport/web-commons";
+import { cleanup, render, screen } from "@testing-library/preact";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReportMetadata } from "@/components/ReportMetadata";
+
+vi.mock("@allurereport/web-commons", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getReportOptions: vi.fn(),
+}));
+
+vi.mock("@allurereport/web-components", () => {
+  const Menu = Object.assign(
+    (props: { children: unknown; menuTrigger: (props: { onClick: () => void }) => unknown }) => (
+      <>
+        {props.menuTrigger({ onClick: vi.fn() })}
+        {props.children}
+      </>
+    ),
+    {
+      Section: (props: { children: unknown }) => <>{props.children}</>,
+    },
+  );
+
+  return {
+    ArrowButton: () => <span />,
+    Button: (props: { text?: string; onClick?: () => void }) => <button onClick={props.onClick}>{props.text}</button>,
+    ButtonLink: (props: { href: string; text?: string }) => <a href={props.href}>{props.text}</a>,
+    Counter: (props: { count: number }) => <span>{props.count}</span>,
+    Loadable: (props: {
+      source: { value?: { data?: unknown } };
+      transformData?: (data: unknown) => unknown;
+      renderData: (data: unknown) => unknown;
+    }) =>
+      props.renderData(props.transformData ? props.transformData(props.source.value?.data) : props.source.value?.data),
+    Menu,
+    SvgIcon: () => <span />,
+    Text: (props: { children: unknown }) => <span>{props.children}</span>,
+    TooltipWrapper: (props: { children: unknown }) => props.children,
+    allureIcons: {
+      lineGeneralCopy3: "copy",
+      lineGeneralLinkExternal: "external",
+    },
+    useElementTruncation: () => ({ ref: { current: null }, isTruncated: false }),
+  };
+});
+
+vi.mock("@/stores", () => ({
+  reportStatsStore: { value: { data: undefined } },
+  statsByEnvStore: { value: { data: {} } },
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/stores/env", () => ({
+  currentEnvironment: { value: undefined },
+}));
+
+vi.mock("@/stores/envInfo", () => ({
+  envInfoStore: { value: { data: [] } },
+}));
+
+vi.mock("@/stores/tree", () => ({
+  collapsedTrees: { value: new Set() },
+  toggleTree: vi.fn(),
+}));
+
+vi.mock("@/stores/variables", () => ({
+  fetchVariables: vi.fn(),
+  variables: { value: { data: { default: {} } } },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe("components > ReportMetadata", () => {
+  it("should render executor metadata as a clickable build link", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      executor: {
+        name: "TeamCity",
+        buildName: "Wrike #123",
+        url: "https://teamcity.example",
+        reportUrl: "https://teamcity.example/report/123",
+        buildUrl: "https://teamcity.example/build/123",
+      },
+    });
+
+    render(<ReportMetadata />);
+
+    expect(screen.getByText("executor")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "TeamCity · Wrike #123" })).toHaveAttribute(
+      "href",
+      "https://teamcity.example/build/123",
+    );
+  });
+
+  it("should fall back to report url when executor build url is missing", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      executor: {
+        name: "TeamCity",
+        buildName: "Wrike #123",
+        reportUrl: "https://teamcity.example/report/123",
+      },
+    });
+
+    render(<ReportMetadata />);
+
+    expect(screen.getByRole("link", { name: "TeamCity · Wrike #123" })).toHaveAttribute(
+      "href",
+      "https://teamcity.example/report/123",
+    );
+  });
+
+  it("should render executor metadata as plain text when url is unsafe", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      executor: {
+        name: "TeamCity",
+        buildName: "Wrike #123",
+        buildUrl: "javascript:alert(1)",
+      },
+    });
+
+    render(<ReportMetadata />);
+
+    expect(screen.queryByRole("link", { name: "TeamCity · Wrike #123" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("metadata-item")).toHaveTextContent("TeamCity · Wrike #123");
+  });
+});

--- a/packages/web-awesome/test/components/TestResult/TrRetriesItem.test.tsx
+++ b/packages/web-awesome/test/components/TestResult/TrRetriesItem.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TrRetriesItem } from "@/components/TestResult/TrRetriesView/TrRetriesItem";
+
+import type { AwesomeTestResult } from "../../../types";
+
+vi.mock("@allurereport/web-components", () => ({
+  ArrowButton: () => <button data-testid="test-result-retries-item-arrow-button" type="button" />,
+  IconButton: (props: { "onClick": () => void; "data-testid"?: string }) => (
+    <button data-testid={props["data-testid"]} type="button" onClick={props.onClick} />
+  ),
+  Text: (props: { "children": unknown; "data-testid"?: string }) => (
+    <span data-testid={props["data-testid"]}>{props.children}</span>
+  ),
+  TreeItemIcon: () => <span data-testid="retry-status" />,
+  allureIcons: {
+    lineArrowsChevronDown: "chevron",
+    lineGeneralLinkExternal: "external",
+  },
+}));
+
+vi.mock("@/components/TestResult/TrError", () => ({
+  TrError: (props: { message?: string; trace?: string; actual?: string; expected?: string }) => (
+    <div data-testid="test-result-error">{props.message || props.trace || `${props.actual} ${props.expected}`}</div>
+  ),
+}));
+
+vi.mock("@/stores/locale", () => ({
+  useI18n: (namespace: string) =>
+    namespace === "controls"
+      ? {
+          t: (key: string) => (key === "comparison" ? "Comparison" : key),
+        }
+      : {
+          t: (_key: string, params: { attempt: number; total: number }) =>
+            `Attempt ${params.attempt} of ${params.total}`,
+        },
+}));
+
+vi.mock("@/stores/router", () => ({
+  navigateToTestResult: vi.fn(),
+}));
+
+vi.mock("@/utils/time", () => ({
+  timestampToDate: (value: number) => `date:${value}`,
+}));
+
+const makeRetry = (overrides: Partial<AwesomeTestResult> = {}): AwesomeTestResult =>
+  ({
+    id: "retry-id",
+    name: "retry",
+    status: "failed",
+    fullName: "retry.fullName",
+    flaky: false,
+    muted: false,
+    known: false,
+    isRetry: true,
+    labels: [],
+    groupedLabels: {},
+    parameters: [],
+    links: [],
+    steps: [],
+    error: undefined,
+    environment: "default",
+    setup: [],
+    teardown: [],
+    history: [],
+    retries: [],
+    breadcrumbs: [],
+    titlePath: [],
+    attachments: [],
+    ...overrides,
+  }) as AwesomeTestResult;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("components > TestResult > TrRetriesItem", () => {
+  it("should render retry error message preview without expanding details", () => {
+    render(
+      <TrRetriesItem
+        attempt={1}
+        totalAttempts={2}
+        testResultItem={makeRetry({
+          stop: 1000,
+          duration: 500,
+          error: {
+            message: "Expected true to be false",
+            trace: "stack trace",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("test-result-retries-item-error-preview")).toHaveTextContent("Expected true to be false");
+    expect(screen.queryByTestId("test-result-error")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("test-result-retries-item-arrow-button"));
+
+    expect(screen.getByTestId("test-result-error")).toHaveTextContent("Expected true to be false");
+  });
+
+  it("should use first meaningful trace line when message is missing", () => {
+    render(
+      <TrRetriesItem
+        attempt={1}
+        totalAttempts={2}
+        testResultItem={makeRetry({
+          error: {
+            trace: "\n\nAssertionError: timeout\n    at test.ts:1",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("test-result-retries-item-error-preview")).toHaveTextContent("AssertionError: timeout");
+  });
+
+  it("should use trace preview when message is only whitespace", () => {
+    render(
+      <TrRetriesItem
+        attempt={1}
+        totalAttempts={2}
+        testResultItem={makeRetry({
+          error: {
+            message: "   ",
+            trace: "\nAssertionError: retry failed",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("test-result-retries-item-arrow-button")).toBeInTheDocument();
+    expect(screen.getByTestId("test-result-retries-item-error-preview")).toHaveTextContent(
+      "AssertionError: retry failed",
+    );
+  });
+
+  it("should render diff-only retry preview and keep details expandable", () => {
+    render(
+      <TrRetriesItem
+        attempt={1}
+        totalAttempts={2}
+        testResultItem={makeRetry({
+          error: {
+            actual: "actual value",
+            expected: "expected value",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("test-result-retries-item-arrow-button")).toBeInTheDocument();
+    expect(screen.getByTestId("test-result-retries-item-error-preview")).toHaveTextContent("Comparison");
+    expect(screen.queryByTestId("test-result-error")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("test-result-retries-item-arrow-button"));
+
+    expect(screen.getByTestId("test-result-error")).toHaveTextContent("actual value expected value");
+  });
+});

--- a/packages/web-awesome/test/utils/time.test.ts
+++ b/packages/web-awesome/test/utils/time.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { timestampToDate } from "@/utils/time";
+
+const numericDateTimeOptions: Intl.DateTimeFormatOptions = {
+  month: "numeric",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  hour12: false,
+};
+
+vi.mock("@/stores/locale", () => ({
+  currentLocale: { value: "en" },
+  currentLocaleIso: { value: "en-US" },
+  useI18n: () => ({
+    t: (key: string) => (key === "at" ? "at" : key),
+  }),
+}));
+
+vi.mock("@allurereport/web-commons", async (importOriginal) => ({
+  ...(await importOriginal()),
+  getLocaleDateTimeOverride: () => undefined,
+}));
+
+describe("utils > timestampToDate", () => {
+  it("should keep Intl-provided at separator for long English dates", () => {
+    const timestamp = 1527776360360;
+    const options: Intl.DateTimeFormatOptions = {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      second: "numeric",
+    };
+    const intlFormatted = new Intl.DateTimeFormat("en-US", options).format(new Date(timestamp));
+    const formatted = timestampToDate(timestamp, options);
+
+    expect(formatted).toBe(intlFormatted);
+    expect(formatted).not.toContain("May 31 at 2018 at");
+  });
+
+  it("should add at separator when Intl returns comma-separated date and time", () => {
+    const timestamp = 1779887536194;
+    const intlFormatted = new Intl.DateTimeFormat("en-US", numericDateTimeOptions).format(new Date(timestamp));
+
+    expect(timestampToDate(timestamp, numericDateTimeOptions)).toBe(intlFormatted.replace(",", " at"));
+  });
+});

--- a/packages/web-awesome/types.d.ts
+++ b/packages/web-awesome/types.d.ts
@@ -14,6 +14,23 @@ import type {
 export type Layout = "base" | "split";
 export type StepTreeExpansion = "collapsed" | "expand_failed_only" | "expanded";
 
+export type AwesomeRunSummary = {
+  start: number;
+  stop: number;
+  duration: number;
+};
+
+export type AwesomeExecutorInfo = {
+  name?: string;
+  type?: string;
+  url?: string;
+  buildOrder?: number;
+  buildName?: string;
+  buildUrl?: string;
+  reportName?: string;
+  reportUrl?: string;
+};
+
 export type AwesomeReportOptions = {
   allureVersion: string;
   reportName?: string;
@@ -28,6 +45,8 @@ export type AwesomeReportOptions = {
   sections?: string[];
   cacheKey: string;
   ci?: CiDescriptor;
+  executor?: AwesomeExecutorInfo;
+  runSummary?: AwesomeRunSummary;
   stepTreeExpansion?: StepTreeExpansion;
 };
 

--- a/packages/web-summary/types.d.ts
+++ b/packages/web-summary/types.d.ts
@@ -12,6 +12,23 @@ import type {
 
 export type Layout = "base" | "split";
 
+export type AwesomeRunSummary = {
+  start: number;
+  stop: number;
+  duration: number;
+};
+
+export type AwesomeExecutorInfo = {
+  name?: string;
+  type?: string;
+  url?: string;
+  buildOrder?: number;
+  buildName?: string;
+  buildUrl?: string;
+  reportName?: string;
+  reportUrl?: string;
+};
+
 export type AwesomeReportOptions = {
   allureVersion: string;
   reportName?: string;
@@ -22,6 +39,8 @@ export type AwesomeReportOptions = {
   createdAt: number;
   reportUuid: string;
   layout?: Layout;
+  executor?: AwesomeExecutorInfo;
+  runSummary?: AwesomeRunSummary;
 };
 
 export type AwesomeFixtureResult = Omit<
@@ -97,4 +116,4 @@ export type AwesomeRecursiveTree = DefaultTreeGroup & {
 // TODO: add worst status
 export type AwesomeTestResultGroup = Pick<AwesomeTestResult, "name" | "fullName" | "groupOrder"> & {
   testResults: AwesomeTestResult[];
-}
+};


### PR DESCRIPTION
Fixed Awesome report parity issues:

- Show actual launch start time and duration in the report header instead of report generation time.
- Preserve executor/build metadata and display it in report metadata with clickable build links.
- Show inline retry failure previews while keeping full retry details collapsed.
- Move the language picker from the main header to the footer to reduce header clutter.