### PR TITLE
fix: Vertically align keyboard shortcuts footer button

### DIFF
--- a/packages/web-awesome/src/components/KeyboardShortcuts/styles.scss
+++ b/packages/web-awesome/src/components/KeyboardShortcuts/styles.scss
@@ -1,7 +1,7 @@
 .shortcuts {
   position: fixed;
   right: 16px;
-  bottom: 16px;
+  bottom: 8px;
   z-index: 1000;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Correct the vertical alignment of the keyboard shortcuts button to introduce spacing between the top of the button and the top of the footer - matching spacing across the rest of the footer.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/14cfd58f-06b0-423d-82f5-d313a2947b15" />

Previously:

<img width="600" alt="Screenshot 2026-06-22 at 23 28 28" src="https://github.com/user-attachments/assets/207e6012-8593-423e-9931-024a150d14ec" />