### PR TITLE
Rerun no longer fails immediately when the config contains qualityGate

### DIFF
--- a/docs/quality_gates.md
+++ b/docs/quality_gates.md
@@ -30,13 +30,20 @@ export default defineConfig({
 });
 ```
 
+## Compatibility with rerun
+
+Quality gate validation doesn't work with `allure run --rerun` when the rerun count is greater than `0`.
+If `qualityGate` is configured and `--rerun` is enabled, Allure runs the test command and prints a warning that quality gate validation is skipped for that run.
+
+Use `--rerun=0` or remove `--rerun` when the quality gate should validate the run.
+
 ## Using external rules
 
 You can use external quality gate rules implemented by the community – just provide them to the `use` field in the quality gate configuration:
 
 ```js
 import { defineConfig } from "allure";
-import { rule1, rule2 } from "custom-rules-package"
+import { rule1, rule2 } from "custom-rules-package";
 
 export default defineConfig({
   qualityGate: {
@@ -54,10 +61,10 @@ export default defineConfig({
 ```js
 import { defineConfig } from "allure";
 // import default rules at once
-import { qualityGateDefaultRules } from "allure/rules"
+import { qualityGateDefaultRules } from "allure/rules";
 // or import them separately
-import { maxFailuresRule, minTestsCountRule, successRateRule, maxDurationRule } from "allure/rules"
-import { rule1, rule2 } from "custom-rules-package"
+import { maxFailuresRule, minTestsCountRule, successRateRule, maxDurationRule } from "allure/rules";
+import { rule1, rule2 } from "custom-rules-package";
 
 export default defineConfig({
   qualityGate: {
@@ -73,7 +80,7 @@ If you don't re-assign `use` field, Allure will use only the default rules autom
 
 ## Authoring custom rules
 
-You can create your own quality gate rules by implementing the `QualityGateRule` interface. 
+You can create your own quality gate rules by implementing the `QualityGateRule` interface.
 
 Below is an example of a custom quality gate rule that checks if the number of test results matches an expected value:
 
@@ -91,8 +98,8 @@ export const myRule: QualityGateRule<number> = {
       success: actual === expected,
       actual,
     };
-  }
-}
+  },
+};
 ```
 
 You can also aggregate validation data in runtime to make more complex rules.
@@ -110,15 +117,15 @@ export const myRule: QualityGateRule<number> = {
     const previous = state.getResult() ?? 0;
     const actual = previous + trs.length;
     const passed = actual === expected;
-    
+
     state.setResult(actual);
 
     return {
       success: actual === expected,
       actual,
     };
-  }
-}
+  },
+};
 ```
 
 Then, you can register your custom rule in the Allure configuration file:
@@ -164,7 +171,7 @@ export default defineConfig({
         // don't forget to use rest spread operator to keep rest rule's fields intact
         ...myRule,
         message: ({ expected, actual }) => `Custom message: expected ${expected}, got ${actual}`,
-      }
+      },
     ],
   },
 });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -6,7 +6,6 @@ import { AllureReport, isFileNotFoundError, readConfig } from "@allurereport/cor
 import Awesome from "@allurereport/plugin-awesome";
 import { serve } from "@allurereport/static-server";
 import { Command, Option, UsageError } from "clipanion";
-import { red } from "yoctocolors";
 
 import {
   environmentNameOption,
@@ -58,7 +57,8 @@ export class RunCommand extends Command {
   });
 
   rerun = Option.String("--rerun", {
-    description: "The number of reruns for failed tests (default: 0)",
+    description:
+      "The number of reruns for failed tests. Quality gate validation is skipped when rerun is greater than 0 (default: 0)",
   });
 
   silent = Option.Boolean("--silent", {
@@ -147,13 +147,11 @@ export class RunCommand extends Command {
       historyLimit: this.historyLimit ? parseInt(this.historyLimit, 10) : undefined,
     });
     const resolvedEnvironment = resolveCommandEnvironment(config, environmentOptions);
-    const withQualityGate = !!config.qualityGate;
-    const withRerun = !!this.rerun;
+    const withRerun = maxRerun > 0;
+    const withQualityGate = !!config.qualityGate && !withRerun;
 
-    if (withQualityGate && withRerun) {
-      console.error(red("At this moment, quality gate and rerun can't be used at the same time!"));
-      console.error(red("Consider using --rerun=0 or disable quality gate in the config to run tests"));
-      exit(-1);
+    if (config.qualityGate && withRerun) {
+      console.warn("Quality gate doesn't work with rerun; skipping quality gate validation.");
     }
 
     try {
@@ -166,6 +164,7 @@ export class RunCommand extends Command {
     const allureReport = new AllureReport({
       ...config,
       environment: resolvedEnvironment?.id,
+      qualityGate: withQualityGate ? config.qualityGate : undefined,
       dump: this.dump,
       realTime: false,
       plugins: [

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -1,3 +1,5 @@
+import * as console from "node:console";
+
 import { readConfig } from "@allurereport/core";
 import AwesomePlugin from "@allurereport/plugin-awesome";
 import { epic, feature, label, story } from "allure-js-commons";
@@ -23,6 +25,7 @@ const { exitMock, processStream } = vi.hoisted(() => {
 vi.mock("node:console", async (importOriginal) => ({
   ...(await importOriginal()),
   log: vi.fn(),
+  warn: vi.fn(),
   error: vi.fn(),
 }));
 vi.mock("node:process", async (importOriginal) => ({
@@ -111,6 +114,9 @@ beforeEach(async () => {
     sendGlobalError: vi.fn(),
     sendGlobalExitCode: vi.fn(),
   };
+  AllureReportMock.prototype.validate = vi.fn().mockResolvedValue({
+    results: [],
+  });
 });
 
 describe("run command", () => {
@@ -203,6 +209,73 @@ describe("run command", () => {
         ]),
       }),
     );
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("should run with rerun and skip configured quality gate without failing early", async () => {
+    const { AllureReportMock } = await import("../utils.js");
+    const { runProcess } = await import("../../src/utils/index.js");
+
+    (readConfig as Mock).mockResolvedValueOnce({
+      output: "./allure-report",
+      open: false,
+      qualityGate: {
+        rules: [],
+      },
+      plugins: [],
+    });
+
+    await run(RunCommand, ["run", "--rerun", "2", "--", "npm", "test"]);
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "Quality gate doesn't work with rerun; skipping quality gate validation.",
+    );
+    expect(AllureReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qualityGate: undefined,
+      }),
+    );
+    expect(AllureReportMock.prototype.realtimeSubscriber.onTestResults).not.toHaveBeenCalled();
+    expect(AllureReportMock.prototype.validate).not.toHaveBeenCalled();
+    expect(runProcess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "npm",
+        commandArgs: ["test"],
+      }),
+    );
+    expect(exitMock).toHaveBeenCalledWith(0);
+    expect(exitMock).not.toHaveBeenCalledWith(-1);
+  });
+
+  it("should keep configured quality gate when rerun is zero", async () => {
+    const { AllureReportMock } = await import("../utils.js");
+    const qualityGate = {
+      rules: [
+        {
+          maxFailures: 0,
+        },
+      ],
+    };
+
+    (readConfig as Mock).mockResolvedValueOnce({
+      output: "./allure-report",
+      open: false,
+      qualityGate,
+      plugins: [],
+    });
+
+    await run(RunCommand, ["run", "--rerun", "0", "--", "npm", "test"]);
+
+    expect(console.warn).not.toHaveBeenCalledWith(
+      "Quality gate doesn't work with rerun; skipping quality gate validation.",
+    );
+    expect(AllureReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qualityGate,
+      }),
+    );
+    expect(AllureReportMock.prototype.realtimeSubscriber.onTestResults).toHaveBeenCalled();
+    expect(AllureReportMock.prototype.validate).toHaveBeenCalled();
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 


### PR DESCRIPTION
--rerun no longer fails immediately when the config contains qualityGate. Instead, the command now runs as requested and prints a warning that quality gate validation is skipped for rerun-enabled runs.