### PR TITLE
fix: gitlfow improvements

### DIFF
--- a/.vscode/oxfmt.sh
+++ b/.vscode/oxfmt.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-exec yarn exec oxfmt "$@"

--- a/.vscode/oxlint.sh
+++ b/.vscode/oxlint.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-exec yarn exec oxlint "$@"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,8 +10,5 @@
   "oxc.enable": true,
   "oxc.typeAware": true,
   "eslint.enable": false,
-  "typescript.experimental.useTsgo": false,
-  "oxc.path.oxfmt": ".vscode/oxfmt.sh",
-  "oxc.path.oxlint": ".vscode/oxlint.sh",
   "oxc.enable.oxlint": true
 }

--- a/.yarn/sdks/oxfmt/bin/oxfmt
+++ b/.yarn/sdks/oxfmt/bin/oxfmt
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require oxfmt
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+
+  if (typeof global[`__yarnpkg_sdk_has_setup_env__`] === `undefined`) {
+    Object.defineProperty(global, `__yarnpkg_sdk_has_setup_env__`, {configurable: true, value: true});
+
+    process.env.NODE_OPTIONS = process.env.NODE_OPTIONS || ``;
+    process.env.NODE_OPTIONS += ` -r ${absPnpApiPath}`;
+    if (isPnpLoaderEnabled && register) {
+      process.env.NODE_OPTIONS += ` --experimental-loader ${pathToFileURL(absPnpLoaderPath)}`;
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+const moduleWrapper = exports => {
+  return wrapWithUserWrapper(moduleWrapperFn(exports));
+};
+
+const moduleWrapperFn = module => module;
+
+const binPath = resolve(absRequire.resolve(`oxfmt/package.json`), `..`, `bin/oxfmt`);
+absRequire(binPath);
+
+// Defer to the real oxfmt your application uses
+module.exports = moduleWrapper(absRequire(`oxfmt`));

--- a/.yarn/sdks/oxfmt/package.json
+++ b/.yarn/sdks/oxfmt/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "oxfmt",
+  "version": "0.52.0-sdk",
+  "bin": {
+    "oxfmt": "bin/oxfmt"
+  },
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/.yarn/sdks/oxlint-tsgolint/bin/tsgolint
+++ b/.yarn/sdks/oxlint-tsgolint/bin/tsgolint
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require oxlint-tsgolint/bin/tsgolint
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real oxlint-tsgolint/bin/tsgolint your application uses
+module.exports = wrapWithUserWrapper(absRequire(`oxlint-tsgolint/bin/tsgolint`));

--- a/.yarn/sdks/oxlint-tsgolint/bin/tsgolint.cmd
+++ b/.yarn/sdks/oxlint-tsgolint/bin/tsgolint.cmd
@@ -1,0 +1,1 @@
+@goto #_undefined_# 2>NUL || @title %COMSPEC% & @setlocal & @"node" "%~dp0tsgolint.js" %*

--- a/.yarn/sdks/oxlint-tsgolint/bin/tsgolint.js
+++ b/.yarn/sdks/oxlint-tsgolint/bin/tsgolint.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require oxlint-tsgolint/bin/tsgolint.js
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real oxlint-tsgolint/bin/tsgolint.js your application uses
+module.exports = wrapWithUserWrapper(absRequire(`oxlint-tsgolint/bin/tsgolint.js`));

--- a/.yarn/sdks/oxlint-tsgolint/package.json
+++ b/.yarn/sdks/oxlint-tsgolint/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "oxlint-tsgolint",
+  "version": "0.23.0-sdk",
+  "bin": {
+    "tsgolint": "./bin/tsgolint.js"
+  },
+  "type": "commonjs"
+}

--- a/.yarn/sdks/oxlint/bin/oxlint
+++ b/.yarn/sdks/oxlint/bin/oxlint
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require oxlint
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+const moduleWrapper = exports => {
+  return wrapWithUserWrapper(moduleWrapperFn(exports));
+};
+
+const moduleWrapperFn = module => module;
+
+process.env.PATH += `;${resolve(__dirname, `../../oxlint-tsgolint/bin`)}`;
+
+const binPath = resolve(absRequire.resolve(`oxlint/package.json`), `..`, `bin/oxlint`);
+import(pathToFileURL(binPath));
+
+// Defer to the real oxlint your application uses
+module.exports = moduleWrapper(absRequire(`oxlint`));

--- a/.yarn/sdks/oxlint/package.json
+++ b/.yarn/sdks/oxlint/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "oxlint",
+  "version": "1.67.0-sdk",
+  "bin": {
+    "oxlint": "bin/oxlint"
+  },
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugins-dev": {
+      "types": "./dist/plugins-dev.d.ts",
+      "default": "./dist/plugins-dev.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/git/src/collectGitFacts.ts
+++ b/packages/git/src/collectGitFacts.ts
@@ -9,6 +9,24 @@ export type CollectGitFactsOptions = {
   ancestorLimit?: number;
 };
 
+const normalizeAncestorLimit = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+
+  return DEFAULT_ANCESTOR_LIMIT;
+};
+
+const normalizePositiveInteger = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+
+  const normalized = Math.floor(value);
+
+  return normalized > 0 ? normalized : undefined;
+};
+
 const stripRemotePrefix = (upstreamRef: string): string => {
   const slashIndex = upstreamRef.indexOf("/");
 
@@ -31,6 +49,28 @@ const resolveBranch = (cwd?: string): string | undefined => {
   return branchRaw;
 };
 
+const ensureAncestorHistory = (ancestorLimit: number, cwd?: string): void => {
+  if (runGit(["rev-parse", "--is-shallow-repository"], cwd) !== "true") {
+    return;
+  }
+
+  const needed = ancestorLimit + 1;
+  const availableRaw = runGit(["rev-list", "--first-parent", "--count", "HEAD"], cwd);
+  const available = normalizePositiveInteger(Number(availableRaw)) ?? 0;
+
+  if (available >= needed) {
+    return;
+  }
+
+  const deepenBy = normalizePositiveInteger(available > 0 ? needed - available : ancestorLimit);
+
+  if (!deepenBy) {
+    return;
+  }
+
+  runGit(["fetch", "--deepen", String(deepenBy), "origin"], cwd);
+};
+
 const collectLocalState = (cwd?: string): GitLocalState => {
   const statusPorcelain = runGit(["status", "--porcelain"], cwd) ?? "";
   const branchRaw = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
@@ -48,7 +88,8 @@ const collectLocalState = (cwd?: string): GitLocalState => {
 };
 
 export const collectGitFacts = (options: CollectGitFactsOptions = {}): GitFacts | undefined => {
-  const { cwd, ancestorLimit = DEFAULT_ANCESTOR_LIMIT } = options;
+  const { cwd } = options;
+  const ancestorLimit = normalizeAncestorLimit(options.ancestorLimit);
 
   if (runGit(["rev-parse", "--is-inside-work-tree"], cwd) !== "true") {
     return undefined;
@@ -61,6 +102,8 @@ export const collectGitFacts = (options: CollectGitFactsOptions = {}): GitFacts 
   }
 
   const branch = resolveBranch(cwd);
+
+  ensureAncestorHistory(ancestorLimit, cwd);
 
   const revList = runGit(["rev-list", "--first-parent", commit, `--max-count=${ancestorLimit + 1}`], cwd);
 

--- a/packages/git/test/collectGitFacts.test.ts
+++ b/packages/git/test/collectGitFacts.test.ts
@@ -1,4 +1,4 @@
-import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+import { type Mock, beforeEach, describe, it, vi, expect } from "vitest";
 
 import { collectGitFacts } from "../src/collectGitFacts.js";
 import * as runGitModule from "../src/runGit.js";
@@ -17,15 +17,21 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const mockHappyGit = (params?: { branch?: string; ancestors?: string[]; detached?: boolean }) => {
+const mockHappyGit = (params?: {
+  branch?: string;
+  ancestors?: string[];
+  detached?: boolean;
+  firstParentCount?: number;
+}) => {
   const branch = params?.detached ? "HEAD" : (params?.branch ?? "main");
   const ancestors = params?.ancestors ?? [COMMIT_C, COMMIT_B, COMMIT_A];
+  const firstParentCount = params?.firstParentCount ?? ancestors.length;
 
   runGit.mockImplementation((args: string[]) => {
     const key = args.join(" ");
 
-    if (key === "rev-parse --is-inside-work-tree") {
-      return "true";
+    if (key === "rev-parse --is-inside-work-tree" || key === "rev-parse --is-shallow-repository") {
+      return key === "rev-parse --is-shallow-repository" ? "false" : "true";
     }
 
     if (key === "rev-parse HEAD") {
@@ -34,6 +40,10 @@ const mockHappyGit = (params?: { branch?: string; ancestors?: string[]; detached
 
     if (key === "rev-parse --abbrev-ref HEAD") {
       return branch;
+    }
+
+    if (key === "rev-list --first-parent --count HEAD") {
+      return String(firstParentCount);
     }
 
     if (key.startsWith("rev-list --first-parent")) {
@@ -64,7 +74,7 @@ describe("collectGitFacts", () => {
       }
     });
 
-    expect(collectGitFacts()).toBeUndefined();
+    expect(collectGitFacts(), "returns undefined outside a git work tree").toBeUndefined();
   });
 
   it("returns undefined when HEAD cannot be resolved", () => {
@@ -80,7 +90,7 @@ describe("collectGitFacts", () => {
       }
     });
 
-    expect(collectGitFacts()).toBeUndefined();
+    expect(collectGitFacts(), "returns undefined when HEAD cannot be resolved").toBeUndefined();
   });
 
   it("collects commit, branch, ancestors newest-first, and local state", () => {
@@ -88,7 +98,7 @@ describe("collectGitFacts", () => {
 
     const facts = collectGitFacts({ ancestorLimit: 2 });
 
-    expect(facts).toEqual({
+    expect(facts, "collects commit, branch, first-parent ancestors newest-first, and local state").toEqual({
       commit: COMMIT_C,
       branch: "main",
       firstParentAncestors: [COMMIT_B, COMMIT_A],
@@ -100,7 +110,9 @@ describe("collectGitFacts", () => {
       },
     });
 
-    expect(runGit).toHaveBeenCalledWith(["rev-list", "--first-parent", COMMIT_C, "--max-count=3"], undefined);
+    expect(runGit.mock.calls, "limits rev-list to ancestorLimit plus HEAD").toEqual(
+      expect.arrayContaining([[["rev-list", "--first-parent", COMMIT_C, "--max-count=3"], undefined]]),
+    );
   });
 
   it("returns empty ancestors when HEAD has no parents", () => {
@@ -108,8 +120,17 @@ describe("collectGitFacts", () => {
 
     const facts = collectGitFacts();
 
-    expect(facts?.firstParentAncestors).toEqual([]);
-    expect(facts?.commit).toBe(COMMIT_C);
+    expect(facts, "keeps HEAD commit and returns no ancestors for a root commit").toEqual({
+      commit: COMMIT_C,
+      branch: "main",
+      firstParentAncestors: [],
+      localState: {
+        uncommittedChanges: false,
+        unpublishedCommit: true,
+        unpublishedBranch: false,
+        detachedHead: false,
+      },
+    });
   });
 
   it("respects ancestorLimit in rev-list max-count", () => {
@@ -117,7 +138,9 @@ describe("collectGitFacts", () => {
 
     collectGitFacts({ ancestorLimit: 1 });
 
-    expect(runGit).toHaveBeenCalledWith(["rev-list", "--first-parent", COMMIT_C, "--max-count=2"], undefined);
+    expect(runGit.mock.calls, "passes ancestorLimit to rev-list max-count as limit plus one for HEAD").toEqual(
+      expect.arrayContaining([[["rev-list", "--first-parent", COMMIT_C, "--max-count=2"], undefined]]),
+    );
   });
 
   it("omits branch and sets detachedHead when HEAD is detached", () => {
@@ -125,8 +148,12 @@ describe("collectGitFacts", () => {
 
     const facts = collectGitFacts();
 
-    expect(facts?.branch).toBeUndefined();
-    expect(facts?.localState?.detachedHead).toBe(true);
+    expect(facts, "omits branch name and marks detached HEAD in local state").toMatchObject({
+      branch: undefined,
+      localState: {
+        detachedHead: true,
+      },
+    });
   });
 
   it("detects uncommitted changes from porcelain status", () => {
@@ -166,13 +193,19 @@ describe("collectGitFacts", () => {
       return undefined;
     });
 
-    expect(collectGitFacts()?.localState?.uncommittedChanges).toBe(true);
+    expect(
+      collectGitFacts()?.localState?.uncommittedChanges,
+      "detects uncommitted changes from porcelain status output",
+    ).toBe(true);
   });
 
   it("marks unpublished commit when HEAD is ahead of upstream", () => {
     mockHappyGit();
 
-    expect(collectGitFacts()?.localState?.unpublishedCommit).toBe(true);
+    expect(
+      collectGitFacts()?.localState?.unpublishedCommit,
+      "marks unpublished commit when HEAD differs from upstream",
+    ).toBe(true);
   });
 
   it("marks published commit when HEAD matches upstream", () => {
@@ -212,7 +245,9 @@ describe("collectGitFacts", () => {
       return undefined;
     });
 
-    expect(collectGitFacts()?.localState?.unpublishedCommit).toBe(false);
+    expect(collectGitFacts()?.localState?.unpublishedCommit, "marks published commit when HEAD matches upstream").toBe(
+      false,
+    );
   });
 
   it("prefers upstream branch name over local branch name", () => {
@@ -252,7 +287,7 @@ describe("collectGitFacts", () => {
       return undefined;
     });
 
-    expect(collectGitFacts()?.branch).toBe("feature/foo");
+    expect(collectGitFacts()?.branch, "prefers upstream branch name over local branch name").toBe("feature/foo");
   });
 
   it("marks unpublished commit and branch when upstream is missing", () => {
@@ -288,10 +323,13 @@ describe("collectGitFacts", () => {
       return undefined;
     });
 
-    const facts = collectGitFacts();
-
-    expect(facts?.localState?.unpublishedCommit).toBe(true);
-    expect(facts?.localState?.unpublishedBranch).toBe(true);
+    expect(
+      collectGitFacts()?.localState,
+      "marks unpublished commit and branch when upstream tracking is missing",
+    ).toMatchObject({
+      unpublishedCommit: true,
+      unpublishedBranch: true,
+    });
   });
 
   it("passes cwd to git commands", () => {
@@ -299,7 +337,362 @@ describe("collectGitFacts", () => {
 
     collectGitFacts({ cwd: "/repo" });
 
-    expect(runGit).toHaveBeenCalledWith(["rev-parse", "--is-inside-work-tree"], "/repo");
-    expect(runGit).toHaveBeenCalledWith(["rev-parse", "HEAD"], "/repo");
+    expect(runGit.mock.calls, "forwards working directory to git commands").toEqual(
+      expect.arrayContaining([
+        [["rev-parse", "--is-inside-work-tree"], "/repo"],
+        [["rev-parse", "HEAD"], "/repo"],
+      ]),
+    );
+  });
+
+  it("deepens shallow history before collecting ancestors", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-shallow-repository") {
+        return "true";
+      }
+
+      if (key === "rev-list --first-parent --count HEAD") {
+        return "2";
+      }
+
+      if (key === "fetch --deepen 41 origin") {
+        return "";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    collectGitFacts({ ancestorLimit: 42 });
+
+    expect(runGit.mock.calls, "counts first-parent history, deepens shallow clone, and lists ancestors").toEqual(
+      expect.arrayContaining([
+        [["rev-list", "--first-parent", "--count", "HEAD"], undefined],
+        [["fetch", "--deepen", "41", "origin"], undefined],
+        [["rev-list", "--first-parent", COMMIT_C, "--max-count=43"], undefined],
+      ]),
+    );
+  });
+
+  it("skips fetch when shallow repository already has enough first-parent history", () => {
+    mockHappyGit({ firstParentCount: 150 });
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-shallow-repository") {
+        return "true";
+      }
+
+      if (key === "rev-list --first-parent --count HEAD") {
+        return "150";
+      }
+
+      if (key.startsWith("fetch --deepen")) {
+        return "";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B, COMMIT_A].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    collectGitFacts({ ancestorLimit: 100 });
+
+    expect(
+      runGit.mock.calls.filter((call) => call[0][0] === "fetch"),
+      "skips fetch when shallow repository already has enough first-parent history",
+    ).toEqual([]);
+  });
+
+  it("deepens only the missing first-parent commits for partial shallow history", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-shallow-repository") {
+        return "true";
+      }
+
+      if (key === "rev-list --first-parent --count HEAD") {
+        return "50";
+      }
+
+      if (key === "fetch --deepen 51 origin") {
+        return "";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    collectGitFacts({ ancestorLimit: 100 });
+
+    expect(runGit.mock.calls, "deepens shallow history only by the missing first-parent commits").toEqual(
+      expect.arrayContaining([[["fetch", "--deepen", "51", "origin"], undefined]]),
+    );
+  });
+
+  it("skips fetch when repository is not shallow", () => {
+    mockHappyGit();
+
+    collectGitFacts({ ancestorLimit: 10 });
+
+    expect(
+      runGit.mock.calls.filter((call) => call[0][0] === "fetch"),
+      "skips fetch when repository is not shallow",
+    ).toEqual([]);
+  });
+
+  it("continues lineage collection when deepen fetch fails", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-shallow-repository") {
+        return "true";
+      }
+
+      if (key === "rev-list --first-parent --count HEAD") {
+        return "2";
+      }
+
+      if (key === "fetch --deepen 99 origin") {
+        return undefined;
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    expect(collectGitFacts()?.firstParentAncestors, "continues lineage collection when deepen fetch fails").toEqual([
+      COMMIT_B,
+    ]);
+  });
+
+  it("falls back to ancestorLimit deepen when first-parent count is unavailable", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-shallow-repository") {
+        return "true";
+      }
+
+      if (key === "rev-list --first-parent --count HEAD") {
+        return undefined;
+      }
+
+      if (key === "fetch --deepen 100 origin") {
+        return "";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    collectGitFacts({ ancestorLimit: 100 });
+
+    expect(runGit.mock.calls, "falls back to ancestorLimit deepen when first-parent count is unavailable").toEqual(
+      expect.arrayContaining([[["fetch", "--deepen", "100", "origin"], undefined]]),
+    );
+  });
+
+  it("rejects unsafe ancestorLimit values before passing them to git", () => {
+    mockHappyGit();
+
+    runGit.mockImplementation((args: string[]) => {
+      const key = args.join(" ");
+
+      if (key === "rev-parse --is-shallow-repository") {
+        return "true";
+      }
+
+      if (key === "rev-list --first-parent --count HEAD") {
+        return "1";
+      }
+
+      if (key.startsWith("fetch --deepen")) {
+        return "";
+      }
+
+      if (key === "rev-parse --is-inside-work-tree") {
+        return "true";
+      }
+
+      if (key === "rev-parse HEAD") {
+        return COMMIT_C;
+      }
+
+      if (key === "rev-parse --abbrev-ref HEAD") {
+        return "main";
+      }
+
+      if (key.startsWith("rev-list --first-parent")) {
+        return [COMMIT_C, COMMIT_B].join("\n");
+      }
+
+      if (key === "status --porcelain") {
+        return "";
+      }
+
+      if (key === "rev-parse --verify @{u}") {
+        return COMMIT_B;
+      }
+
+      if (key === "rev-parse --abbrev-ref @{u}") {
+        return "origin/main";
+      }
+
+      return undefined;
+    });
+
+    collectGitFacts({ ancestorLimit: "--upload-pack=evil" as unknown as number });
+
+    expect(
+      runGit.mock.calls.filter((call) => call[0][0] === "fetch"),
+      "uses default ancestor limit instead of unsafe git option strings",
+    ).toEqual([[["fetch", "--deepen", "100", "origin"], undefined]]);
   });
 });

--- a/packages/git/test/isGitAvailable.test.ts
+++ b/packages/git/test/isGitAvailable.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 
-import { type Mock, describe, expect, it, vi } from "vitest";
+import { type Mock, describe, it, vi, expect } from "vitest";
 
 import { isGitAvailable } from "../src/isGitAvailable.js";
 
@@ -14,13 +14,23 @@ describe("isGitAvailable", () => {
   it("returns true when git --version succeeds", () => {
     spawnSyncMock.mockReturnValue({ error: undefined, status: 0 });
 
-    expect(isGitAvailable()).toBe(true);
-    expect(spawnSyncMock).toHaveBeenCalledWith("git", ["--version"], { encoding: "utf-8" });
+    const available = isGitAvailable();
+
+    expect(
+      {
+        available,
+        command: spawnSyncMock.mock.calls[0],
+      },
+      "detects git CLI availability from a successful git --version call",
+    ).toEqual({
+      available: true,
+      command: ["git", ["--version"], { encoding: "utf-8" }],
+    });
   });
 
   it("returns false when git is missing or fails", () => {
     spawnSyncMock.mockReturnValue({ error: new Error("ENOENT"), status: 1 });
 
-    expect(isGitAvailable()).toBe(false);
+    expect(isGitAvailable(), "returns false when git --version fails or git is missing").toBe(false);
   });
 });

--- a/packages/git/test/runGit.test.ts
+++ b/packages/git/test/runGit.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, it, vi, expect } from "vitest";
 
 import { runGit } from "../src/runGit.js";
 
@@ -30,26 +30,55 @@ describe("runGit", () => {
       error: undefined,
     } as ReturnType<typeof spawnSync>);
 
-    expect(runGit(["rev-parse", "HEAD"])).toBeUndefined();
-    expect(writeSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[allurereport/git] git rev-parse HEAD failed (status=128): fatal: not a git repository"),
-    );
+    const result = runGit(["rev-parse", "HEAD"]);
+
+    expect(
+      {
+        result,
+        stderr: writeSpy.mock.calls[0]?.[0],
+      },
+      "returns undefined and logs a debug hint when git command fails",
+    ).toEqual({
+      result: undefined,
+      stderr: expect.stringContaining(
+        "[allurereport/git] git rev-parse HEAD failed (status=128): fatal: not a git repository",
+      ),
+    });
   });
 
   it("blocks --upload-pack and does not spawn git", () => {
-    expect(runGit(["ls-remote", "--upload-pack=evil"])).toBeUndefined();
-    expect(spawnSyncMock).not.toHaveBeenCalled();
+    const result = runGit(["ls-remote", "--upload-pack=evil"]);
+
+    expect(
+      {
+        result,
+        spawned: spawnSyncMock.mock.calls,
+      },
+      "blocks unsafe --upload-pack arguments without spawning git",
+    ).toEqual({
+      result: undefined,
+      spawned: [],
+    });
   });
 
   it("writes stderr hint when ALLURE_DEBUG is set and unsafe args are blocked", () => {
     vi.stubEnv("ALLURE_DEBUG", "true");
     const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-    expect(runGit(["--upload-pack"])).toBeUndefined();
-    expect(spawnSyncMock).not.toHaveBeenCalled();
-    expect(writeSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[allurereport/git] blocked unsafe git arguments: --upload-pack"),
-    );
+    const result = runGit(["--upload-pack"]);
+
+    expect(
+      {
+        result,
+        spawned: spawnSyncMock.mock.calls,
+        stderr: writeSpy.mock.calls.map((call) => call[0]),
+      },
+      "blocks unsafe arguments, avoids spawning git, and logs a debug hint",
+    ).toEqual({
+      result: undefined,
+      spawned: [],
+      stderr: [expect.stringContaining("[allurereport/git] blocked unsafe git arguments: --upload-pack")],
+    });
   });
 
   it("does not write stderr hint when ALLURE_DEBUG is unset", () => {
@@ -65,7 +94,17 @@ describe("runGit", () => {
       error: undefined,
     } as ReturnType<typeof spawnSync>);
 
-    expect(runGit(["status"])).toBeUndefined();
-    expect(writeSpy).not.toHaveBeenCalled();
+    const result = runGit(["status"]);
+
+    expect(
+      {
+        result,
+        stderrWrites: writeSpy.mock.calls,
+      },
+      "returns undefined without debug stderr output when ALLURE_DEBUG is unset",
+    ).toEqual({
+      result: undefined,
+      stderrWrites: [],
+    });
   });
 });

--- a/packages/plugin-testops/src/logger.ts
+++ b/packages/plugin-testops/src/logger.ts
@@ -36,7 +36,11 @@ function getLogLevelFromEnv(): LogLevel {
 
 export class Logger {
   #level: LogLevel = getLogLevelFromEnv();
-  constructor(readonly name: string) {}
+  #prefix: string;
+
+  constructor(private readonly loggerName: string) {
+    this.#prefix = cyan(bold(`[${this.loggerName}]:`));
+  }
 
   #isLogLevel(level: LogLevel) {
     return logLevelsPriority[this.#level] <= logLevelsPriority[level];
@@ -45,8 +49,6 @@ export class Logger {
   #isSilent() {
     return this.#level === "silent";
   }
-
-  #prefix = cyan(bold(`[${this.name}]:`));
 
   progressBarCounter(message: string, total: number) {
     if (this.#isSilent()) {

--- a/packages/service/src/utils/http.ts
+++ b/packages/service/src/utils/http.ts
@@ -124,12 +124,12 @@ export const createServiceHttpClient = (
         let res: AxiosResponse<T>;
 
         if (method === "get" || method === "delete") {
-          res = await client[method](endpoint, {
+          res = await client[method]<T>(endpoint, {
             ...payload,
             headers,
           });
         } else {
-          res = await client[method](endpoint, payload?.body, {
+          res = await client[method]<T>(endpoint, payload?.body, {
             ...payload,
             headers,
           });
@@ -167,7 +167,7 @@ export const createServiceHttpClient = (
     post: sendRequest("post"),
     put: sendRequest("put"),
     delete: sendRequest("delete"),
-  };
+  } as const;
 };
 
 export type HttpClient = ReturnType<typeof createServiceHttpClient>;


### PR DESCRIPTION
CI usually has shallow fetch depth clone of a repo, lacking enough first-parent history for git lineage. 
This PR deepens ancestor collection.

Also: 
- Yarn PnP SDKs for oxfmt/oxlint (drop .vscode wrapper scripts)
- testops plugin logger prefix init fix
- axios generic typing in service HTTP client