### PR TITLE
Hide and mask sensitive parameters in report output

### DIFF
--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -19,6 +19,7 @@ export * from "./utils/time.js";
 export * from "./utils/comparator.js";
 export * from "./utils/predicate.js";
 export * from "./utils/label.js";
+export * from "./utils/parameter.js";
 export * from "./utils/testplan.js";
 export * from "./utils/status.js";
 export * from "./utils/environment.js";

--- a/packages/core-api/src/utils/parameter.ts
+++ b/packages/core-api/src/utils/parameter.ts
@@ -1,0 +1,18 @@
+import type { TestParameter } from "../metadata.js";
+
+const maskedParameterPlaceholder = "<masked>";
+
+export const redactParameters = (parameters: readonly TestParameter[] | undefined): TestParameter[] => {
+  return (parameters ?? []).flatMap((parameter) => {
+    if (parameter.hidden) {
+      return [];
+    }
+
+    return [
+      {
+        ...parameter,
+        value: parameter.masked ? maskedParameterPlaceholder : parameter.value,
+      },
+    ];
+  });
+};

--- a/packages/core-api/src/utils/parameter.ts
+++ b/packages/core-api/src/utils/parameter.ts
@@ -3,16 +3,10 @@ import type { TestParameter } from "../metadata.js";
 const maskedParameterPlaceholder = "<masked>";
 
 export const redactParameters = (parameters: readonly TestParameter[] | undefined): TestParameter[] => {
-  return (parameters ?? []).flatMap((parameter) => {
-    if (parameter.hidden) {
-      return [];
-    }
-
-    return [
-      {
-        ...parameter,
-        value: parameter.masked ? maskedParameterPlaceholder : parameter.value,
-      },
-    ];
-  });
+  return (parameters ?? [])
+    .filter((parameter) => !parameter.hidden)
+    .map((parameter) => ({
+      ...parameter,
+      value: parameter.masked ? maskedParameterPlaceholder : parameter.value,
+    }));
 };

--- a/packages/core-api/test/utils/parameter.test.ts
+++ b/packages/core-api/test/utils/parameter.test.ts
@@ -1,0 +1,34 @@
+import { epic, feature, label, story } from "allure-js-commons";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { redactParameters } from "../../src/utils/parameter.js";
+
+beforeEach(async () => {
+  await epic("coverage");
+  await feature("report-data-model");
+  await story("parameter");
+  await label("coverage", "report-data-model");
+});
+
+describe("parameter utils", () => {
+  it("should remove hidden parameters and replace masked values", () => {
+    const parameters = redactParameters([
+      { name: "visible", value: "value", hidden: false, masked: false, excluded: false },
+      { name: "token", value: "secret-token", hidden: false, masked: true, excluded: false },
+      { name: "internal", value: "hidden-value", hidden: true, masked: false, excluded: false },
+      { name: "hidden-token", value: "hidden-token-value", hidden: true, masked: true, excluded: false },
+    ]);
+
+    expect(parameters).toEqual([
+      { name: "visible", value: "value", hidden: false, masked: false, excluded: false },
+      { name: "token", value: "<masked>", hidden: false, masked: true, excluded: false },
+    ]);
+    expect(JSON.stringify(parameters)).not.toContain("secret-token");
+    expect(JSON.stringify(parameters)).not.toContain("hidden-value");
+    expect(JSON.stringify(parameters)).not.toContain("hidden-token-value");
+  });
+
+  it("should handle missing parameter collections", () => {
+    expect(redactParameters(undefined)).toEqual([]);
+  });
+});

--- a/packages/plugin-allure2/src/converters.ts
+++ b/packages/plugin-allure2/src/converters.ts
@@ -7,7 +7,7 @@ import type {
   TestStatus,
   TestStepResult,
 } from "@allurereport/core-api";
-import { filterIncludedInSuccessRate, isStep } from "@allurereport/core-api";
+import { filterIncludedInSuccessRate, isStep, redactParameters } from "@allurereport/core-api";
 
 import { matchCategories } from "./categories.js";
 import type {
@@ -41,7 +41,7 @@ const sortByTime = (a: { time: Allure2Time }, b: { time: Allure2Time }): number 
 const convertStatus = (status: TestStatus): Allure2Status => status;
 
 const convertStageResult = (context: ConvertContext, result: TestResult | TestFixtureResult): Allure2StageResult => {
-  const { name, ...testStage } = convertStep(context, {
+  const { name: _name, ...testStage } = convertStep(context, {
     name: "test",
     steps: result.steps,
     start: result.start,
@@ -59,7 +59,7 @@ const convertStep = (context: ConvertContext, step: TestStepResult): Allure2Step
     const name = step.name;
     const steps = step.steps.map((child) => convertStep(context, child));
     const stepsCount = steps.length;
-    const parameters = step.parameters;
+    const parameters = redactParameters(step.parameters);
     const parametersCount = parameters.length;
     const statusMessage = step.error?.message;
     const shouldDisplayMessage = !!statusMessage || steps.findIndex((s) => s.statusMessage === statusMessage) > 0;
@@ -214,7 +214,7 @@ export const convertTestResult = (context: ConvertContext, test: TestResult): Al
     statusTrace,
     labels: test.labels,
     links: test.links,
-    parameters: test.parameters,
+    parameters: redactParameters(test.parameters),
     afterStages,
     beforeStages,
     testStage: testStage,

--- a/packages/plugin-allure2/test/converters.test.ts
+++ b/packages/plugin-allure2/test/converters.test.ts
@@ -6,9 +6,9 @@ import { convertTestResult } from "../src/converters.js";
 
 beforeEach(async () => {
   await epic("coverage");
-  await feature("report-output");
+  await feature("plugin-allure2");
   await story("converters");
-  await label("coverage", "report-output");
+  await label("coverage", "plugin-allure2");
 });
 
 const createTestResult = (overrides: Partial<TestResult> = {}): TestResult => {
@@ -36,25 +36,15 @@ const createTestResult = (overrides: Partial<TestResult> = {}): TestResult => {
 };
 
 describe("convertTestResult", () => {
-  it("converts markdown description to html when descriptionHtml is missing", () => {
-    const result = convertTestResult(createTestResult({ description: "**bold** text" }));
-
-    expect(result.descriptionHtml).toBe("<p><strong>bold</strong> text</p>\n");
-  });
-
-  it("keeps provided descriptionHtml as-is", () => {
-    const result = convertTestResult(
-      createTestResult({
-        description: "**bold** text",
-        descriptionHtml: "<p>custom html</p>",
-      }),
-    );
-
-    expect(result.descriptionHtml).toBe("<p>custom html</p>");
-  });
-
   it("should redact hidden and masked parameters", () => {
     const result = convertTestResult(
+      {
+        attachmentMap: new Map(),
+        fixtures: [],
+        categories: [],
+        retries: [],
+        history: [],
+      },
       createTestResult({
         parameters: [
           { name: "visible", value: "value", hidden: false, masked: false, excluded: false },
@@ -91,20 +81,10 @@ describe("convertTestResult", () => {
       { name: "visible", value: "value", hidden: false, masked: false, excluded: false },
       { name: "token", value: "<masked>", hidden: false, masked: true, excluded: false },
     ]);
-
-    const [step] = result.steps;
-    if (step?.type !== "step") {
-      throw new Error("expected converted step");
-    }
-    expect(step.parameters).toEqual([
+    expect(result.testStage.steps[0].parameters).toEqual([
       { name: "step-token", value: "<masked>", hidden: false, masked: true, excluded: false },
     ]);
-
-    const [nestedStep] = step.steps;
-    if (nestedStep?.type !== "step") {
-      throw new Error("expected converted nested step");
-    }
-    expect(nestedStep.parameters).toEqual([
+    expect(result.testStage.steps[0].steps[0].parameters).toEqual([
       { name: "nested-token", value: "<masked>", hidden: false, masked: true, excluded: false },
     ]);
 

--- a/packages/plugin-awesome/src/converters.ts
+++ b/packages/plugin-awesome/src/converters.ts
@@ -4,6 +4,8 @@ import {
   type TestResult,
   type TestStepResult,
   createDictionary,
+  isStep,
+  redactParameters,
   shouldHideLabel,
 } from "@allurereport/core-api";
 import type { AwesomeFixtureResult, AwesomeTestResult, AwesomeTestStepResult } from "@allurereport/web-awesome";
@@ -47,9 +49,9 @@ export const convertTestResult = (
     isRetry: tr.isRetry,
     labels,
     groupedLabels: mapLabelsByName(labels),
-    parameters: tr.parameters,
+    parameters: redactParameters(tr.parameters),
     links: tr.links,
-    steps: tr.steps,
+    steps: (tr.steps ?? []).map(convertTestStepResult),
     error: tr.error,
     testCase: tr.testCase,
     descriptionHtml: tr.descriptionHtml ?? markdownToHtml(tr.description),
@@ -66,6 +68,14 @@ export const convertTestResult = (
 };
 
 export const convertTestStepResult = (tsr: TestStepResult): AwesomeTestStepResult => {
+  if (isStep(tsr)) {
+    return {
+      ...tsr,
+      parameters: redactParameters(tsr.parameters),
+      steps: (tsr.steps ?? []).map(convertTestStepResult),
+    };
+  }
+
   return tsr;
 };
 

--- a/packages/plugin-awesome/test/converters.test.ts
+++ b/packages/plugin-awesome/test/converters.test.ts
@@ -157,4 +157,68 @@ describe("convertTestResult", () => {
     expect(result.groupedLabels._internal).toBeUndefined();
     expect(result.groupedLabels.tag).toEqual(["api"]);
   });
+
+  it("should redact hidden and masked parameters", () => {
+    const result = convertTestResult(
+      createTestResult({
+        parameters: [
+          { name: "visible", value: "value", hidden: false, masked: false, excluded: false },
+          { name: "token", value: "secret-token", hidden: false, masked: true, excluded: false },
+          { name: "internal", value: "hidden-value", hidden: true, masked: false, excluded: false },
+        ],
+        steps: [
+          {
+            type: "step",
+            name: "step",
+            status: "passed",
+            parameters: [
+              { name: "step-token", value: "step-secret", hidden: false, masked: true, excluded: false },
+              { name: "step-internal", value: "step-hidden", hidden: true, masked: false, excluded: false },
+            ],
+            steps: [
+              {
+                type: "step",
+                name: "nested step",
+                status: "passed",
+                parameters: [
+                  { name: "nested-token", value: "nested-secret", hidden: false, masked: true, excluded: false },
+                  { name: "nested-internal", value: "nested-hidden", hidden: true, masked: false, excluded: false },
+                ],
+                steps: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(result.parameters).toEqual([
+      { name: "visible", value: "value", hidden: false, masked: false, excluded: false },
+      { name: "token", value: "<masked>", hidden: false, masked: true, excluded: false },
+    ]);
+
+    const [step] = result.steps;
+    if (step?.type !== "step") {
+      throw new Error("expected converted step");
+    }
+    expect(step.parameters).toEqual([
+      { name: "step-token", value: "<masked>", hidden: false, masked: true, excluded: false },
+    ]);
+
+    const [nestedStep] = step.steps;
+    if (nestedStep?.type !== "step") {
+      throw new Error("expected converted nested step");
+    }
+    expect(nestedStep.parameters).toEqual([
+      { name: "nested-token", value: "<masked>", hidden: false, masked: true, excluded: false },
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("secret-token");
+    expect(serialized).not.toContain("hidden-value");
+    expect(serialized).not.toContain("step-secret");
+    expect(serialized).not.toContain("step-hidden");
+    expect(serialized).not.toContain("nested-secret");
+    expect(serialized).not.toContain("nested-hidden");
+  });
 });

--- a/packages/plugin-classic/src/converters.ts
+++ b/packages/plugin-classic/src/converters.ts
@@ -1,4 +1,11 @@
-import type { TestFixtureResult, TestLabel, TestResult, TestStepResult } from "@allurereport/core-api";
+import {
+  type TestFixtureResult,
+  type TestLabel,
+  type TestResult,
+  type TestStepResult,
+  isStep,
+  redactParameters,
+} from "@allurereport/core-api";
 import type { ClassicFixtureResult, ClassicTestResult, ClassicTestStepResult } from "@allurereport/web-classic";
 import MarkdownIt from "markdown-it";
 
@@ -33,9 +40,9 @@ export const convertTestResult = (tr: TestResult): ClassicTestResult => {
     isRetry: tr.isRetry,
     labels: tr.labels,
     groupedLabels: mapLabelsByName(tr.labels),
-    parameters: tr.parameters,
+    parameters: redactParameters(tr.parameters),
     links: tr.links,
-    steps: tr.steps,
+    steps: (tr.steps ?? []).map(convertTestStepResult),
     error: tr.error,
     testCase: tr.testCase,
     descriptionHtml: tr.descriptionHtml ?? markdownToHtml(tr.description),
@@ -50,6 +57,14 @@ export const convertTestResult = (tr: TestResult): ClassicTestResult => {
 };
 
 export const convertTestStepResult = (tsr: TestStepResult): ClassicTestStepResult => {
+  if (isStep(tsr)) {
+    return {
+      ...tsr,
+      parameters: redactParameters(tsr.parameters),
+      steps: (tsr.steps ?? []).map(convertTestStepResult),
+    };
+  }
+
   return tsr;
 };
 


### PR DESCRIPTION
Allure 3 now respects hidden and masked test parameters when generating Awesome, Classic, and Allure 2 style reports. Hidden parameters are removed from report payloads, while masked parameters keep their names but show "<masked>" instead of the original value.