### PR TITLE
chore(plugin-testops): support `enable` property from config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,7 +3,7 @@ import { extname, resolve } from "node:path";
 import * as process from "node:process";
 
 import { validateEnvironmentName } from "@allurereport/core-api";
-import type { Config, PluginDescriptor } from "@allurereport/plugin-api";
+import type { Config, Plugin, PluginConstructorContext, PluginDescriptor } from "@allurereport/plugin-api";
 import { parse } from "yaml";
 
 import type { FullConfig, PluginInstance } from "./api.js";
@@ -19,6 +19,8 @@ import {
 import { importWrapper } from "./utils/module.js";
 import { normalizeImportPath } from "./utils/path.js";
 import { assertValidPluginIdForWindows, isWindows } from "./utils/windows.js";
+
+type PluginConstructor = new (options?: Record<string, any>, context?: PluginConstructorContext) => Plugin;
 
 export interface ConfigOverride {
   name?: Config["name"];
@@ -456,7 +458,7 @@ const isModuleNotFoundError = (err: unknown): err is Error & { code: "ERR_MODULE
   );
 };
 
-export const resolvePlugin = async (path: string) => {
+export const resolvePlugin = async (path: string): Promise<PluginConstructor> => {
   // try to append @allurereport/plugin- scope
   if (!path.startsWith("@allurereport/plugin-")) {
     try {
@@ -489,12 +491,14 @@ const resolvePlugins = async (plugins: Record<string, PluginDescriptor>) => {
     const pluginConfig = plugins[id];
     const pluginId = getPluginId(id);
     const Plugin = await resolvePlugin(pluginConfig.import ?? id);
+    const enabled = pluginConfig.enabled ?? true;
+    const constructorContext: PluginConstructorContext = { enabled };
 
     pluginInstances.push({
       id: pluginId,
-      enabled: pluginConfig.enabled ?? true,
+      enabled,
       options: pluginConfig.options ?? {},
-      plugin: new Plugin(pluginConfig.options),
+      plugin: new Plugin(pluginConfig.options, constructorContext),
     });
   }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -492,7 +492,11 @@ const resolvePlugins = async (plugins: Record<string, PluginDescriptor>) => {
     const pluginId = getPluginId(id);
     const Plugin = await resolvePlugin(pluginConfig.import ?? id);
     const enabled = pluginConfig.enabled ?? true;
-    const constructorContext: PluginConstructorContext = { enabled };
+    const constructorContext: PluginConstructorContext = {};
+
+    if ("enabled" in pluginConfig) {
+      constructorContext.enabled = pluginConfig.enabled;
+    }
 
     pluginInstances.push({
       id: pluginId,

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { MAX_ENVIRONMENT_ID_LENGTH, MAX_ENVIRONMENT_NAME_LENGTH } from "@allurereport/core-api";
-import type { Config } from "@allurereport/plugin-api";
+import type { Config, PluginConstructorContext } from "@allurereport/plugin-api";
 import { epic, feature, label, story } from "allure-js-commons";
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -606,6 +606,35 @@ describe("resolveConfig", () => {
       },
       plugin: expect.any(PluginFixture),
     });
+  });
+
+  it("should pass resolved plugin enabled state to plugin constructor", async () => {
+    const constructorMock = vi.fn();
+
+    class PluginWithConstructorFixture {
+      constructor(options?: Record<string, any>, context?: PluginConstructorContext) {
+        constructorMock(options, context);
+      }
+    }
+
+    (importWrapper as unknown as MockInstance).mockResolvedValue({ default: PluginWithConstructorFixture });
+
+    await resolveConfig({
+      plugins: {
+        custom: {
+          import: "custom-plugin",
+          options: {
+            foo: "bar",
+          },
+        },
+        disabled: {
+          enabled: false,
+        },
+      },
+    });
+
+    expect(constructorMock).toHaveBeenCalledWith({ foo: "bar" }, { enabled: true });
+    expect(constructorMock).toHaveBeenCalledWith(undefined, { enabled: false });
   });
 
   it("should throw an error when config contains unsupported fields", async () => {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -608,7 +608,7 @@ describe("resolveConfig", () => {
     });
   });
 
-  it("should pass resolved plugin enabled state to plugin constructor", async () => {
+  it("should pass explicit plugin enabled state to plugin constructor", async () => {
     const constructorMock = vi.fn();
 
     class PluginWithConstructorFixture {
@@ -627,13 +627,17 @@ describe("resolveConfig", () => {
             foo: "bar",
           },
         },
+        enabled: {
+          enabled: true,
+        },
         disabled: {
           enabled: false,
         },
       },
     });
 
-    expect(constructorMock).toHaveBeenCalledWith({ foo: "bar" }, { enabled: true });
+    expect(constructorMock).toHaveBeenCalledWith({ foo: "bar" }, {});
+    expect(constructorMock).toHaveBeenCalledWith(undefined, { enabled: true });
     expect(constructorMock).toHaveBeenCalledWith(undefined, { enabled: false });
   });
 

--- a/packages/plugin-api/src/plugin.ts
+++ b/packages/plugin-api/src/plugin.ts
@@ -20,6 +20,10 @@ export interface PluginDescriptor {
   options?: Record<string, any>;
 }
 
+export interface PluginConstructorContext {
+  enabled?: boolean;
+}
+
 export interface ReportFiles {
   addFile(path: string, data: Buffer): Promise<string>;
 }

--- a/packages/plugin-testops/src/plugin.ts
+++ b/packages/plugin-testops/src/plugin.ts
@@ -3,7 +3,13 @@ import { env } from "node:process";
 import { detect, isLocalCiDescriptor } from "@allurereport/ci";
 import type { CategoryDefinition, EnvironmentIdentity, TestStatus } from "@allurereport/core-api";
 import { getWorstStatus } from "@allurereport/core-api";
-import { type AllureStore, type Plugin, type PluginContext, createPluginSummary } from "@allurereport/plugin-api";
+import {
+  type AllureStore,
+  type Plugin,
+  type PluginConstructorContext,
+  type PluginContext,
+  createPluginSummary,
+} from "@allurereport/plugin-api";
 import { uniqBy, stubTrue } from "lodash-es";
 import { bold } from "yoctocolors";
 
@@ -34,9 +40,21 @@ export class TestOpsPlugin implements Plugin {
   #autocloseLaunch: boolean = false;
   // @ts-expect-error - if gitFlow is not initialized it will not be used
   #gitFlow: LaunchGitFlow;
+  #enabledByConfig: boolean = false;
+  #disabledByConfig: boolean = false;
 
-  constructor(readonly options: TestOpsPluginOptions) {
-    if (isLocalCiDescriptor(this.#ci) && !this.isOverridenByEnv) {
+  constructor(
+    readonly options: TestOpsPluginOptions,
+    context: PluginConstructorContext = {},
+  ) {
+    this.#enabledByConfig = context.enabled === true;
+    this.#disabledByConfig = context.enabled === false;
+
+    if (this.#disabledByConfig) {
+      return;
+    }
+
+    if (isLocalCiDescriptor(this.#ci) && !this.isManuallyEnabled) {
       this.#logger.info(
         `plugin is disabled - no CI environment detected. To enable, set ${bold("ALLURE_TESTOPS_ENABLED")}=true or ${bold("CI")}=true.`,
       );
@@ -105,12 +123,16 @@ export class TestOpsPlugin implements Plugin {
     return isEnabled(env.ALLURE_TESTOPS_ENABLED) || isEnabled(env.CI);
   }
 
+  get isManuallyEnabled(): boolean {
+    return this.#enabledByConfig || this.isOverridenByEnv;
+  }
+
   get enabled(): boolean {
     if (!(this.#client instanceof TestOpsClient)) {
       return false;
     }
 
-    if (this.isOverridenByEnv) {
+    if (this.isManuallyEnabled) {
       return true;
     }
 

--- a/packages/plugin-testops/src/plugin.ts
+++ b/packages/plugin-testops/src/plugin.ts
@@ -41,16 +41,14 @@ export class TestOpsPlugin implements Plugin {
   // @ts-expect-error - if gitFlow is not initialized it will not be used
   #gitFlow: LaunchGitFlow;
   #enabledByConfig: boolean = false;
-  #disabledByConfig: boolean = false;
 
   constructor(
     readonly options: TestOpsPluginOptions,
     context: PluginConstructorContext = {},
   ) {
     this.#enabledByConfig = context.enabled === true;
-    this.#disabledByConfig = context.enabled === false;
 
-    if (this.#disabledByConfig) {
+    if (context.enabled === false) {
       return;
     }
 

--- a/packages/plugin-testops/test/plugin.test.ts
+++ b/packages/plugin-testops/test/plugin.test.ts
@@ -272,6 +272,38 @@ describe("testops plugin", () => {
         expect(plugin.enabled).toBe(false);
       });
 
+      it("should return true from enabled getter when enabled in config and ci is local", () => {
+        (detect as unknown as Mock).mockReturnValue({ type: "local" } as CiDescriptor);
+        (resolvePluginOptions as Mock).mockReturnValue({
+          accessToken: fixtures.accessToken,
+          endpoint: fixtures.endpoint,
+          projectId: fixtures.projectId,
+          launchName: "Allure Report",
+          launchTags: fixtures.launchTags,
+        });
+
+        plugin = new TestOpsPlugin({} as TestOpsPluginOptions, { enabled: true });
+
+        expect(plugin.enabled).toBe(true);
+      });
+
+      it("should return false from enabled getter when disabled in config and ci is detected", () => {
+        (detect as unknown as Mock).mockReturnValue({ type: "github" } as CiDescriptor);
+        (resolvePluginOptions as Mock).mockReturnValue({
+          accessToken: fixtures.accessToken,
+          endpoint: fixtures.endpoint,
+          projectId: fixtures.projectId,
+          launchName: "Allure Report",
+          launchTags: fixtures.launchTags,
+        });
+        TestOpsClientMock.mockClear();
+
+        plugin = new TestOpsPlugin({} as TestOpsPluginOptions, { enabled: false });
+
+        expect(plugin.enabled).toBe(false);
+        expect(TestOpsClientMock).not.toHaveBeenCalled();
+      });
+
       it("should not start upload when ci is local", async () => {
         (detect as unknown as Mock).mockReturnValue({ type: "local" } as CiDescriptor);
         (resolvePluginOptions as Mock).mockReturnValue({


### PR DESCRIPTION
The config resolver now passes the resolved plugin enabled state into plugin constructors, so enabled defaults are handled consistently.