### PR TITLE
fix(web-awesome): modal ESC close, clipboard trace, split flash, first-click scroll

### DIFF
--- a/packages/web-awesome/src/components/SplitLayout/index.tsx
+++ b/packages/web-awesome/src/components/SplitLayout/index.tsx
@@ -1,8 +1,7 @@
 import { Loadable, PageLoader, Text } from "@allurereport/web-components";
 import { computed } from "@preact/signals";
 import clsx from "clsx";
-import type { JSX } from "preact";
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useMemo, useRef } from "preact/hooks";
 
 import MainReport from "@/components/MainReport";
 import SideBySide from "@/components/SideBySide";
@@ -40,10 +39,11 @@ const isTestResultRoute = computed(
 
 export const SplitLayout = () => {
   const testResultId = currentTrId.value;
-  const [cachedMain, setCachedMain] = useState<JSX.Element | null>(null);
   const { t } = useI18n("controls");
-  const leftSide = (
-    <Loadable source={treeStore} renderLoader={() => <PageLoader />} renderData={() => <MainReportWrapper />} />
+
+  const leftSide = useMemo(
+    () => <Loadable source={treeStore} renderLoader={() => <PageLoader />} renderData={() => <MainReportWrapper />} />,
+    [],
   );
 
   const TrView = () => {
@@ -67,15 +67,9 @@ export const SplitLayout = () => {
     );
   };
 
-  useEffect(() => {
-    if (!cachedMain) {
-      setCachedMain(leftSide);
-    }
-  }, [cachedMain]);
-
   return (
     <div className={styles["side-by-side"]} data-testId={"split-layout"}>
-      <SideBySide left={cachedMain} right={<TrView />} />
+      <SideBySide left={leftSide} right={<TrView />} />
     </div>
   );
 };

--- a/packages/web-awesome/src/components/TestResult/TrError/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrError/index.tsx
@@ -83,7 +83,7 @@ export const TrError: FunctionalComponent<
                 size={"s"}
                 icon={allureIcons.lineGeneralCopy3}
                 onClick={() => {
-                  copyToClipboard(message);
+                  copyToClipboard(trace || message);
                 }}
               />
             </TooltipWrapper>
@@ -117,7 +117,7 @@ export const TrError: FunctionalComponent<
               size={"s"}
               icon={allureIcons.lineGeneralCopy3}
               onClick={() => {
-                copyToClipboard(message);
+                copyToClipboard(trace || message);
               }}
             />
           </TooltipWrapper>

--- a/packages/web-awesome/src/hooks/useTestResultOverviewFocusScroll.ts
+++ b/packages/web-awesome/src/hooks/useTestResultOverviewFocusScroll.ts
@@ -1,23 +1,23 @@
 import { scrollFocusIntoView } from "@allurereport/web-commons";
 import { useLayoutEffect } from "preact/hooks";
 
-import { getFlatTestResultNode, testResultFocusId } from "@/stores/testResultOverviewNav";
+import { getFlatTestResultNode, testResultScrollToId } from "@/stores/testResultOverviewNav";
 
 export const useTestResultOverviewFocusScroll = () => {
-  const focusId = testResultFocusId.value;
+  const scrollToId = testResultScrollToId.value;
 
   useLayoutEffect(() => {
-    if (!focusId) {
+    if (!scrollToId) {
       return;
     }
 
-    const node = document.querySelector(`[data-tr-focus-id="${focusId}"]`);
+    const node = document.querySelector(`[data-tr-focus-id="${scrollToId}"]`);
 
     if (!(node instanceof HTMLElement)) {
       return;
     }
 
-    const flatNode = getFlatTestResultNode(focusId);
+    const flatNode = getFlatTestResultNode(scrollToId);
     scrollFocusIntoView(node, { containerAttribute: "data-tr-scroll-container", kind: flatNode?.kind });
-  }, [focusId]);
+  }, [scrollToId]);
 };

--- a/packages/web-awesome/src/stores/testResultOverviewNav.ts
+++ b/packages/web-awesome/src/stores/testResultOverviewNav.ts
@@ -9,6 +9,9 @@ import { collapsedTrees, isTreeOpened, setTreeOpened, toggleTree } from "@/store
 import { flattenTestResultOverview } from "@/utils/flattenTestResultOverview";
 export const testResultFocusId = signal<string | undefined>(undefined);
 
+/** Set only by explicit keyboard navigation (not auto-initialization). Controls scroll in useTestResultOverviewFocusScroll. */
+export const testResultScrollToId = signal<string | undefined>(undefined);
+
 export const isTestResultOverviewNavigationContext = (): boolean =>
   isTestResultHotkeysContext() && trCurrentTab.value === "overview";
 
@@ -52,6 +55,7 @@ export const moveTestResultFocus = (direction: MoveDirection): MoveFocusResult =
 
 export const setTestResultFocusId = (id: string | undefined) => {
   testResultFocusId.value = id;
+  testResultScrollToId.value = id;
 };
 
 export const ensureTestResultFocusId = () => {
@@ -87,6 +91,7 @@ effect(() => {
 
   if (trCurrentTab.value !== "overview") {
     testResultFocusId.value = undefined;
+    testResultScrollToId.value = undefined;
   }
 });
 

--- a/packages/web-components/src/components/Modal/index.tsx
+++ b/packages/web-components/src/components/Modal/index.tsx
@@ -104,6 +104,19 @@ export const Modal = ({
     };
   }, [isModalOpen]);
 
+  useEffect(() => {
+    if (!isModalOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        closeModal?.();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isModalOpen, closeModal]);
+
   const downloadData = async (e: Event) => {
     e.stopPropagation();
     const { id, ext, contentType } = link || {};


### PR DESCRIPTION
## Summary

- **Modal ESC close** (`web-components/Modal`): adds a `keydown` listener that calls `closeModal` when `Escape` is pressed while the modal is open
- **Clipboard copies trace** (`TrError`): both clipboard icon buttons now copy `trace` when available, falling back to `message`; previously always copied message
- **Split layout flash** (`SplitLayout`): left pane is now computed with `useMemo([], [])` instead of deferred `useState + useEffect`, so both panes render at their correct widths on the very first paint
- **First-click scroll-up** (`testResultOverviewNav` + `useTestResultOverviewFocusScroll`): introduces a separate `testResultScrollToId` signal that is only set by explicit keyboard navigation (`setTestResultFocusId`); `ensureTestResultFocusId` auto-initialization only updates `testResultFocusId` and never triggers a scroll — fixes the scroll-to-top that occurred on the first mouse click inside the test result pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)