### PR TITLE
fix(web-awesome): restore step tree expansion policy logic

### DIFF
--- a/packages/web-awesome/src/components/TestResult/TrSteps/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/index.tsx
@@ -8,6 +8,8 @@ import { TrDropdown } from "@/components/TestResult/TrDropdown";
 import {
   collectExpandableStepNodes,
   getStepTreeExpansionPolicy,
+  hasFailedStepContext,
+  isOpenByDefaultForPolicy,
   isSubtreeFirstLevelOnlyOpened,
   type SubtreeNode,
 } from "@/components/TestResult/TrSteps/stepTreeExpansion";
@@ -33,7 +35,7 @@ export type TrStepsProps = {
 export const TrSteps: FunctionalComponent<TrStepsProps> = ({ bodyItems, id }) => {
   const stepsId = typeof id === "string" ? `${id}-steps` : null;
   const policy = getStepTreeExpansionPolicy();
-  const isRootOpenedByDefault = true;
+  const isRootOpenedByDefault = isOpenByDefaultForPolicy(policy, hasFailedStepContext(bodyItems));
   const isOpened = stepsId !== null ? isTreeOpened(stepsId, isRootOpenedByDefault) : isRootOpenedByDefault;
   const expandableTreeNodes = collectExpandableStepNodes(bodyItems, policy);
   const hasChildren = stepsId !== null && bodyItems.length > 0;


### PR DESCRIPTION
## Summary

- Restores the accidentally removed imports (`hasFailedStepContext`, `isOpenByDefaultForPolicy`) in `TrSteps/index.tsx`
- Fixes `isRootOpenedByDefault` that was hardcoded to `true` in #676, causing steps to always render as expanded regardless of the configured expansion policy

## Root cause

In #676, the line:
```ts
const isRootOpenedByDefault = isOpenByDefaultForPolicy(policy, hasFailedStepContext(bodyItems));
```
was replaced with:
```ts
const isRootOpenedByDefault = true;
```

This broke `expand_failed_only` (passed-only steps were shown) and `collapsed` (steps were never collapsed by default).