### PR TITLE
Improve ANSI color readability in report error details

### DIFF
--- a/packages/web-awesome/src/components/Categories/MessageTreeItem/index.tsx
+++ b/packages/web-awesome/src/components/Categories/MessageTreeItem/index.tsx
@@ -1,6 +1,6 @@
 import type { CategoryNode, CategoryNodeProps, Statistic, TestStatus } from "@allurereport/core-api";
 import { getWorstStatus } from "@allurereport/core-api";
-import { ansiToHTML } from "@allurereport/web-commons";
+import { ansiSemanticColors, ansiToHTML, normalizeAnsiForegroundColors } from "@allurereport/web-commons";
 import { ArrowButton, Button, Code, TreeStatusBar } from "@allurereport/web-components";
 import clsx from "clsx";
 import type { ComponentChildren } from "preact";
@@ -57,7 +57,11 @@ export const MessageTreeItem: FC<MessageTreeItemProps> = ({
 }) => {
   const { t } = useI18n("ui");
   const status = statusFromStatistic(node.statistic);
-  const sanitizedMessage = ansiToHTML(node.name ?? "", { fg: "var(--color-text-primary)", colors: {} });
+  const sanitizedMessage = ansiToHTML(normalizeAnsiForegroundColors(node.name ?? ""), {
+    fg: "var(--color-text-primary)",
+    bg: "none",
+    colors: ansiSemanticColors,
+  });
   const stickyStyle = createCategoriesStickyStyle(depth);
   const hasLongMessage = (node.name ?? "").length > 80;
   const [isMessageExpanded, setIsMessageExpanded] = useState(false);

--- a/packages/web-awesome/src/components/TestResult/TrError/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrError/index.tsx
@@ -1,5 +1,5 @@
 import type { TestError, TestStatus } from "@allurereport/core-api";
-import { ansiToHTML } from "@allurereport/web-commons";
+import { ansiSemanticColors, ansiToHTML, normalizeAnsiForegroundColors } from "@allurereport/web-commons";
 import { Button, Code, IconButton, Text, TooltipWrapper, allureIcons } from "@allurereport/web-components";
 import clsx from "clsx";
 import { type FunctionalComponent } from "preact";
@@ -13,19 +13,15 @@ import { copyToClipboard } from "@/utils/copyToClipboard";
 
 import * as styles from "./styles.scss";
 
-const TrErrorTrace = ({ trace }: { trace: string }) => {
-  const sanitizedTrace = ansiToHTML(trace, {
+const ansiStatusDetailsToHTML = (text: string) =>
+  ansiToHTML(normalizeAnsiForegroundColors(text), {
     fg: "var(--color-text-primary)",
     bg: "none",
-    colors: {
-      0: "none",
-      1: "none",
-      2: "var(--color-intent-info-text)",
-      3: "var(--color-intent-warning-text)",
-      4: "var(--color-status-unknown-chart)",
-      5: "var(--color-syntax-type)",
-    },
+    colors: ansiSemanticColors,
   });
+
+const TrErrorTrace = ({ trace }: { trace: string }) => {
+  const sanitizedTrace = ansiStatusDetailsToHTML(trace);
 
   return (
     <div data-testid="test-result-error-trace" className={styles["test-result-error-trace"]}>
@@ -52,13 +48,7 @@ export const TrError: FunctionalComponent<
       data: { actual, expected },
       component: <TrDiff actual={actual} expected={expected} />,
     });
-  const sanitizedMessage =
-    showMessage && message
-      ? ansiToHTML(message, {
-          fg: "var(--color-text-primary)",
-          colors: {},
-        })
-      : "";
+  const sanitizedMessage = showMessage && message ? ansiStatusDetailsToHTML(message) : "";
 
   return (
     <div

--- a/packages/web-commons/src/strings.ts
+++ b/packages/web-commons/src/strings.ts
@@ -23,6 +23,175 @@ const ansiRegex = /\x1B\[[0-9;?]*[ -/]*[@-~]/g;
 
 export const isAnsi = (text?: string): boolean => typeof text === "string" && new RegExp(ansiRegex).test(text);
 
+const semanticAnsiColor = {
+  primary: 256,
+  muted: 257,
+  danger: 258,
+  success: 259,
+  warning: 260,
+  info: 261,
+  unknown: 262,
+  decorative: 263,
+} as const;
+
+export const ansiSemanticColors: Record<number, string> = {
+  0: "var(--color-text-primary)",
+  1: "var(--color-intent-danger-text)",
+  2: "var(--color-intent-success-text)",
+  3: "var(--color-intent-warning-text)",
+  4: "var(--color-intent-info-text)",
+  5: "var(--color-status-unknown-text)",
+  6: "var(--color-decorative-5-text)",
+  7: "var(--color-text-primary)",
+  8: "var(--color-text-muted)",
+  9: "var(--color-intent-danger-text)",
+  10: "var(--color-intent-success-text)",
+  11: "var(--color-intent-warning-text)",
+  12: "var(--color-intent-info-text)",
+  13: "var(--color-status-unknown-text)",
+  14: "var(--color-decorative-5-text)",
+  15: "var(--color-text-primary)",
+  [semanticAnsiColor.primary]: "var(--color-text-primary)",
+  [semanticAnsiColor.muted]: "var(--color-text-muted)",
+  [semanticAnsiColor.danger]: "var(--color-intent-danger-text)",
+  [semanticAnsiColor.success]: "var(--color-intent-success-text)",
+  [semanticAnsiColor.warning]: "var(--color-intent-warning-text)",
+  [semanticAnsiColor.info]: "var(--color-intent-info-text)",
+  [semanticAnsiColor.unknown]: "var(--color-status-unknown-text)",
+  [semanticAnsiColor.decorative]: "var(--color-decorative-5-text)",
+};
+
+const xtermColorLevels = [0, 95, 135, 175, 215, 255];
+
+const getReadableAnsiColor = (red: number, green: number, blue: number) => {
+  const brightness = red * 0.299 + green * 0.587 + blue * 0.114;
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+
+  if (red >= 150 && green >= 120 && blue <= 210 && red + green >= blue * 2.2) {
+    return semanticAnsiColor.warning;
+  }
+
+  if (green >= red + 20 && green >= blue + 20) {
+    return semanticAnsiColor.success;
+  }
+
+  if (red >= green + 30 && red >= blue + 30) {
+    return semanticAnsiColor.danger;
+  }
+
+  if (blue >= red + 20 && blue >= green - 10) {
+    return semanticAnsiColor.info;
+  }
+
+  if (red >= 120 && blue >= 120 && green <= max - 20) {
+    return semanticAnsiColor.unknown;
+  }
+
+  if (max - min <= 32) {
+    return brightness >= 150 || brightness <= 80 ? semanticAnsiColor.primary : semanticAnsiColor.muted;
+  }
+
+  return semanticAnsiColor.primary;
+};
+
+const getXtermColorRgb = (colorIndex: number) => {
+  if (colorIndex >= 16 && colorIndex <= 231) {
+    const cubeIndex = colorIndex - 16;
+
+    return {
+      red: xtermColorLevels[Math.floor(cubeIndex / 36)],
+      green: xtermColorLevels[Math.floor((cubeIndex % 36) / 6)],
+      blue: xtermColorLevels[cubeIndex % 6],
+    };
+  }
+
+  if (colorIndex >= 232 && colorIndex <= 255) {
+    const level = (colorIndex - 232) * 10 + 8;
+
+    return {
+      red: level,
+      green: level,
+      blue: level,
+    };
+  }
+};
+
+const isValidColorPart = (value: number) => Number.isInteger(value) && value >= 0 && value <= 255;
+
+export const normalizeAnsiForegroundColors = (text: string) =>
+  text.replace(/\x1b\[([0-9;]*)m/g, (match, sequence: string) => {
+    const codes = sequence.length === 0 ? [0] : sequence.split(";").map(Number);
+
+    if (codes.some((code) => !Number.isInteger(code))) {
+      return match;
+    }
+
+    const fragments: string[] = [];
+    let displayCodes: number[] = [];
+    const flushDisplayCodes = () => {
+      if (displayCodes.length > 0) {
+        fragments.push(`\x1b[${displayCodes.join(";")}m`);
+        displayCodes = [];
+      }
+    };
+
+    for (let index = 0; index < codes.length; ) {
+      const code = codes[index];
+
+      if (code === 38 && codes[index + 1] === 5 && isValidColorPart(codes[index + 2])) {
+        const rgb = getXtermColorRgb(codes[index + 2]);
+
+        flushDisplayCodes();
+        fragments.push(
+          `\x1b[38;5;${rgb ? getReadableAnsiColor(rgb.red, rgb.green, rgb.blue) : semanticAnsiColor.primary}m`,
+        );
+        index += 3;
+        continue;
+      }
+
+      if (
+        code === 38 &&
+        codes[index + 1] === 2 &&
+        isValidColorPart(codes[index + 2]) &&
+        isValidColorPart(codes[index + 3]) &&
+        isValidColorPart(codes[index + 4])
+      ) {
+        flushDisplayCodes();
+        fragments.push(`\x1b[38;5;${getReadableAnsiColor(codes[index + 2], codes[index + 3], codes[index + 4])}m`);
+        index += 5;
+        continue;
+      }
+
+      if (code === 48 && codes[index + 1] === 5 && isValidColorPart(codes[index + 2])) {
+        flushDisplayCodes();
+        fragments.push(`\x1b[48;5;${codes[index + 2]}m`);
+        index += 3;
+        continue;
+      }
+
+      if (
+        code === 48 &&
+        codes[index + 1] === 2 &&
+        isValidColorPart(codes[index + 2]) &&
+        isValidColorPart(codes[index + 3]) &&
+        isValidColorPart(codes[index + 4])
+      ) {
+        flushDisplayCodes();
+        fragments.push(`\x1b[48;2;${codes[index + 2]};${codes[index + 3]};${codes[index + 4]}m`);
+        index += 5;
+        continue;
+      }
+
+      displayCodes.push(code);
+      index += 1;
+    }
+
+    flushDisplayCodes();
+
+    return fragments.join("");
+  });
+
 /**
  * Pre-sanitized by XML escaping ANSI to HTML converter.
  * @param text ANSI text to convert to HTML.

--- a/packages/web-commons/test/strings.test.ts
+++ b/packages/web-commons/test/strings.test.ts
@@ -1,0 +1,67 @@
+import { attachment, label, step } from "allure-js-commons";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { ansiSemanticColors, ansiToHTML, isAnsi, normalizeAnsiForegroundColors } from "../src/strings.js";
+
+const renderAnsiHtml = async (name: string, ansiText: string) =>
+  step(name, async () => {
+    const html = ansiToHTML(normalizeAnsiForegroundColors(ansiText), {
+      fg: "var(--color-text-primary)",
+      bg: "none",
+      colors: ansiSemanticColors,
+    });
+
+    await attachment("rendered-html.html", html, "text/html");
+
+    return html;
+  });
+
+describe("strings", () => {
+  beforeEach(async () => {
+    await label("layer", "unit");
+    await label("component", "web-commons");
+  });
+
+  test("detects ANSI escape sequences", () => {
+    expect(isAnsi("\u001B[31mError\u001B[39m")).toBe(true);
+    expect(isAnsi("plain output")).toBe(false);
+  });
+
+  test("renders standard ANSI colors with theme semantic variables", async () => {
+    const html = await renderAnsiHtml(
+      "render standard ANSI foreground colors",
+      "\u001B[31mError\u001B[39m \u001B[32mOK\u001B[39m",
+    );
+
+    expect({
+      usesDangerToken: html.includes("color:var(--color-intent-danger-text)"),
+      usesSuccessToken: html.includes("color:var(--color-intent-success-text)"),
+      usesDefaultRed: html.includes("#A00"),
+      usesDefaultGreen: html.includes("#0A0"),
+    }).toEqual({
+      usesDangerToken: true,
+      usesSuccessToken: true,
+      usesDefaultRed: false,
+      usesDefaultGreen: false,
+    });
+  });
+
+  test("normalizes extended foreground colors to readable theme semantic colors", async () => {
+    const html = await renderAnsiHtml(
+      "render extended ANSI foreground colors",
+      "\u001B[38;2;255;0;0mError\u001B[39m \u001B[38;5;46mOK\u001B[39m",
+    );
+
+    expect({
+      usesDangerToken: html.includes("color:var(--color-intent-danger-text)"),
+      usesSuccessToken: html.includes("color:var(--color-intent-success-text)"),
+      usesInlineRgbRed: html.includes("rgb(255,0,0)"),
+      usesRawXtermGreen: html.includes("#00ff00"),
+    }).toEqual({
+      usesDangerToken: true,
+      usesSuccessToken: true,
+      usesInlineRgbRed: false,
+      usesRawXtermGreen: false,
+    });
+  });
+});

--- a/packages/web-components/src/components/Attachment/AttachmentCode.tsx
+++ b/packages/web-components/src/components/Attachment/AttachmentCode.tsx
@@ -1,4 +1,4 @@
-import { ansiToHTML, isAnsi } from "@allurereport/web-commons";
+import { ansiSemanticColors, ansiToHTML, isAnsi, normalizeAnsiForegroundColors } from "@allurereport/web-commons";
 import { useMemo } from "preact/hooks";
 
 import type { AttachmentProps } from "./model";
@@ -60,175 +60,6 @@ const highlightCode = (text: string, language: string): string => {
   }
 };
 
-const semanticAnsiColor = {
-  primary: 256,
-  muted: 257,
-  danger: 258,
-  success: 259,
-  warning: 260,
-  info: 261,
-  unknown: 262,
-  decorative: 263,
-} as const;
-
-const ansiColors: Record<number, string> = {
-  0: "var(--color-text-primary)",
-  1: "var(--color-intent-danger-text)",
-  2: "var(--color-intent-success-text)",
-  3: "var(--color-intent-warning-text)",
-  4: "var(--color-intent-info-text)",
-  5: "var(--color-status-unknown-text)",
-  6: "var(--color-decorative-5-text)",
-  7: "var(--color-text-primary)",
-  8: "var(--color-text-muted)",
-  9: "var(--color-intent-danger-text)",
-  10: "var(--color-intent-success-text)",
-  11: "var(--color-intent-warning-text)",
-  12: "var(--color-intent-info-text)",
-  13: "var(--color-status-unknown-text)",
-  14: "var(--color-decorative-5-text)",
-  15: "var(--color-text-primary)",
-  [semanticAnsiColor.primary]: "var(--color-text-primary)",
-  [semanticAnsiColor.muted]: "var(--color-text-muted)",
-  [semanticAnsiColor.danger]: "var(--color-intent-danger-text)",
-  [semanticAnsiColor.success]: "var(--color-intent-success-text)",
-  [semanticAnsiColor.warning]: "var(--color-intent-warning-text)",
-  [semanticAnsiColor.info]: "var(--color-intent-info-text)",
-  [semanticAnsiColor.unknown]: "var(--color-status-unknown-text)",
-  [semanticAnsiColor.decorative]: "var(--color-decorative-5-text)",
-};
-
-const xtermColorLevels = [0, 95, 135, 175, 215, 255];
-
-const getReadableAnsiColor = (red: number, green: number, blue: number) => {
-  const brightness = red * 0.299 + green * 0.587 + blue * 0.114;
-  const max = Math.max(red, green, blue);
-  const min = Math.min(red, green, blue);
-
-  if (red >= 150 && green >= 120 && blue <= 210 && red + green >= blue * 2.2) {
-    return semanticAnsiColor.warning;
-  }
-
-  if (green >= red + 20 && green >= blue + 20) {
-    return semanticAnsiColor.success;
-  }
-
-  if (red >= green + 30 && red >= blue + 30) {
-    return semanticAnsiColor.danger;
-  }
-
-  if (blue >= red + 20 && blue >= green - 10) {
-    return semanticAnsiColor.info;
-  }
-
-  if (red >= 120 && blue >= 120 && green <= max - 20) {
-    return semanticAnsiColor.unknown;
-  }
-
-  if (max - min <= 32) {
-    return brightness >= 150 || brightness <= 80 ? semanticAnsiColor.primary : semanticAnsiColor.muted;
-  }
-
-  return semanticAnsiColor.primary;
-};
-
-const getXtermColorRgb = (colorIndex: number) => {
-  if (colorIndex >= 16 && colorIndex <= 231) {
-    const cubeIndex = colorIndex - 16;
-
-    return {
-      red: xtermColorLevels[Math.floor(cubeIndex / 36)],
-      green: xtermColorLevels[Math.floor((cubeIndex % 36) / 6)],
-      blue: xtermColorLevels[cubeIndex % 6],
-    };
-  }
-
-  if (colorIndex >= 232 && colorIndex <= 255) {
-    const level = (colorIndex - 232) * 10 + 8;
-
-    return {
-      red: level,
-      green: level,
-      blue: level,
-    };
-  }
-};
-
-const isValidColorPart = (value: number) => Number.isInteger(value) && value >= 0 && value <= 255;
-
-const normalizeAnsiForegroundColors = (text: string) =>
-  text.replace(/\x1b\[([0-9;]*)m/g, (match, sequence: string) => {
-    const codes = sequence.length === 0 ? [0] : sequence.split(";").map(Number);
-
-    if (codes.some((code) => !Number.isInteger(code))) {
-      return match;
-    }
-
-    const fragments: string[] = [];
-    let displayCodes: number[] = [];
-    const flushDisplayCodes = () => {
-      if (displayCodes.length > 0) {
-        fragments.push(`\x1b[${displayCodes.join(";")}m`);
-        displayCodes = [];
-      }
-    };
-
-    for (let index = 0; index < codes.length; ) {
-      const code = codes[index];
-
-      if (code === 38 && codes[index + 1] === 5 && isValidColorPart(codes[index + 2])) {
-        const rgb = getXtermColorRgb(codes[index + 2]);
-
-        flushDisplayCodes();
-        fragments.push(
-          `\x1b[38;5;${rgb ? getReadableAnsiColor(rgb.red, rgb.green, rgb.blue) : semanticAnsiColor.primary}m`,
-        );
-        index += 3;
-        continue;
-      }
-
-      if (
-        code === 38 &&
-        codes[index + 1] === 2 &&
-        isValidColorPart(codes[index + 2]) &&
-        isValidColorPart(codes[index + 3]) &&
-        isValidColorPart(codes[index + 4])
-      ) {
-        flushDisplayCodes();
-        fragments.push(`\x1b[38;5;${getReadableAnsiColor(codes[index + 2], codes[index + 3], codes[index + 4])}m`);
-        index += 5;
-        continue;
-      }
-
-      if (code === 48 && codes[index + 1] === 5 && isValidColorPart(codes[index + 2])) {
-        flushDisplayCodes();
-        fragments.push(`\x1b[48;5;${codes[index + 2]}m`);
-        index += 3;
-        continue;
-      }
-
-      if (
-        code === 48 &&
-        codes[index + 1] === 2 &&
-        isValidColorPart(codes[index + 2]) &&
-        isValidColorPart(codes[index + 3]) &&
-        isValidColorPart(codes[index + 4])
-      ) {
-        flushDisplayCodes();
-        fragments.push(`\x1b[48;2;${codes[index + 2]};${codes[index + 3]};${codes[index + 4]}m`);
-        index += 5;
-        continue;
-      }
-
-      displayCodes.push(code);
-      index += 1;
-    }
-
-    flushDisplayCodes();
-
-    return fragments.join("");
-  });
-
 const languageFromName = (name?: string): string | undefined => {
   if (!name) {
     return undefined;
@@ -280,7 +111,7 @@ export const AttachmentCode = (props: AttachmentProps & { highlight?: boolean })
     const sanitizedText = ansiToHTML(normalizeAnsiForegroundColors(rawText), {
       fg: "var(--color-text-primary)",
       bg: "none",
-      colors: ansiColors,
+      colors: ansiSemanticColors,
     });
 
     return (


### PR DESCRIPTION
ANSI-colored output in status details now renders with Allure theme colors instead of raw terminal colors. Failure messages, traces, and category messages remain readable on tinted status panels, so red or green terminal output no longer clashes with failed or broken backgrounds.

This also keeps ANSI rendering consistent with text attachments, including standard terminal colors and extended RGB/xterm foreground colors. Reports preserve useful terminal emphasis while adapting it to the active report theme.