### PR TITLE
chore: add plugin-jira npm support metadata

### DIFF
--- a/packages/plugin-jira/package.json
+++ b/packages/plugin-jira/package.json
@@ -12,6 +12,10 @@
   "license": "Apache-2.0",
   "author": "Qameta Software",
   "repository": "https://github.com/allure-framework/allure3",
+  "homepage": "https://github.com/allure-framework/allure3#readme",
+  "bugs": {
+    "url": "https://github.com/allure-framework/allure3/issues"
+  },
   "files": [
     "./dist"
   ],


### PR DESCRIPTION
## Summary
- add npm homepage metadata for @allurereport/plugin-jira
- add bugs.url metadata pointing to the Allure issue tracker

## Verification
- checked packages/plugin-jira/package.json contains homepage and bugs.url
- no runtime code changed