### PR TITLE
chore(plugin-agent): add npm package links

### DIFF
--- a/packages/plugin-agent/package.json
+++ b/packages/plugin-agent/package.json
@@ -13,6 +13,10 @@
   "license": "Apache-2.0",
   "author": "Qameta Software",
   "repository": "https://github.com/allure-framework/allure3",
+  "homepage": "https://github.com/allure-framework/allure3/tree/main/packages/plugin-agent#readme",
+  "bugs": {
+    "url": "https://github.com/allure-framework/allure3/issues"
+  },
   "files": [
     "./dist"
   ],


### PR DESCRIPTION
## Summary

Adds standard npm link metadata for `@allurereport/plugin-agent`:

- `homepage` points to the package README
- `bugs.url` points to the repository issue tracker

This makes the npm package page link back to the package documentation and issues.

## Validation

- Node metadata assertion for `homepage` and `bugs.url`
- `npm pack --dry-run --json --ignore-scripts` from `packages/plugin-agent`
- `git diff --check`

No build was run because this is a package metadata-only change.