### PR TITLE
fix(web-components): constrain portrait media to viewport height

### DIFF
--- a/packages/web-classic/src/components/TestResult/TestResultSteps/attachmentVideo.tsx
+++ b/packages/web-classic/src/components/TestResult/TestResultSteps/attachmentVideo.tsx
@@ -1,6 +1,8 @@
 import { Spinner } from "@allurereport/web-components";
 import { type FunctionalComponent } from "preact";
 
+import * as styles from "./styles.scss";
+
 export const AttachmentVideo: FunctionalComponent<{
   attachment: { src: string; contentType?: string };
 }> = ({ attachment }) => {
@@ -8,7 +10,7 @@ export const AttachmentVideo: FunctionalComponent<{
     return <Spinner />;
   }
   return (
-    <video controls loop muted>
+    <video class={styles["test-result-attachment-video"]} controls loop muted>
       <source src={attachment?.src} type={attachment?.contentType} />
     </video>
   );

--- a/packages/web-classic/src/components/TestResult/TestResultSteps/styles.scss
+++ b/packages/web-classic/src/components/TestResult/TestResultSteps/styles.scss
@@ -159,9 +159,12 @@
   height: 100%;
 
   img {
-    width: 100%;
-    height: 100%;
-    object-fit: scale-down;
+    display: block;
+    max-width: 100%;
+    max-height: 80vh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
   }
 }
 
@@ -227,4 +230,12 @@
 
 .html-attachment-preview {
   padding: 0 16px;
+}
+
+.test-result-attachment-video {
+  display: block;
+  max-width: 100%;
+  max-height: 80vh;
+  width: auto;
+  height: auto;
 }

--- a/packages/web-components/src/components/Attachment/styles.scss
+++ b/packages/web-components/src/components/Attachment/styles.scss
@@ -157,7 +157,11 @@
   height: 100%;
 
   img {
-    width: 100%;
+    display: block;
+    max-width: 100%;
+    max-height: 80vh;
+    width: auto;
+    height: auto;
     object-fit: contain;
   }
 }
@@ -236,7 +240,11 @@
 }
 
 .test-result-attachment-video {
-  width: 100%;
+  display: block;
+  max-width: 100%;
+  max-height: 80vh;
+  width: auto;
+  height: auto;
 }
 
 .imageDiffWrapper {


### PR DESCRIPTION
## Summary

Fixes #534

- Portrait screenshots and videos were stretched to full panel width, making them hard to view on wide monitors
- Added `max-height: 80vh; width: auto; height: auto; max-width: 100%` to `img` and `video` attachment elements in both `web-components` and `web-classic`
- Landscape media continues to fill the available width (no regression); portrait media now stays within the visible viewport without scrolling