### PR TITLE
Make Allure agent runs safer and easier to review

### DIFF
--- a/packages/cli/src/commands/agent-run.ts
+++ b/packages/cli/src/commands/agent-run.ts
@@ -184,6 +184,9 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
     ...(rerunContext ? { ALLURE_TESTPLAN_PATH: rerunContext.testPlanPath } : {}),
   };
 
+  let resolvedExitCode = -1;
+  let runCompleted = false;
+
   try {
     if (getActiveAllureCliCommand()) {
       console.log(commandString);
@@ -196,7 +199,9 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
         silent,
       });
 
-      exit(exitCode ?? -1);
+      resolvedExitCode = exitCode ?? -1;
+      runCompleted = true;
+
       return;
     }
 
@@ -316,9 +321,17 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
     });
     await cleanupManagedAgentOutputs({ cwd, runId, managedOutput });
 
-    exit(globalExitCode.actual ?? globalExitCode.original);
+    resolvedExitCode = globalExitCode.actual ?? globalExitCode.original;
+    runCompleted = true;
   } finally {
     await rerunContext?.cleanup();
+
+    // Defer exit() until after cleanup: process.exit() skips pending finally blocks, so calling it
+    // inside the try would leak the rerun test-plan temp dir. On the error path runCompleted stays
+    // false, so the original error propagates instead of being masked by an exit.
+    if (runCompleted) {
+      exit(resolvedExitCode);
+    }
   }
 };
 

--- a/packages/cli/src/commands/agent-run.ts
+++ b/packages/cli/src/commands/agent-run.ts
@@ -10,7 +10,9 @@ import {
   createAgentTestPlanContext,
   AgentUsageError,
   formatAgentOutputLinks,
+  formatAgentRunSummary,
   isPathInside,
+  loadAgentOutput,
   normalizeAgentRerunPreset,
   parseAgentLabelFilters,
   cleanupAgentRunState,
@@ -41,6 +43,47 @@ export const formatAgentInspectCommand = (params: { dumps?: string[]; resultsDir
 export const printAgentOutputLinks = (outputDir: string) => {
   for (const line of formatAgentOutputLinks(outputDir)) {
     console.log(line);
+  }
+};
+
+/**
+ * Before an agent run starts, print where the output goes and how to watch it. The agent plugin
+ * appends manifest/test-events.jsonl per test and rewrites index.md live, so an agent can inspect
+ * progress mid-run without waiting for the final summary.
+ */
+export const printAgentRunStart = (outputDir: string, commandString: string) => {
+  console.log(`agent output: ${outputDir}`);
+  console.log(commandString);
+  console.log(
+    "live: read manifest/test-events.jsonl (appended per test) in that directory to watch progress before the run finishes",
+  );
+};
+
+/**
+ * After an agent run, print a compact summary (status, links, and what to read where) instead of the
+ * test command's own console output, which is captured into the agent output rather than echoed.
+ */
+export const printAgentRunSummary = async (
+  outputDir: string,
+  options: { durationMs?: number; rerunCommand?: string } = {},
+) => {
+  try {
+    const bundle = await loadAgentOutput(outputDir);
+
+    const summary = formatAgentRunSummary({
+      outputDir,
+      run: bundle.run,
+      humanReport: bundle.humanReport,
+      durationMs: options.durationMs,
+      rerunCommand: options.rerunCommand,
+    });
+
+    for (const line of summary) {
+      console.log(line);
+    }
+  } catch {
+    // Best effort: fall back to the basic output links if the summary cannot be built.
+    printAgentOutputLinks(outputDir);
   }
 };
 
@@ -270,13 +313,7 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
       pid: process.pid,
     });
 
-    printAgentOutputLinks(outputDir);
-    if (expectationsPath) {
-      console.log(`agent expectations: ${expectationsPath}`);
-    } else if (inlineExpectations) {
-      console.log("agent expectations: CLI options");
-    }
-    console.log(commandString);
+    printAgentRunStart(outputDir, commandString);
 
     const allureReport = new AllureReport({
       ...config,
@@ -301,7 +338,9 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
       environment: resolvedEnvironment?.id,
       withQualityGate: false,
       logs: "pipe",
-      silent,
+      // Capture the test command's output into the agent artifacts instead of echoing it to the
+      // terminal; the post-run summary points at the captured logs.
+      silent: true,
       ignoreLogs: false,
       logProcessExit: false,
     });
@@ -320,6 +359,7 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
       pid: process.pid,
     });
     await cleanupManagedAgentOutputs({ cwd, runId, managedOutput });
+    await printAgentRunSummary(outputDir, { durationMs: Date.now() - startedAt, rerunCommand: commandString });
 
     resolvedExitCode = globalExitCode.actual ?? globalExitCode.original;
     runCompleted = true;
@@ -468,12 +508,6 @@ export const executeAgentInspectMode = async (params: ExecuteAgentInspectModePar
     pid: process.pid,
   });
 
-  printAgentOutputLinks(outputDir);
-  if (expectationsPath) {
-    console.log(`agent expectations: ${expectationsPath}`);
-  } else if (inlineExpectations) {
-    console.log("agent expectations: CLI options");
-  }
   console.log(commandString);
 
   const allureReport = new AllureReport({
@@ -511,6 +545,7 @@ export const executeAgentInspectMode = async (params: ExecuteAgentInspectModePar
     pid: process.pid,
   });
   await cleanupManagedAgentOutputs({ cwd, runId, managedOutput });
+  await printAgentRunSummary(outputDir, { durationMs: Date.now() - startedAt });
 
   exit(0);
 };

--- a/packages/cli/src/commands/agent-run.ts
+++ b/packages/cli/src/commands/agent-run.ts
@@ -1,6 +1,6 @@
 import * as console from "node:console";
 import { randomUUID } from "node:crypto";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readdir, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import process, { exit } from "node:process";
@@ -49,6 +49,40 @@ export const persistAgentRunState = async (value: Parameters<typeof writeAgentRu
     await writeAgentRunState(value);
   } catch (error) {
     console.error(`Could not update agent state in ${resolveAgentStateDir(value.cwd)}: ${(error as Error).message}`);
+  }
+};
+
+const isMissingPathError = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && (error as NodeJS.ErrnoException).code === "ENOENT";
+
+/**
+ * An explicit, caller-provided `--output` directory is recursively deleted at the start of a run.
+ * Only allow a directory that is absent or empty, so a mistyped `--output` (e.g. `--output .` or
+ * `--output ./src`) cannot destroy unrelated files. Managed temp outputs are created by `mkdtemp`
+ * and are always safe, so they skip this check.
+ */
+const assertExplicitOutputDirIsSafe = async (outputDir: string) => {
+  let stats;
+
+  try {
+    stats = await stat(outputDir);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+
+  if (!stats.isDirectory()) {
+    throw new AgentUsageError(`--output ${JSON.stringify(outputDir)} is not a directory; use a new or empty directory`);
+  }
+
+  if ((await readdir(outputDir)).length > 0) {
+    throw new AgentUsageError(
+      `refusing to use --output ${JSON.stringify(outputDir)}: the agent recursively deletes its output directory, ` +
+        `so it must be a new or empty directory.`,
+    );
   }
 };
 
@@ -181,6 +215,10 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
       throw new AgentUsageError(
         `--expectations path ${JSON.stringify(expectationsPath)} must not be inside the agent output directory ${JSON.stringify(outputDir)}`,
       );
+    }
+
+    if (!managedOutput) {
+      await assertExplicitOutputDirIsSafe(outputDir);
     }
 
     const humanReport = await createAgentHumanReportConfig({
@@ -354,6 +392,10 @@ export const executeAgentInspectMode = async (params: ExecuteAgentInspectModePar
     throw new AgentUsageError(
       `--expectations path ${JSON.stringify(expectationsPath)} must not be inside the agent output directory ${JSON.stringify(outputDir)}`,
     );
+  }
+
+  if (!managedOutput) {
+    await assertExplicitOutputDirIsSafe(outputDir);
   }
 
   const historyLimitValue = historyLimit ? parseInt(historyLimit, 10) : undefined;

--- a/packages/cli/src/commands/agent-run.ts
+++ b/packages/cli/src/commands/agent-run.ts
@@ -1,6 +1,6 @@
 import * as console from "node:console";
 import { randomUUID } from "node:crypto";
-import { mkdtemp, readdir, realpath, rm, stat } from "node:fs/promises";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import process, { exit } from "node:process";
@@ -9,6 +9,7 @@ import { AllureReport, isFileNotFoundError, readConfig } from "@allurereport/cor
 import {
   createAgentTestPlanContext,
   AgentUsageError,
+  assertExplicitAgentOutputDirIsSafe,
   formatAgentOutputLinks,
   formatAgentRunSummary,
   isPathInside,
@@ -92,40 +93,6 @@ export const persistAgentRunState = async (value: Parameters<typeof writeAgentRu
     await writeAgentRunState(value);
   } catch (error) {
     console.error(`Could not update agent state in ${resolveAgentStateDir(value.cwd)}: ${(error as Error).message}`);
-  }
-};
-
-const isMissingPathError = (error: unknown): boolean =>
-  typeof error === "object" && error !== null && (error as NodeJS.ErrnoException).code === "ENOENT";
-
-/**
- * An explicit, caller-provided `--output` directory is recursively deleted at the start of a run.
- * Only allow a directory that is absent or empty, so a mistyped `--output` (e.g. `--output .` or
- * `--output ./src`) cannot destroy unrelated files. Managed temp outputs are created by `mkdtemp`
- * and are always safe, so they skip this check.
- */
-const assertExplicitOutputDirIsSafe = async (outputDir: string) => {
-  let stats;
-
-  try {
-    stats = await stat(outputDir);
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      return;
-    }
-
-    throw error;
-  }
-
-  if (!stats.isDirectory()) {
-    throw new AgentUsageError(`--output ${JSON.stringify(outputDir)} is not a directory; use a new or empty directory`);
-  }
-
-  if ((await readdir(outputDir)).length > 0) {
-    throw new AgentUsageError(
-      `refusing to use --output ${JSON.stringify(outputDir)}: the agent recursively deletes its output directory, ` +
-        `so it must be a new or empty directory.`,
-    );
   }
 };
 
@@ -266,7 +233,7 @@ export const executeAgentMode = async (params: ExecuteAgentModeParams) => {
     }
 
     if (!managedOutput) {
-      await assertExplicitOutputDirIsSafe(outputDir);
+      await assertExplicitAgentOutputDirIsSafe(outputDir);
     }
 
     const humanReport = await createAgentHumanReportConfig({
@@ -448,7 +415,7 @@ export const executeAgentInspectMode = async (params: ExecuteAgentInspectModePar
   }
 
   if (!managedOutput) {
-    await assertExplicitOutputDirIsSafe(outputDir);
+    await assertExplicitAgentOutputDirIsSafe(outputDir);
   }
 
   const historyLimitValue = historyLimit ? parseInt(historyLimit, 10) : undefined;

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -11,6 +11,7 @@ import {
   AGENT_TASK_MAP_HELP,
   AGENT_TEST_STATUSES,
   AgentExpectationUsageError,
+  assertExplicitAgentOutputDirIsSafe,
   buildAgentInlineExpectations,
   buildAgentQueryPayload,
   cleanupAgentRunState,
@@ -327,6 +328,12 @@ export class AgentCommand extends Command {
     }
 
     try {
+      // Reject an unsafe explicit --output before any code path (including the invalid-expectation
+      // fallback) recursively deletes it.
+      if (output) {
+        await assertExplicitAgentOutputDirIsSafe(resolve(await realpath(configuredCwd ?? process.cwd()), output));
+      }
+
       const inlineExpectations = buildInlineExpectationsFromOptions({
         goal: this.goal,
         taskId: this.taskId,
@@ -561,6 +568,12 @@ export class AgentInspectCommand extends Command {
     }
 
     try {
+      // Reject an unsafe explicit --output before any code path (including the invalid-expectation
+      // fallback) recursively deletes it.
+      if (output) {
+        await assertExplicitAgentOutputDirIsSafe(resolve(await realpath(configuredCwd ?? process.cwd()), output));
+      }
+
       const inlineExpectations = buildInlineExpectationsFromOptions({
         goal: this.goal,
         taskId: this.taskId,

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -675,13 +675,18 @@ export class AgentLatestCommand extends Command {
     try {
       latestState = await readLatestAgentState(cwd);
     } catch (error) {
-      console.error(`Could not read the latest agent output for ${cwd}: ${(error as Error).message}`);
+      console.error(
+        `Could not read the latest Allure agent output for ${cwd}: ${(error as Error).message}. ` +
+          "Check the state directory printed by `allure agent state-dir`, or set ALLURE_AGENT_STATE_DIR to a writable path.",
+      );
       exit(1);
       return;
     }
 
     if (!latestState) {
-      console.error(`No latest agent output found for ${cwd}`);
+      console.error(
+        `No recorded Allure agent output for ${cwd}. Run \`allure agent <command>\` first to create one.`,
+      );
       exit(1);
       return;
     }
@@ -886,7 +891,11 @@ export class AgentSelectCommand extends Command {
       });
 
       if (!selection.testPlan.tests.length) {
-        console.error(`No tests matched selection in ${selection.outputDir}`);
+        console.error(
+          `No tests matched selection in ${selection.outputDir}. ` +
+            "Adjust --preset (review|failed|unsuccessful|all), --label, or --environment, " +
+            "or pick a different run with --from/--latest.",
+        );
         exit(1);
         return;
       }

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -697,9 +697,7 @@ export class AgentLatestCommand extends Command {
     }
 
     if (!latestState) {
-      console.error(
-        `No recorded Allure agent output for ${cwd}. Run \`allure agent <command>\` first to create one.`,
-      );
+      console.error(`No recorded Allure agent output for ${cwd}. Run \`allure agent <command>\` first to create one.`);
       exit(1);
       return;
     }

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -10,6 +10,8 @@ import {
   cleanupAgentRunState,
   cleanupStaleAgentRunStates,
   createAgentTestPlanContext,
+  formatAgentRunSummary,
+  loadAgentOutput,
   resolveAgentStateDir,
   validateAgentExpectationsFile,
   writeInvalidAgentExpectationOutput,
@@ -125,6 +127,8 @@ vi.mock("@allurereport/plugin-agent", async (importOriginal) => {
     resolveAgentSelectionOutputDir: vi.fn(),
     selectAgentTestPlan: vi.fn(),
     createAgentTestPlanContext: vi.fn().mockResolvedValue(undefined),
+    loadAgentOutput: vi.fn().mockResolvedValue({ outputDir: "", run: {}, tests: [], findings: [], humanReport: null }),
+    formatAgentRunSummary: vi.fn((params: { outputDir: string }) => [`agent summary: ${params.outputDir}`]),
     buildAgentInlineExpectations: vi.fn((options: Record<string, unknown>) =>
       Object.values(options).some((value) =>
         Array.isArray(value) ? value.length > 0 : typeof value === "string" && value.length > 0,
@@ -156,6 +160,8 @@ beforeEach(async () => {
   (cleanupAgentRunState as Mock).mockReset();
   (cleanupStaleAgentRunStates as Mock).mockReset();
   (createAgentTestPlanContext as Mock).mockReset();
+  (loadAgentOutput as Mock).mockReset();
+  (formatAgentRunSummary as Mock).mockReset();
   (buildAgentInlineExpectations as Mock).mockReset();
   (validateAgentExpectationsFile as Mock).mockReset();
   (writeInvalidAgentExpectationOutput as Mock).mockReset();
@@ -184,6 +190,10 @@ beforeEach(async () => {
     skipped: [],
   });
   (createAgentTestPlanContext as Mock).mockResolvedValue(undefined);
+  (loadAgentOutput as Mock).mockResolvedValue({ outputDir: "", run: {}, tests: [], findings: [], humanReport: null });
+  (formatAgentRunSummary as Mock).mockImplementation((params: { outputDir: string }) => [
+    `agent summary: ${params.outputDir}`,
+  ]);
   (buildAgentInlineExpectations as Mock).mockImplementation((options: Record<string, unknown>) =>
     Object.values(options).some((value) =>
       Array.isArray(value) ? value.length > 0 : typeof value === "string" && value.length > 0,
@@ -530,14 +540,24 @@ describe("agent command", () => {
         },
         withQualityGate: false,
         logs: "pipe",
+        // Agent runs capture the test output instead of streaming it to the terminal.
+        silent: true,
         ignoreLogs: false,
         logProcessExit: false,
       }),
     );
+    // Before the run, the output dir is announced first so an agent can watch the live state; the
+    // command is echoed but its own output is not streamed.
     expect(logMock).toHaveBeenNthCalledWith(1, `agent output: ${agentOutputDir}`);
-    expect(logMock).toHaveBeenNthCalledWith(2, `agent index: ${join(agentOutputDir, "index.md")}`);
-    expect(logMock).toHaveBeenNthCalledWith(3, "npm test");
+    expect(logMock).toHaveBeenNthCalledWith(2, "npm test");
+    expect(logMock).toHaveBeenCalledWith(expect.stringContaining("manifest/test-events.jsonl"));
     expect(logMock.mock.invocationCallOrder[0]).toBeLessThan((executeAllureRun as Mock).mock.invocationCallOrder[0]);
+    // After the run, a compact summary is printed (built from the agent output) instead of test logs,
+    // with the wall-clock duration and a rerun-failed command derived from the test command.
+    expect(formatAgentRunSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ outputDir: agentOutputDir, rerunCommand: "npm test", durationMs: expect.any(Number) }),
+    );
+    expect(logMock).toHaveBeenCalledWith(`agent summary: ${agentOutputDir}`);
     expect(writeAgentRunState).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -872,11 +892,11 @@ describe("agent command", () => {
     expect(AllureReportMock.prototype.readDirectory).toHaveBeenCalledWith("/cwd/local/allure-results/");
     expect(AllureReportMock.prototype.done).toHaveBeenCalledTimes(1);
     expect(executeAllureRun).not.toHaveBeenCalled();
-    expect(logMock).toHaveBeenCalledWith(`agent output: ${resolvedOutput}`);
-    expect(logMock).toHaveBeenCalledWith(`agent index: ${join(resolvedOutput, "index.md")}`);
     expect(logMock).toHaveBeenCalledWith(
       "allure agent inspect --dump /cwd/allure-results-linux.zip --dump /cwd/allure-results-macos.zip /cwd/local/allure-results/",
     );
+    expect(formatAgentRunSummary).toHaveBeenCalledWith(expect.objectContaining({ outputDir: resolvedOutput }));
+    expect(logMock).toHaveBeenCalledWith(`agent summary: ${resolvedOutput}`);
     expect(writeAgentRunState).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -1022,14 +1042,11 @@ describe("agent command", () => {
         },
       },
     });
-    expect(consoleModule.log).toHaveBeenCalledWith(`agent output: ${resolvedOutput}`);
-    expect(consoleModule.log).toHaveBeenCalledWith(`agent index: ${join(resolvedOutput, "index.md")}`);
-    expect(consoleModule.log).toHaveBeenCalledWith(`agent expectations: ${resolvedExpectations}`);
+    expect(formatAgentRunSummary).toHaveBeenCalledWith(expect.objectContaining({ outputDir: resolvedOutput }));
+    expect(consoleModule.log).toHaveBeenCalledWith(`agent summary: ${resolvedOutput}`);
   });
 
   it("should pass inline expectation options to plugin-agent and readConfig", async () => {
-    const consoleModule = await import("node:console");
-
     await run(AgentCommand, [
       "agent",
       "--goal",
@@ -1090,7 +1107,6 @@ describe("agent command", () => {
         },
       }),
     );
-    expect(consoleModule.log).toHaveBeenCalledWith("agent expectations: CLI options");
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -494,6 +494,46 @@ describe("agent command", () => {
     }
   });
 
+  it("refuses a non-empty --output before the invalid-expectation fallback can delete it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-invalid-output-guard-"));
+    writeFileSync(join(dir, "important.txt"), "keep me");
+    // An expectation error is queued so that, without the guard, the flow would reach
+    // writeInvalidAgentExpectationOutput (which rm -rf's the dir).
+    (validateAgentExpectationsFile as Mock).mockRejectedValueOnce(new AgentExpectationUsageError("invalid expectation"));
+
+    try {
+      const command = new AgentCommand();
+
+      command.output = dir;
+      command.commandToRun = ["--", "npm", "test"];
+
+      await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+
+      expect(writeInvalidAgentExpectationOutput).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a non-empty inspect --output before the invalid-expectation fallback can delete it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-invalid-inspect-guard-"));
+    writeFileSync(join(dir, "important.txt"), "keep me");
+    (validateAgentExpectationsFile as Mock).mockRejectedValueOnce(new AgentExpectationUsageError("invalid expectation"));
+
+    try {
+      const command = new AgentInspectCommand();
+
+      command.output = dir;
+      command.resultsDir = ["./allure-results"];
+
+      await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+
+      expect(writeInvalidAgentExpectationOutput).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("should use an auto-created agent output dir and pass agent-mode overrides to readConfig", async () => {
     const { AllureReportMock } = await import("../utils.js");
     const consoleModule = await import("node:console");

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -499,7 +499,9 @@ describe("agent command", () => {
     writeFileSync(join(dir, "important.txt"), "keep me");
     // An expectation error is queued so that, without the guard, the flow would reach
     // writeInvalidAgentExpectationOutput (which rm -rf's the dir).
-    (validateAgentExpectationsFile as Mock).mockRejectedValueOnce(new AgentExpectationUsageError("invalid expectation"));
+    (validateAgentExpectationsFile as Mock).mockRejectedValueOnce(
+      new AgentExpectationUsageError("invalid expectation"),
+    );
 
     try {
       const command = new AgentCommand();
@@ -518,7 +520,9 @@ describe("agent command", () => {
   it("refuses a non-empty inspect --output before the invalid-expectation fallback can delete it", async () => {
     const dir = mkdtempSync(join(tmpdir(), "allure-agent-invalid-inspect-guard-"));
     writeFileSync(join(dir, "important.txt"), "keep me");
-    (validateAgentExpectationsFile as Mock).mockRejectedValueOnce(new AgentExpectationUsageError("invalid expectation"));
+    (validateAgentExpectationsFile as Mock).mockRejectedValueOnce(
+      new AgentExpectationUsageError("invalid expectation"),
+    );
 
     try {
       const command = new AgentInspectCommand();

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -1,3 +1,4 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -412,6 +413,75 @@ describe("agent command", () => {
 
     expect(readConfig).not.toHaveBeenCalled();
     expect(executeAllureRun).not.toHaveBeenCalled();
+  });
+
+  it("refuses to delete a non-empty, non-agent --output directory before a run", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-output-guard-"));
+    writeFileSync(join(dir, "important.txt"), "keep me");
+
+    try {
+      const command = new AgentCommand();
+
+      command.output = dir;
+      command.commandToRun = ["--", "npm", "test"];
+
+      await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+
+      expect(readConfig).not.toHaveBeenCalled();
+      expect(executeAllureRun).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows an empty --output directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-output-empty-"));
+
+    try {
+      await run(AgentCommand, ["agent", "--output", dir, "--", "npm", "test"]);
+
+      expect(executeAllureRun).toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a non-empty --output directory even when it looks like a previous agent output", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-output-prev-"));
+    writeFileSync(join(dir, "index.md"), "# previous agent run");
+
+    try {
+      const command = new AgentCommand();
+
+      command.output = dir;
+      command.commandToRun = ["--", "npm", "test"];
+
+      await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+
+      expect(readConfig).not.toHaveBeenCalled();
+      expect(executeAllureRun).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an inspect --output that points at a non-empty results directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-inspect-output-"));
+    writeFileSync(join(dir, "0a1b2c3d-result.json"), "{}");
+    vi.mocked(glob).mockResolvedValueOnce([`${dir}/`]);
+
+    try {
+      const command = new AgentInspectCommand();
+
+      command.output = dir;
+      command.resultsDir = [dir];
+
+      await expect(command.execute()).rejects.toBeInstanceOf(UsageError);
+
+      expect(readConfig).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("should use an auto-created agent output dir and pass agent-mode overrides to readConfig", async () => {

--- a/packages/cli/test/commands/agent.test.ts
+++ b/packages/cli/test/commands/agent.test.ts
@@ -1246,6 +1246,25 @@ describe("agent command", () => {
     expect(cleanupMock).toHaveBeenCalledTimes(1);
   });
 
+  it("cleans up the rerun test-plan context before exiting", async () => {
+    const cleanupMock = vi.fn().mockResolvedValue(undefined);
+
+    (createAgentTestPlanContext as Mock).mockResolvedValueOnce({
+      outputDir: previousAgentOutputDir,
+      preset: "review",
+      selectedCount: 1,
+      testPlanPath,
+      cleanup: cleanupMock,
+    });
+
+    await run(AgentCommand, ["agent", "--rerun-from", "./previous-agent", "--", "npm", "test"]);
+
+    expect(cleanupMock).toHaveBeenCalledTimes(1);
+    expect(exitMock).toHaveBeenCalled();
+    // process.exit() skips pending finally blocks, so cleanup must run before exit().
+    expect(cleanupMock.mock.invocationCallOrder[0]).toBeLessThan(exitMock.mock.invocationCallOrder[0]);
+  });
+
   it("should bypass nested allure wrappers and execute the child command directly", async () => {
     process.env[ALLURE_CLI_ACTIVE_COMMAND_ENV] = "run";
     const consoleModule = await import("node:console");

--- a/packages/cli/test/commands/agentLatest.test.ts
+++ b/packages/cli/test/commands/agentLatest.test.ts
@@ -80,7 +80,9 @@ describe("agent latest command", () => {
 
     await run(AgentLatestCommand, ["agent", "latest"]);
 
-    expect(consoleModule.error).toHaveBeenCalledWith("No latest agent output found for /cwd");
+    expect(consoleModule.error).toHaveBeenCalledWith(
+      "No recorded Allure agent output for /cwd. Run `allure agent <command>` first to create one.",
+    );
     expect(processModule.exit).toHaveBeenCalledWith(1);
   });
 

--- a/packages/cli/test/commands/run.integration.test.ts
+++ b/packages/cli/test/commands/run.integration.test.ts
@@ -449,9 +449,13 @@ console.log("emitted simple result");
       expect(await pathExists(join(outputDir, "dashboard"))).toBe(false);
       expect(stdout).toContain(`node ${emitResultsPath} ${simpleResultFixture}`);
       expect(stdout).toContain(`agent output: ${outputDir}`);
-      expect(stdout).toContain(`agent index: ${join(outputDir, "index.md")}`);
-      expect(stdout).toContain(`agent expectations: ${expectationsPath}`);
-      expect(stdout).toContain("emitted simple result");
+      // The post-run summary links the index and reports expectation status (no streamed test output).
+      expect(stdout).toContain(join(outputDir, "index.md"));
+      expect(stdout).toContain("expectations: matched");
+      // The test command's own stdout is captured into the agent artifacts, not echoed to the terminal.
+      const capturedStdout = await readFile(join(outputDir, "artifacts", "global", "stdout.txt"), "utf-8");
+      expect(capturedStdout).toContain("emitted simple result");
+      expect(stdout).not.toContain("emitted simple result");
       expect(stdout).not.toContain("process finished with code");
       expect(stdout).not.toContain("exit code ");
       expect(stdout).not.toContain("[DEP0190]");
@@ -588,8 +592,9 @@ console.log("emitted newly added test result");
       ]);
       expect(findingsContent).toBe("");
       expect(indexMarkdown).toContain(expectedFullName);
-      expect(stdout).toContain("agent expectations: CLI options");
-      expect(stdout).toContain("emitted newly added test result");
+      expect(stdout).toContain("expectations: matched");
+      const capturedStdout = await readFile(join(outputDir, "artifacts", "global", "stdout.txt"), "utf-8");
+      expect(capturedStdout).toContain("emitted newly added test result");
       expect(stderr).toBe("");
     });
   }, 240_000);
@@ -817,7 +822,7 @@ console.log(\`selected selectors: \${Array.from(selectors).join(",")}\`);
           subject: "tests/default/feature-a.md",
           severity: "high",
           category: "evidence",
-          check_name: "failed-without-useful-steps",
+          check_name: "insufficient-expected-steps",
           message: "Feature A needs focused rerun coverage",
           explanation: "Feature A should be the only review-targeted rerun candidate.",
           evidence_paths: [],
@@ -920,7 +925,11 @@ console.log(\`selected selectors: \${Array.from(selectors).join(",")}\`);
       expect(selectFileStdout).toContain("agent selection preset: review");
       expect(selectFileStdout).toContain("agent selection tests: 1");
       expect(selectFileStderr).toBe("");
-      expect(stdout).toContain("selected selectors: suite feature A");
+      // The rerun prints its summary to the terminal, but the command's own stdout is captured into
+      // the agent artifacts rather than echoed.
+      expect(stdout).toContain("Allure agent:");
+      const capturedStdout = await readFile(join(outputDir, "artifacts", "global", "stdout.txt"), "utf-8");
+      expect(capturedStdout).toContain("selected selectors: suite feature A");
       expect(stderr).toBe("");
 
       const selectedTests = (await readFile(join(outputDir, "manifest", "tests.jsonl"), "utf-8"))

--- a/packages/plugin-agent/src/guidance.ts
+++ b/packages/plugin-agent/src/guidance.ts
@@ -113,11 +113,6 @@ export const ENRICHMENT_ACTIONS_BY_CHECK_NAME: Record<string, EnrichmentActionDe
     title: "Repair logical test identity",
     guidance: "Use stable, unique history IDs so distinct logical tests do not collapse into one file.",
   },
-  "failed-without-useful-steps": {
-    category: "add-meaningful-steps",
-    title: "Add meaningful setup, action, and assertion steps",
-    guidance: "Wrap only real actions, state transitions, and checks in Allure steps before rerunning.",
-  },
   "expected-step-containing-missing": {
     category: "add-meaningful-steps",
     title: "Add or correct the expected step text",
@@ -137,44 +132,6 @@ export const ENRICHMENT_ACTIONS_BY_CHECK_NAME: Record<string, EnrichmentActionDe
     category: "add-test-attachments",
     title: "Add the required attachment",
     guidance: "Attach the requested runtime artifact near the relevant action or assertion.",
-  },
-  "failed-without-attachments": {
-    category: "add-test-attachments",
-    title: "Attach focused runtime evidence near the failure",
-    guidance: "Add real payloads, responses, screenshots, DOM snapshots, diffs, or logs near the failing point.",
-  },
-  "nontrivial-run-with-empty-trace": {
-    category: "add-meaningful-steps",
-    title: "Make the execution path observable",
-    guidance: "Expose the real setup, action, and verification path with steps or attachments on the next run.",
-  },
-  "retries-without-new-evidence": {
-    category: "add-retry-diagnostics",
-    title: "Capture what changes between retries",
-    guidance: "Add per-attempt diagnostics so retries show new evidence instead of repeating the same trace.",
-  },
-  "noop-dominated-steps": {
-    category: "collapse-low-signal-trace",
-    title: "Replace noop-style steps with real evidence",
-    guidance:
-      "Keep only steps tied to real actions or checks, and replace bulk event spam with a compact artifact when needed.",
-  },
-  "step-spam": {
-    category: "collapse-low-signal-trace",
-    title: "Reduce low-signal step spam",
-    guidance:
-      "Prefer a smaller set of meaningful steps plus one compact text attachment when the trace is mostly event logs.",
-  },
-  "global-only-artifacts": {
-    category: "add-test-attachments",
-    title: "Move evidence closer to the failing test",
-    guidance:
-      "Use step-scoped or test-scoped attachments near the relevant failing action instead of relying only on global logs.",
-  },
-  "passed-without-observable-evidence": {
-    category: "add-meaningful-steps",
-    title: "Make the success path reviewable",
-    guidance: "Add a few real verification steps or attachments so the passing test shows what it proved.",
   },
 };
 
@@ -334,7 +291,7 @@ export const AGENT_VERIFICATION_RULES = [
 ] as const;
 
 export const AGENT_TEST_ENRICHMENT_BEST_PRACTICES = [
-  "Steps must wrap real actions, state transitions, or assertions. Prefer a small setup/action/assertion narrative over event-by-event step spam.",
+  "Steps should wrap real actions, state transitions, or assertions; let the test's nature decide how granular they are.",
   "Attachments must capture real runtime evidence from that execution: payloads, responses, screenshots, DOM snapshots, diffs, logs, or traces.",
   "Add metadata only when it improves scope review, debugging, or downstream policy. Keep labels and parameters intentionally minimal.",
   "If multiple call sites need the same evidence, instrument the helper once. Example: teach `runCommand` to emit a step instead of wrapping every `runCommand(...)` call site with identical step blocks.",
@@ -350,7 +307,6 @@ export const AGENT_ACCEPTANCE_CHECKLIST = [
   "The rerun matches the intended scope and does not trigger forbidden or unexpected-test findings.",
   "Each touched test shows enough evidence to explain what happened and what was verified.",
   "Retries include per-attempt diagnostics when the same test reruns.",
-  "No high-confidence anti-dummy findings remain, especially `noop-dominated-steps` or low-signal `step-spam` traces.",
 ] as const;
 
 export const AGENT_REVIEW_COMPLETENESS_CHECKLIST = [
@@ -391,7 +347,7 @@ export const AGENT_INSTRUCTIONS_TEMPLATE = `## Allure Agent Mode Instructions
 - Attach only real runtime evidence such as payloads, responses, screenshots, DOM snapshots, diffs, logs, or traces.
 - Keep metadata minimal. Add labels or severity only when scope review, debugging, or quality policy uses them.
 - Instrument stable helpers when several call sites need the same evidence. For example, teach \`runCommand\` to emit a step instead of wrapping every caller.
-- Reject the rerun if scope drifts, evidence stays weak, or high-confidence noop-style findings remain.`;
+- Reject the rerun if scope drifts or evidence stays weak.`;
 
 const renderBullets = (items: readonly string[]) => items.map((item) => `- ${item}`).join("\n");
 

--- a/packages/plugin-agent/src/harness.ts
+++ b/packages/plugin-agent/src/harness.ts
@@ -387,14 +387,11 @@ export const ITERATION_REQUIRED_CHECKS = [
   "insufficient-expected-steps",
   "insufficient-expected-attachments",
   "missing-expected-attachment",
-  "failed-without-useful-steps",
-  "failed-without-attachments",
-  "nontrivial-run-with-empty-trace",
-  "retries-without-new-evidence",
-  "passed-without-observable-evidence",
 ] as const;
 
-export const ANTI_DUMMY_CHECKS = ["noop-dominated-steps"] as const;
+// Anti-fakery checks force a reject above the confidence threshold. None ship yet (the previous
+// evidence-shape heuristics were removed); honesty/staleness checks will be added here.
+export const ANTI_DUMMY_CHECKS: readonly string[] = [];
 
 const SEVERITY_ORDER: Record<AgentFindingSeverity, number> = {
   high: 0,
@@ -546,10 +543,7 @@ const impactForFinding = (
     return "reject";
   }
 
-  if (
-    ANTI_DUMMY_CHECKS.includes(checkName as (typeof ANTI_DUMMY_CHECKS)[number]) &&
-    (finding.confidence ?? 0) >= antiDummyConfidenceThreshold
-  ) {
+  if (ANTI_DUMMY_CHECKS.includes(checkName) && (finding.confidence ?? 0) >= antiDummyConfidenceThreshold) {
     return "reject";
   }
 
@@ -699,12 +693,6 @@ export const planAgentEnrichmentReview = (
   if (!output.run.expectations_present) {
     notes.push(
       "Declare inline expectations or provide an expectations file before the next enrichment iteration so scope checks are comparable.",
-    );
-  }
-
-  if (rejecting.some((item) => item.checkName === "noop-dominated-steps")) {
-    notes.push(
-      "Reject noop-dominated enrichment: keep only steps tied to real actions or checks, and use real runtime attachments instead of placeholders.",
     );
   }
 

--- a/packages/plugin-agent/src/harness.ts
+++ b/packages/plugin-agent/src/harness.ts
@@ -5,6 +5,7 @@ import type { Statistic, TestLabel, TestStatus } from "@allurereport/core-api";
 
 import { ENRICHMENT_ACTIONS_BY_CHECK_NAME, type EnrichmentActionCategory } from "./guidance.js";
 import type { AgentHumanReportStatus } from "./model.js";
+import { isPathInside } from "./paths.js";
 
 export type AgentFindingSeverity = "info" | "warning" | "high";
 export type AgentFindingCategory = "bootstrap" | "scope" | "metadata" | "evidence" | "smells";
@@ -582,17 +583,29 @@ export const mapFindingToEnrichmentAction = (finding: AgentFindingManifestLine |
   return mapped ?? { ...FALLBACK_ACTION, checkName };
 };
 
+// Manifest-supplied paths are untrusted (the output directory may be an attacker-supplied bundle),
+// so never read a path that resolves outside the output directory.
+const resolveContainedOutputPath = (outputDir: string, relativePath: string) => {
+  const resolved = join(outputDir, relativePath);
+
+  return isPathInside(outputDir, resolved) ? resolved : undefined;
+};
+
 export const loadAgentOutput = async (outputDir: string): Promise<AgentOutputBundle> => {
   const absoluteOutputDir = resolve(outputDir);
   const run = await readJson<AgentRunManifest>(join(absoluteOutputDir, "manifest", "run.json"));
   const tests = await readJsonl<AgentTestManifestLine>(join(absoluteOutputDir, "manifest", "tests.jsonl"));
   const findings = await readJsonl<AgentFindingManifestLine>(join(absoluteOutputDir, "manifest", "findings.jsonl"));
-  const expected =
+  const expectedManifestPath =
     run.paths.expected_manifest && run.expectations_present
-      ? await readJson<AgentExpectations>(join(absoluteOutputDir, run.paths.expected_manifest))
+      ? resolveContainedOutputPath(absoluteOutputDir, run.paths.expected_manifest)
       : undefined;
-  const humanReport = run.paths.human_report_manifest
-    ? await readJson<AgentHumanReportStatus>(join(absoluteOutputDir, run.paths.human_report_manifest))
+  const expected = expectedManifestPath ? await readJson<AgentExpectations>(expectedManifestPath) : undefined;
+  const humanReportManifestPath = run.paths.human_report_manifest
+    ? resolveContainedOutputPath(absoluteOutputDir, run.paths.human_report_manifest)
+    : undefined;
+  const humanReport = humanReportManifestPath
+    ? await readJson<AgentHumanReportStatus>(humanReportManifestPath)
     : undefined;
 
   return {

--- a/packages/plugin-agent/src/harness.ts
+++ b/packages/plugin-agent/src/harness.ts
@@ -3,9 +3,11 @@ import { join, resolve } from "node:path";
 
 import type { Statistic, TestLabel, TestStatus } from "@allurereport/core-api";
 
+import { AgentUsageError } from "./errors.js";
 import { ENRICHMENT_ACTIONS_BY_CHECK_NAME, type EnrichmentActionCategory } from "./guidance.js";
 import type { AgentHumanReportStatus } from "./model.js";
 import { isPathInside } from "./paths.js";
+import { isFileNotFoundError } from "./utils.js";
 
 export type AgentFindingSeverity = "info" | "warning" | "high";
 export type AgentFindingCategory = "bootstrap" | "scope" | "metadata" | "evidence" | "smells";
@@ -591,11 +593,51 @@ const resolveContainedOutputPath = (outputDir: string, relativePath: string) => 
   return isPathInside(outputDir, resolved) ? resolved : undefined;
 };
 
+const readAgentRunManifest = async (outputDir: string): Promise<AgentRunManifest> => {
+  const runManifestPath = join(outputDir, "manifest", "run.json");
+  let raw: string;
+
+  try {
+    raw = await readFile(runManifestPath, "utf-8");
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      throw new AgentUsageError(
+        `No Allure agent output found at ${JSON.stringify(outputDir)} (missing manifest/run.json). ` +
+          "It must be a directory created by a previous `allure agent` run. " +
+          "Run `allure agent latest` to find the most recent output, pass a valid --from <agent-output-dir> or --latest, " +
+          "or run `allure agent <command>` to create one.",
+      );
+    }
+
+    throw error;
+  }
+
+  try {
+    return JSON.parse(raw) as AgentRunManifest;
+  } catch {
+    throw new AgentUsageError(
+      `The Allure agent output at ${JSON.stringify(outputDir)} is corrupted: manifest/run.json is not valid JSON. ` +
+        "Re-run `allure agent` to regenerate the output.",
+    );
+  }
+};
+
 export const loadAgentOutput = async (outputDir: string): Promise<AgentOutputBundle> => {
   const absoluteOutputDir = resolve(outputDir);
-  const run = await readJson<AgentRunManifest>(join(absoluteOutputDir, "manifest", "run.json"));
-  const tests = await readJsonl<AgentTestManifestLine>(join(absoluteOutputDir, "manifest", "tests.jsonl"));
-  const findings = await readJsonl<AgentFindingManifestLine>(join(absoluteOutputDir, "manifest", "findings.jsonl"));
+  const run = await readAgentRunManifest(absoluteOutputDir);
+  let tests: AgentTestManifestLine[];
+  let findings: AgentFindingManifestLine[];
+
+  try {
+    tests = await readJsonl<AgentTestManifestLine>(join(absoluteOutputDir, "manifest", "tests.jsonl"));
+    findings = await readJsonl<AgentFindingManifestLine>(join(absoluteOutputDir, "manifest", "findings.jsonl"));
+  } catch {
+    throw new AgentUsageError(
+      `The Allure agent output at ${JSON.stringify(absoluteOutputDir)} is incomplete or corrupted: ` +
+        "its test/finding manifests could not be read. Re-run `allure agent` to regenerate the output.",
+    );
+  }
+
   const expectedManifestPath =
     run.paths.expected_manifest && run.expectations_present
       ? resolveContainedOutputPath(absoluteOutputDir, run.paths.expected_manifest)

--- a/packages/plugin-agent/src/index.ts
+++ b/packages/plugin-agent/src/index.ts
@@ -17,6 +17,7 @@ export * from "./errors.js";
 export * from "./harness.js";
 export * from "./inline-expectations.js";
 export * from "./invalid-output.js";
+export * from "./output-dir.js";
 export * from "./paths.js";
 export * from "./query.js";
 export * from "./selection.js";

--- a/packages/plugin-agent/src/index.ts
+++ b/packages/plugin-agent/src/index.ts
@@ -21,4 +21,5 @@ export * from "./paths.js";
 export * from "./query.js";
 export * from "./selection.js";
 export * from "./state.js";
+export * from "./summary.js";
 export { AgentPlugin as default } from "./plugin.js";

--- a/packages/plugin-agent/src/inline-expectations.ts
+++ b/packages/plugin-agent/src/inline-expectations.ts
@@ -80,17 +80,19 @@ const readSingleStringOption = (value: SingleStringOptionValue, optionName: stri
 };
 
 const parseNameValue = (value: string, optionName: string, example: string) => {
-  const parts = value.split("=");
+  const separatorIndex = value.indexOf("=");
 
-  if (parts.length !== 2) {
+  if (separatorIndex === -1) {
     throw new AgentExpectationUsageError(
       `Invalid ${optionName} ${JSON.stringify(value)}. Expected ${example}`,
       optionName,
     );
   }
 
-  const name = parts[0].trim();
-  const filterValue = parts[1].trim();
+  // Split on the first "=" only so values may themselves contain "="
+  // (e.g. content-type=text/html;charset=utf-8 or a label value with "=").
+  const name = value.slice(0, separatorIndex).trim();
+  const filterValue = value.slice(separatorIndex + 1).trim();
 
   if (!name || !filterValue) {
     throw new AgentExpectationUsageError(

--- a/packages/plugin-agent/src/output-dir.ts
+++ b/packages/plugin-agent/src/output-dir.ts
@@ -1,0 +1,35 @@
+import { readdir, stat } from "node:fs/promises";
+
+import { AgentUsageError } from "./errors.js";
+import { isFileNotFoundError } from "./utils.js";
+
+/**
+ * An explicit, caller-provided agent output directory is recursively deleted before it is written
+ * (both by a run/inspect and by the invalid-expectation fallback). Only allow a directory that is
+ * absent or empty, so a mistyped path (e.g. `--output ./src`) cannot destroy unrelated files.
+ * Managed temp outputs are created fresh and never need this check.
+ */
+export const assertExplicitAgentOutputDirIsSafe = async (outputDir: string) => {
+  let stats;
+
+  try {
+    stats = await stat(outputDir);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+
+  if (!stats.isDirectory()) {
+    throw new AgentUsageError(`--output ${JSON.stringify(outputDir)} is not a directory; use a new or empty directory`);
+  }
+
+  if ((await readdir(outputDir)).length > 0) {
+    throw new AgentUsageError(
+      `refusing to use --output ${JSON.stringify(outputDir)}: the agent recursively deletes its output directory, ` +
+        `so it must be a new or empty directory.`,
+    );
+  }
+};

--- a/packages/plugin-agent/src/plugin.ts
+++ b/packages/plugin-agent/src/plugin.ts
@@ -3283,7 +3283,6 @@ const buildRunAndTestFindings = (params: {
         }),
       );
     });
-
   }
 
   return {

--- a/packages/plugin-agent/src/plugin.ts
+++ b/packages/plugin-agent/src/plugin.ts
@@ -2664,7 +2664,8 @@ const computeScopeEvaluation = (params: {
       scopeMatch: "forbidden",
       reasons: forbidden.reasons,
       expectedReferences: forbidden.references,
-      metadataMismatches,
+      // A forbidden match is reported on its own; expected-label mismatches are not relevant here.
+      metadataMismatches: [],
     } satisfies ScopeEvaluation;
   }
 
@@ -2701,7 +2702,9 @@ const buildDurationSummary = (entries: TestEntry[]) => {
   return {
     total,
     average: durations.length ? Math.round(total / durations.length) : 0,
-    max: durations.length ? Math.max(...durations) : 0,
+    // Reduce instead of Math.max(...durations): the spread overflows the call-stack/argument
+    // limit (RangeError) on very large runs.
+    max: durations.reduce((acc, value) => (value > acc ? value : acc), 0),
   };
 };
 

--- a/packages/plugin-agent/src/plugin.ts
+++ b/packages/plugin-agent/src/plugin.ts
@@ -51,8 +51,6 @@ const FINDING_SEVERITY_ORDER = {
   info: 2,
 } as const;
 const NONTRIVIAL_DURATION_MS = 100;
-const STEP_SPAM_THRESHOLD = 25;
-const NOOP_RATIO_THRESHOLD = 0.8;
 const ASSERTION_STEP_PATTERN = /\b(assert|expect|check|verify|validate|should)\b/i;
 const LOW_VALUE_STDERR_WARNING_PATTERNS = [
   /\bNO_COLOR\b/i,
@@ -374,8 +372,6 @@ const formatDurationValue = (value?: number) => formatDuration(value);
 
 const escapeJsonPointerSegment = (value: string) => value.replace(/~/g, "~0").replace(/\//g, "~1");
 
-const isFailedLikeStatus = (status: TestStatus) => status === "failed" || status === "broken";
-
 const normalizeStringArray = (value: unknown) => {
   if (!Array.isArray(value)) {
     return [];
@@ -586,11 +582,18 @@ const analyzeStepTree = (steps: TestStepResult[]): StepTreeSummary => {
         summary.nestedSteps += 1;
       }
 
-      if (ASSERTION_STEP_PATTERN.test(node.name)) {
+      const isAssertionLike = ASSERTION_STEP_PATTERN.test(node.name);
+      const isNonTrivialDuration = (node.duration ?? 0) >= NONTRIVIAL_DURATION_MS;
+
+      if (isAssertionLike) {
         summary.assertionLikeSteps += 1;
       }
 
-      if (hasEvidence) {
+      // A leaf step is low-signal only when it carries no signal at all. The step name and duration
+      // are signal too: an assertion step states its check in the name, and a step that did real work
+      // (non-trivial duration) is not a noop. Without this, assertion DSLs and setup narratives that
+      // record one named leaf per check or action are wrongly flagged as noop-dominated.
+      if (hasEvidence || isAssertionLike || isNonTrivialDuration) {
         summary.meaningfulSteps += 1;
       } else {
         summary.noopSteps += 1;
@@ -656,19 +659,6 @@ const testStepContainsText = (entry: TestEntry, expectedText: string) => {
 
   return collectStepNames(entry.attempts[0].tr.steps).some(({ name }) => normalizeStepText(name).includes(expected));
 };
-
-const buildAttemptSignature = (attempt: AttemptRecord) =>
-  JSON.stringify({
-    status: attempt.tr.status,
-    errorMessage: attempt.tr.error?.message,
-    errorTrace: attempt.tr.error?.trace,
-    stepSummary: attempt.stepSummary,
-    fixtureSummary: attempt.fixtureStepSummary,
-    artifactNames: attempt.artifacts.map((artifact) => ({
-      name: artifact.displayName,
-      missing: artifact.missing,
-    })),
-  });
 
 const getPackageName = (tr: TestResult) => tr.labels.find(({ name }) => name === "package")?.value;
 
@@ -1600,10 +1590,6 @@ const defaultImpactForFinding = (finding: AgentFinding): FindingImpact => {
     return "reject";
   }
 
-  if (finding.checkName === "noop-dominated-steps" && (finding.confidence ?? 0) >= 0.75) {
-    return "reject";
-  }
-
   if (
     [
       "expectations-invalid",
@@ -1617,11 +1603,6 @@ const defaultImpactForFinding = (finding: AgentFinding): FindingImpact => {
       "runner-failures-outside-logical-results",
       "metadata-mismatch",
       "history-id-collision",
-      "failed-without-useful-steps",
-      "failed-without-attachments",
-      "nontrivial-run-with-empty-trace",
-      "retries-without-new-evidence",
-      "passed-without-observable-evidence",
     ].includes(finding.checkName)
   ) {
     return "iterate";
@@ -1875,9 +1856,7 @@ const renderExpectationResultSection = (params: {
 };
 
 const renderRerunGuidance = (findings: AgentFinding[]) => {
-  const relevant = findings.filter(
-    ({ category }) => category === "evidence" || category === "smells" || category === "metadata",
-  );
+  const relevant = findings.filter(({ category }) => category === "evidence" || category === "metadata");
 
   if (!relevant.length) {
     return undefined;
@@ -1892,10 +1871,6 @@ const renderRerunGuidance = (findings: AgentFinding[]) => {
 
   if (relevant.some(({ category }) => category === "metadata")) {
     lines.push("- Add or repair the labels and parameters needed to identify the intended scope.");
-  }
-
-  if (relevant.some(({ checkName }) => checkName === "noop-dominated-steps")) {
-    lines.push("- Replace repetitive event-style steps with a compact text attachment when the signal is mostly logs.");
   }
 
   lines.push("- Rerun only the relevant tests with the same expectations so the next review is scoped and comparable.");
@@ -2708,18 +2683,6 @@ const buildDurationSummary = (entries: TestEntry[]) => {
   };
 };
 
-const collectTestEvidencePaths = (entry: TestEntry) => {
-  const paths = [entry.relativePath];
-
-  for (const artifact of entry.allArtifacts) {
-    if (artifact.relativePath) {
-      paths.push(artifact.relativePath);
-    }
-  }
-
-  return uniqueValues(paths);
-};
-
 const getExpectationTargetEntries = (entries: TestEntry[], expectations: LoadedExpectations) => {
   if (!hasSelector(expectations.expected)) {
     return entries;
@@ -3082,21 +3045,11 @@ const buildRunAndTestFindings = (params: {
     : new Set<string>();
 
   for (const entry of entries) {
-    const currentAttempt = entry.attempts[0];
-    const attemptSignatures = uniqueValues(entry.attempts.map(buildAttemptSignature));
-    const testEvidencePaths = collectTestEvidencePaths(entry);
-    const allStepSummary = mergeStepSummaries(
-      entry.attempts.map((attempt) => mergeStepSummaries([attempt.stepSummary, attempt.fixtureStepSummary])),
-    );
     const expectedEvidenceApplies = expectations ? evidenceTargetKeys.has(entry.key) : false;
     const expectedEvidence = expectations?.evidence;
     const currentStepSummary = currentAttemptStepSummary(entry);
     const currentMeaningfulSteps = currentStepSummary.meaningfulSteps;
     const currentAttachments = nonMissingArtifacts(entry);
-    const hasUsefulSteps =
-      currentAttempt.stepSummary.meaningfulSteps + currentAttempt.fixtureStepSummary.meaningfulSteps > 0;
-    const hasAnyAttachments = entry.allArtifacts.some((artifact) => !artifact.missing);
-    const noopRatio = allStepSummary.totalSteps > 0 ? allStepSummary.noopSteps / allStepSummary.totalSteps : 0;
 
     if (entry.scope.scopeMatch === "forbidden") {
       const forbiddenLabelReference = entry.scope.expectedReferences.find((reference) =>
@@ -3331,162 +3284,6 @@ const buildRunAndTestFindings = (params: {
       );
     });
 
-    if (isFailedLikeStatus(currentAttempt.tr.status) && !hasUsefulSteps) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "warning",
-          category: "evidence",
-          checkName: "failed-without-useful-steps",
-          message: "A failed or broken test has no useful runtime steps.",
-          explanation:
-            "The failure is recorded, but the step tree does not explain the state transitions that led to it.",
-          evidencePaths: testEvidencePaths,
-          remediationHint: "Add meaningful steps around the important actions and checks before rerunning.",
-          confidence: 0.92,
-        }),
-      );
-    }
-
-    if (isFailedLikeStatus(currentAttempt.tr.status) && !hasAnyAttachments) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "warning",
-          category: "evidence",
-          checkName: "failed-without-attachments",
-          message: "A failed or broken test has no test-scoped attachments.",
-          explanation: "Attachments often provide the fastest route to understanding why the test failed.",
-          evidencePaths: testEvidencePaths,
-          remediationHint: "Attach targeted logs, payloads, screenshots, or DOM snapshots around the failing point.",
-          confidence: 0.88,
-        }),
-      );
-    }
-
-    if (
-      (currentAttempt.tr.duration ?? 0) >= NONTRIVIAL_DURATION_MS &&
-      currentAttempt.stepSummary.totalSteps === 0 &&
-      currentAttempt.fixtureStepSummary.totalSteps === 0
-    ) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "warning",
-          category: "evidence",
-          checkName: "nontrivial-run-with-empty-trace",
-          message: "A nontrivial test run recorded no steps or fixture activity.",
-          explanation: "The duration suggests real work happened, but the trace contains no step-level evidence.",
-          evidencePaths: testEvidencePaths,
-          remediationHint: "Add runtime steps or attachments so the execution path is observable on the next run.",
-          confidence: 0.8,
-        }),
-      );
-    }
-
-    if (entry.attempts.length > 1 && attemptSignatures.length === 1) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "info",
-          category: "evidence",
-          checkName: "retries-without-new-evidence",
-          message: "Retries did not add any new observable evidence.",
-          explanation:
-            "The recorded status, error, steps, and attachments stayed effectively unchanged across retries.",
-          evidencePaths: testEvidencePaths,
-          remediationHint: "Add retry-specific diagnostics or targeted attachments so reruns can show what changed.",
-          confidence: 0.7,
-        }),
-      );
-    }
-
-    if (allStepSummary.totalSteps >= 3 && noopRatio >= NOOP_RATIO_THRESHOLD && !hasAnyAttachments) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "warning",
-          category: "smells",
-          checkName: "noop-dominated-steps",
-          message: "The step tree is dominated by low-signal steps.",
-          explanation:
-            "Most recorded steps are leaf steps without parameters, nested actions, attachments, or error context.",
-          evidencePaths: testEvidencePaths,
-          remediationHint:
-            "Collapse repetitive event-style steps into a smaller set of meaningful steps or attach a text log instead.",
-          confidence: 0.75,
-        }),
-      );
-    }
-
-    if (allStepSummary.totalSteps >= STEP_SPAM_THRESHOLD && !hasAnyAttachments) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "info",
-          category: "smells",
-          checkName: "step-spam",
-          message: "The trace records many steps but no compact artifact.",
-          explanation: "A large number of small steps can be harder to review than a focused log attachment.",
-          evidencePaths: testEvidencePaths,
-          remediationHint: "Consider attaching a structured text log when the trace is mostly event reporting.",
-          confidence: 0.7,
-        }),
-      );
-    }
-
-    if (isFailedLikeStatus(currentAttempt.tr.status) && !hasAnyAttachments && globalArtifacts.length > 0) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "info",
-          category: "smells",
-          checkName: "global-only-artifacts",
-          message: "Only run-level artifacts are available for this failed test.",
-          explanation:
-            "The run captured global logs, but the failed test has no test-scoped attachments to pinpoint the failure.",
-          evidencePaths: uniqueValues(
-            testEvidencePaths.concat(
-              globalArtifacts.flatMap((artifact) => (artifact.relativePath ? [artifact.relativePath] : [])),
-            ),
-          ),
-          remediationHint:
-            "Prefer step-scoped or test-scoped attachments near the failing action when debugging targeted failures.",
-          confidence: 0.78,
-        }),
-      );
-    }
-
-    if (
-      currentAttempt.tr.status === "passed" &&
-      (currentAttempt.tr.duration ?? 0) >= NONTRIVIAL_DURATION_MS &&
-      currentAttempt.stepSummary.totalSteps === 0 &&
-      currentAttempt.fixtureStepSummary.totalSteps === 0 &&
-      !hasAnyAttachments
-    ) {
-      entry.findings.push(
-        createFinding({
-          subject: entry.key,
-          subjectType: "test",
-          severity: "info",
-          category: "smells",
-          checkName: "passed-without-observable-evidence",
-          message: "A nontrivial passing test recorded no observable evidence.",
-          explanation:
-            "The test passed, but the agentic output contains no steps, fixture activity, or attachments showing what was verified.",
-          evidencePaths: testEvidencePaths,
-          remediationHint: "Add a few meaningful verification steps or attachments so the success path is reviewable.",
-          confidence: 0.65,
-        }),
-      );
-    }
   }
 
   return {

--- a/packages/plugin-agent/src/query.ts
+++ b/packages/plugin-agent/src/query.ts
@@ -243,6 +243,18 @@ const buildAgentQueryTestPayload = async (output: AgentOutputBundle, filters: Ag
   const test = matched[0];
   const markdownPath = resolveAgentOutputPath(output, test.markdown_path);
   const findings = output.findings.filter((finding) => agentFindingSubjectRef(finding) === test.markdown_path);
+  let markdown: string | undefined;
+
+  if (filters.includeMarkdown && markdownPath) {
+    try {
+      markdown = await readFile(markdownPath, "utf-8");
+    } catch {
+      throw new AgentUsageError(
+        `Could not read the per-test markdown for ${JSON.stringify(test.full_name)} at ${JSON.stringify(markdownPath)}; ` +
+          "the agent output is incomplete. Re-run `allure agent` to regenerate it, or omit --include-markdown.",
+      );
+    }
+  }
 
   return {
     schema: AGENT_QUERY_SCHEMA,
@@ -251,7 +263,7 @@ const buildAgentQueryTestPayload = async (output: AgentOutputBundle, filters: Ag
     markdown_path: markdownPath,
     test,
     findings,
-    ...(filters.includeMarkdown && markdownPath ? { markdown: await readFile(markdownPath, "utf-8") } : {}),
+    ...(markdown !== undefined ? { markdown } : {}),
   };
 };
 

--- a/packages/plugin-agent/src/query.ts
+++ b/packages/plugin-agent/src/query.ts
@@ -10,6 +10,7 @@ import type {
   AgentOutputBundle,
   AgentTestManifestLine,
 } from "./harness.js";
+import { isPathInside } from "./paths.js";
 import type { AgentLabelFilter } from "./selection.js";
 
 export const AGENT_QUERY_SCHEMA = "allure-agent-query/v1";
@@ -152,8 +153,16 @@ const filterAgentQueryFindings = (output: AgentOutputBundle, filters: AgentQuery
 const applyAgentQueryLimit = <T>(items: T[], limit: number | undefined): T[] =>
   limit === undefined ? items : items.slice(0, limit);
 
-const resolveAgentOutputPath = (output: AgentOutputBundle, relativePath: string | null | undefined) =>
-  relativePath ? join(output.outputDir, relativePath) : null;
+const resolveAgentOutputPath = (output: AgentOutputBundle, relativePath: string | null | undefined) => {
+  if (!relativePath) {
+    return null;
+  }
+
+  const resolved = join(output.outputDir, relativePath);
+
+  // Manifest-supplied paths are untrusted; never resolve (or read) outside the output directory.
+  return isPathInside(output.outputDir, resolved) ? resolved : null;
+};
 
 const buildAgentQuerySummaryPayload = (output: AgentOutputBundle) => ({
   schema: AGENT_QUERY_SCHEMA,

--- a/packages/plugin-agent/src/selection.ts
+++ b/packages/plugin-agent/src/selection.ts
@@ -163,7 +163,10 @@ export const resolveAgentSelectionOutputDir = async (params: {
   const latestState = await readLatestAgentState(cwd);
 
   if (!latestState) {
-    throw new AgentUsageError(`No latest agent output found for ${cwd}`);
+    throw new AgentUsageError(
+      `No recorded Allure agent output for ${JSON.stringify(cwd)}. ` +
+        "Run `allure agent <command>` first to create one, or pass --from <agent-output-dir>.",
+    );
   }
 
   return latestState.outputDir;

--- a/packages/plugin-agent/src/state.ts
+++ b/packages/plugin-agent/src/state.ts
@@ -174,9 +174,7 @@ const isAgentRunActive = (state: AgentRunState) =>
   state.status === "running" && state.pid !== undefined && isProcessAlive(state.pid);
 
 const isManagedOutputStale = (state: AgentRunState, now: number, staleOutputTtlMs: number) =>
-  state.managedOutput &&
-  !isAgentRunActive(state) &&
-  now - getAgentRunStateAgeTimestamp(state) >= staleOutputTtlMs;
+  state.managedOutput && !isAgentRunActive(state) && now - getAgentRunStateAgeTimestamp(state) >= staleOutputTtlMs;
 
 const isAgentOutputDirectory = async (outputDir: string) =>
   (await pathExists(join(outputDir, "manifest", "run.json"))) || (await pathExists(join(outputDir, "index.md")));

--- a/packages/plugin-agent/src/state.ts
+++ b/packages/plugin-agent/src/state.ts
@@ -53,6 +53,9 @@ export type AgentStaleStateCleanupResult = AgentStateCleanupResult & {
 
 const AGENT_RUN_STATE_SCHEMA = "allure-agent-run/v1";
 const AGENT_STALE_OUTPUT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+// Recently finished managed outputs are kept past the keep-newest limit so that concurrent agent
+// runs in the same project do not delete output another run may still be reading.
+const AGENT_MANAGED_OUTPUT_GRACE_MS = 60 * 60 * 1000;
 
 const isAgentRunState = (value: unknown): value is AgentRunState => {
   if (typeof value !== "object" || value === null) {
@@ -304,9 +307,13 @@ export const cleanupAgentRunState = async (params: {
   cwd: string;
   currentRunId?: string;
   keepManagedRuns?: number;
+  managedOutputGraceMs?: number;
+  now?: number;
 }): Promise<AgentStateCleanupResult> =>
   withAgentStateLock(params.cwd, async () => {
     const keepManagedRuns = Math.max(0, params.keepManagedRuns ?? 1);
+    const managedOutputGraceMs = Math.max(0, params.managedOutputGraceMs ?? AGENT_MANAGED_OUTPUT_GRACE_MS);
+    const now = params.now ?? Date.now();
     const states = foldAgentRunStates(await readAgentRunStateLines(params.cwd));
     const existing: AgentRunState[] = [];
 
@@ -333,6 +340,12 @@ export const cleanupAgentRunState = async (params: {
 
     for (const state of existing) {
       if (!state.managedOutput || state.status !== "finished" || retainedManagedRunIds.has(state.runId)) {
+        continue;
+      }
+
+      // Keep recently finished managed outputs so a concurrent run does not delete output that
+      // another agent run in the same project may still be reading.
+      if (now - (state.finishedAt ?? state.startedAt) <= managedOutputGraceMs) {
         continue;
       }
 

--- a/packages/plugin-agent/src/state.ts
+++ b/packages/plugin-agent/src/state.ts
@@ -1,5 +1,6 @@
 import { appendFile, readFile, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import process from "node:process";
 
 import {
   isFileNotFoundError,
@@ -152,8 +153,27 @@ const foldAgentRunStates = (states: AgentRunState[]): AgentRunState[] => {
 
 const getAgentRunStateAgeTimestamp = (state: AgentRunState) => state.finishedAt ?? state.startedAt;
 
+const isProcessAlive = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+
+    return true;
+  } catch (error) {
+    // ESRCH means the process is gone; EPERM means it exists but we may not signal it.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+};
+
+// A run is active only while its process is still alive. A crashed run keeps status "running"
+// forever (it never writes finishedAt), so we must check liveness, not just status, to avoid
+// either deleting a live run's output or leaking a crashed run's output.
+const isAgentRunActive = (state: AgentRunState) =>
+  state.status === "running" && state.pid !== undefined && isProcessAlive(state.pid);
+
 const isManagedOutputStale = (state: AgentRunState, now: number, staleOutputTtlMs: number) =>
-  state.managedOutput && now - getAgentRunStateAgeTimestamp(state) >= staleOutputTtlMs;
+  state.managedOutput &&
+  !isAgentRunActive(state) &&
+  now - getAgentRunStateAgeTimestamp(state) >= staleOutputTtlMs;
 
 const isAgentOutputDirectory = async (outputDir: string) =>
   (await pathExists(join(outputDir, "manifest", "run.json"))) || (await pathExists(join(outputDir, "index.md")));

--- a/packages/plugin-agent/src/summary.ts
+++ b/packages/plugin-agent/src/summary.ts
@@ -88,8 +88,10 @@ export const formatAgentRunSummary = (params: {
   }
 
   if (params.rerunCommand && failedCount > 0) {
+    // Use --rerun-from <this run's dir>, not --rerun-latest: under concurrent agent runs "latest" is
+    // cwd-global and may resolve to a sibling run, while --from targets exactly this output.
     lines.push(
-      `  rerun failed: allure agent --rerun-latest --rerun-preset failed -- ${params.rerunCommand}` +
+      `  rerun failed: allure agent --rerun-from ${outputDir} --rerun-preset failed -- ${params.rerunCommand}` +
         `  (reruns ${failedCount} failed test${failedCount === 1 ? "" : "s"})`,
     );
   }

--- a/packages/plugin-agent/src/summary.ts
+++ b/packages/plugin-agent/src/summary.ts
@@ -1,0 +1,122 @@
+import { join } from "node:path";
+
+import type { Statistic } from "@allurereport/core-api";
+
+import type { AgentRunManifest } from "./harness.js";
+import type { AgentHumanReportStatus } from "./model.js";
+
+const formatStatusCounts = (stats: Statistic): string => {
+  const parts = [
+    stats.failed ? `${stats.failed} failed` : undefined,
+    stats.broken ? `${stats.broken} broken` : undefined,
+    stats.passed ? `${stats.passed} passed` : undefined,
+    stats.skipped ? `${stats.skipped} skipped` : undefined,
+    stats.unknown ? `${stats.unknown} unknown` : undefined,
+  ].filter((part): part is string => part !== undefined);
+  const total = stats.total ?? 0;
+
+  return `${parts.length ? parts.join(", ") : "no tests"} (${total} total)`;
+};
+
+const formatDurationMs = (ms: number): string => {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+
+  const seconds = ms / 1000;
+
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+
+  return `${minutes}m ${remainingSeconds}s`;
+};
+
+const formatFindingCounts = (countsBySeverity: AgentRunManifest["check_summary"]["countsBySeverity"]): string =>
+  [
+    countsBySeverity.high ? `${countsBySeverity.high} high` : undefined,
+    countsBySeverity.warning ? `${countsBySeverity.warning} warning` : undefined,
+    countsBySeverity.info ? `${countsBySeverity.info} info` : undefined,
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(", ");
+
+/**
+ * Build a compact (<=20 line) agent-facing summary of an agent run: status at a glance, the key
+ * output links, and what to read where. An agent run does not echo the test command's own console
+ * output, so this summary is the entry point to the captured evidence.
+ */
+export const formatAgentRunSummary = (params: {
+  outputDir: string;
+  run: AgentRunManifest;
+  humanReport?: AgentHumanReportStatus | null;
+  /** Wall-clock duration of the run, used for the "global run time" in the header. */
+  durationMs?: number;
+  /** The original test command; when set and the run has failures, a rerun-failed instruction is shown. */
+  rerunCommand?: string;
+}): string[] => {
+  const { outputDir, run } = params;
+  const humanReport = params.humanReport ?? run.human_report ?? undefined;
+  const toAbsolute = (relativePath?: string | null) => (relativePath ? join(outputDir, relativePath) : undefined);
+  const lines: string[] = [];
+
+  const exitCode = run.actual_exit_code ?? run.original_exit_code;
+  const flaky = run.summary.stats.flaky ?? 0;
+  const failedCount = (run.summary.stats.failed ?? 0) + (run.summary.stats.broken ?? 0);
+
+  lines.push(
+    `Allure agent: ${formatStatusCounts(run.summary.stats)} · exit ${exitCode ?? "unknown"}` +
+      (params.durationMs !== undefined ? ` · ${formatDurationMs(params.durationMs)}` : "") +
+      (flaky ? ` · ${flaky} flaky` : ""),
+  );
+
+  if (run.check_summary.total > 0) {
+    lines.push(
+      `  findings: ${run.check_summary.total} (${formatFindingCounts(run.check_summary.countsBySeverity)}) — a green count is not a pass`,
+    );
+  }
+
+  if (run.expectations_present) {
+    lines.push(`  expectations: ${run.expectation_result.status} (${run.expectation_result.impact})`);
+  }
+
+  if (run.modeling?.completeness === "partial") {
+    lines.push("  runtime modeling: partial — some runner failures are outside logical tests; check stderr");
+  }
+
+  if (params.rerunCommand && failedCount > 0) {
+    lines.push(
+      `  rerun failed: allure agent --rerun-latest --rerun-preset failed -- ${params.rerunCommand}` +
+        `  (reruns ${failedCount} failed test${failedCount === 1 ? "" : "s"})`,
+    );
+  }
+
+  lines.push("");
+  lines.push("Reach every conclusion from this agent output, not the raw console:");
+  lines.push(`  overview   ${toAbsolute(run.paths.index_md)}  (read this first)`);
+  lines.push(`  findings   ${toAbsolute(run.paths.findings_manifest)}`);
+  lines.push(`  tests      ${toAbsolute(run.paths.tests_manifest)}`);
+
+  const logs = [toAbsolute(run.paths.process_logs.stdout), toAbsolute(run.paths.process_logs.stderr)].filter(
+    (value): value is string => value !== undefined,
+  );
+
+  if (logs.length) {
+    lines.push(`  test logs  ${logs.join("  ")}`);
+  }
+
+  lines.push(`  run data   ${join(outputDir, "manifest", "run.json")}`);
+  lines.push(`  guide      ${toAbsolute(run.paths.agents_md)}`);
+  lines.push(`  inspect    allure agent query --from ${outputDir} summary|tests|findings|test`);
+
+  const reportPath = humanReport?.status === "generated" ? toAbsolute(humanReport.path) : undefined;
+
+  if (reportPath) {
+    lines.push(`Here is the report: [report](${reportPath})`);
+  }
+
+  return lines;
+};

--- a/packages/plugin-agent/test/harness.test.ts
+++ b/packages/plugin-agent/test/harness.test.ts
@@ -12,7 +12,6 @@ import AgentPlugin, {
   type AgentFindingManifestLine,
   type AgentExpectationsInput,
   type AgentOutputBundle,
-  AGENT_ENRICHMENT_ACTIONS,
   AgentUsageError,
   buildAgentExpectations,
   loadAgentOutput,
@@ -120,11 +119,11 @@ const createFinding = (overrides: Partial<AgentFindingManifestLine> = {}): Agent
   subject: "run",
   severity: "warning",
   category: "evidence",
-  check_name: "failed-without-useful-steps",
-  message: "Add meaningful steps.",
-  explanation: "The trace is empty.",
+  check_name: "insufficient-expected-steps",
+  message: "Expected at least 1 meaningful step.",
+  explanation: "The trace did not contain the expected steps.",
   evidence_paths: ["tests/default/example.md"],
-  remediation_hint: "Add meaningful steps.",
+  remediation_hint: "Add the expected meaningful steps.",
   ...overrides,
 });
 
@@ -716,68 +715,20 @@ describe("agent enrichment harness", () => {
 
   it("should map enrichment findings to the intended remediation categories", async () => {
     const mappedActions = {
-      "failed-without-useful-steps": AGENT_ENRICHMENT_ACTIONS["failed-without-useful-steps"].category,
-      "nontrivial-run-with-empty-trace": mapFindingToEnrichmentAction("nontrivial-run-with-empty-trace").category,
-      "passed-without-observable-evidence": mapFindingToEnrichmentAction("passed-without-observable-evidence").category,
-      "failed-without-attachments": mapFindingToEnrichmentAction("failed-without-attachments").category,
-      "global-only-artifacts": mapFindingToEnrichmentAction("global-only-artifacts").category,
       "runner-failures-outside-logical-results": mapFindingToEnrichmentAction("runner-failures-outside-logical-results")
         .category,
       "unmodeled-visible-results": mapFindingToEnrichmentAction("unmodeled-visible-results").category,
       "metadata-mismatch": mapFindingToEnrichmentAction("metadata-mismatch").category,
-      "retries-without-new-evidence": mapFindingToEnrichmentAction("retries-without-new-evidence").category,
-      "noop-dominated-steps": mapFindingToEnrichmentAction("noop-dominated-steps").category,
-      "step-spam": mapFindingToEnrichmentAction("step-spam").category,
       "unexpected-test": mapFindingToEnrichmentAction("unexpected-test").category,
     };
 
     await attachJsonEvidence("enrichment action category map", mappedActions);
     expect(mappedActions).toEqual({
-      "failed-without-useful-steps": "add-meaningful-steps",
-      "nontrivial-run-with-empty-trace": "add-meaningful-steps",
-      "passed-without-observable-evidence": "add-meaningful-steps",
-      "failed-without-attachments": "add-test-attachments",
-      "global-only-artifacts": "add-test-attachments",
       "runner-failures-outside-logical-results": "bootstrap-allure",
       "unmodeled-visible-results": "review-manually",
       "metadata-mismatch": "repair-test-metadata",
-      "retries-without-new-evidence": "add-retry-diagnostics",
-      "noop-dominated-steps": "collapse-low-signal-trace",
-      "step-spam": "collapse-low-signal-trace",
       "unexpected-test": "narrow-test-scope",
     });
-  });
-
-  it("should reject high-confidence noop-style evidence", async () => {
-    const review = planAgentEnrichmentReview(
-      createOutputBundle({
-        findings: [
-          createFinding({
-            subject: "tests/default/history-1.md",
-            check_name: "noop-dominated-steps",
-            category: "smells",
-            severity: "warning",
-            confidence: 0.8,
-            remediation_hint: "Remove empty wrapper steps.",
-          }),
-        ],
-      }),
-    );
-
-    await attachJsonEvidence("noop-style evidence review decision", review);
-    expect(review.status).toBe("reject");
-    expect(review.rejecting).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkName: "noop-dominated-steps",
-          category: "collapse-low-signal-trace",
-          acceptanceImpact: "reject",
-        }),
-      ]),
-    );
-    expect(review.notes).toContain(
-      "Reject noop-dominated enrichment: keep only steps tied to real actions or checks, and use real runtime attachments instead of placeholders.",
-    );
   });
 
   it("should accept a clean scoped run from a real agent output directory", async () => {
@@ -994,69 +945,6 @@ describe("agent enrichment harness", () => {
     expect(checkNames).not.toContain("metadata-mismatch");
   });
 
-  it("should iterate when a failed test needs real steps and attachments", async () => {
-    const outputDir = join(tempDir, "low-signal-output");
-    const expectationsPath = join(tempDir, "expected-low-signal.json");
-    const testResult = createTestResult({
-      id: "tr-low-signal",
-      historyId: "low-signal-history",
-      fullName: "suite low signal",
-      status: "failed",
-      duration: 250,
-      labels: [
-        {
-          name: "feature",
-          value: "feature-low-signal",
-        },
-      ],
-      error: {
-        message: "boom",
-      },
-    });
-
-    await writeFile(
-      expectationsPath,
-      JSON.stringify({
-        goal: "Improve low-signal failure evidence",
-        task_id: "low-signal",
-        expected: {
-          environments: ["default"],
-          full_names: ["suite low signal"],
-          label_values: {
-            feature: "feature-low-signal",
-          },
-        },
-      }),
-      "utf-8",
-    );
-
-    await new AgentPlugin({ outputDir, expectationsPath }).done(
-      createContext(),
-      createStore({
-        allTestResults: vi.fn().mockResolvedValue([testResult]),
-        testsStatistic: vi.fn().mockResolvedValue({ total: 1, failed: 1 }),
-      }),
-    );
-
-    const review = await reviewAgentOutput(outputDir);
-
-    await attachJsonEvidence("low-signal failure review decision", review);
-    expect(review.status).toBe("iterate");
-    expect(review.iterate).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkName: "failed-without-useful-steps",
-          category: "add-meaningful-steps",
-        }),
-        expect.objectContaining({
-          checkName: "failed-without-attachments",
-          category: "add-test-attachments",
-        }),
-      ]),
-    );
-    expect(review.rerun.targetedTests).toContain("suite low signal");
-  });
-
   it("should iterate when runner failures exist outside logical test results", () => {
     const review = planAgentEnrichmentReview(
       createOutputBundle({
@@ -1083,76 +971,4 @@ describe("agent enrichment harness", () => {
     );
   });
 
-  it("should iterate retry scenarios and request per-attempt diagnostics", async () => {
-    const outputDir = join(tempDir, "retry-output");
-    const expectationsPath = join(tempDir, "expected-retry.json");
-    const current = createTestResult({
-      id: "tr-current",
-      historyId: "retry-evidence-history",
-      fullName: "suite retry evidence",
-      status: "failed",
-      duration: 150,
-      start: 400,
-      labels: [
-        {
-          name: "feature",
-          value: "retry-feature",
-        },
-      ],
-      error: {
-        message: "same failure",
-        trace: "same trace",
-      },
-    });
-    const retry = createTestResult({
-      id: "tr-retry",
-      historyId: "retry-evidence-history",
-      fullName: "suite retry evidence",
-      status: "failed",
-      isRetry: true,
-      duration: 150,
-      start: 300,
-      error: {
-        message: "same failure",
-        trace: "same trace",
-      },
-    });
-
-    await writeFile(
-      expectationsPath,
-      JSON.stringify({
-        goal: "Improve retry diagnostics",
-        task_id: "retry-feature",
-        expected: {
-          environments: ["default"],
-          full_names: ["suite retry evidence"],
-          label_values: {
-            feature: "retry-feature",
-          },
-        },
-      }),
-      "utf-8",
-    );
-
-    await new AgentPlugin({ outputDir, expectationsPath }).done(
-      createContext(),
-      createStore({
-        allTestResults: vi.fn().mockResolvedValue([current]),
-        testsStatistic: vi.fn().mockResolvedValue({ total: 1, failed: 1, retries: 1 }),
-        retriesByTr: vi.fn().mockResolvedValue([retry]),
-      }),
-    );
-
-    const review = await reviewAgentOutput(outputDir);
-
-    expect(review.status).toBe("iterate");
-    expect(review.iterate).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          checkName: "retries-without-new-evidence",
-          category: "add-retry-diagnostics",
-        }),
-      ]),
-    );
-  });
 });

--- a/packages/plugin-agent/test/harness.test.ts
+++ b/packages/plugin-agent/test/harness.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -14,6 +14,7 @@ import AgentPlugin, {
   type AgentOutputBundle,
   AGENT_ENRICHMENT_ACTIONS,
   buildAgentExpectations,
+  loadAgentOutput,
   mapFindingToEnrichmentAction,
   planAgentEnrichmentReview,
   reviewAgentOutput,
@@ -836,6 +837,28 @@ describe("agent enrichment harness", () => {
     expect(review.status).toBe("accept");
     expect(review.plan).toEqual([]);
     expect(review.rerun.useExistingExpectations).toBe(true);
+  });
+
+  it("does not read an expected_manifest path that escapes the output directory", async () => {
+    const outputDir = join(tempDir, "tampered-output");
+    const secretPath = join(tempDir, "outside-expected.json");
+
+    await mkdir(join(outputDir, "manifest"), { recursive: true });
+    await writeFile(secretPath, JSON.stringify({ goal: "SECRET" }), "utf-8");
+    await writeFile(
+      join(outputDir, "manifest", "run.json"),
+      JSON.stringify({
+        paths: { expected_manifest: "../outside-expected.json", human_report_manifest: null },
+        expectations_present: true,
+      }),
+      "utf-8",
+    );
+    await writeFile(join(outputDir, "manifest", "tests.jsonl"), "", "utf-8");
+    await writeFile(join(outputDir, "manifest", "findings.jsonl"), "", "utf-8");
+
+    const bundle = await loadAgentOutput(outputDir);
+
+    expect(bundle.expected).toBeUndefined();
   });
 
   it("should reject scope drift from a real agent output directory", async () => {

--- a/packages/plugin-agent/test/harness.test.ts
+++ b/packages/plugin-agent/test/harness.test.ts
@@ -13,6 +13,7 @@ import AgentPlugin, {
   type AgentExpectationsInput,
   type AgentOutputBundle,
   AGENT_ENRICHMENT_ACTIONS,
+  AgentUsageError,
   buildAgentExpectations,
   loadAgentOutput,
   mapFindingToEnrichmentAction,
@@ -861,6 +862,22 @@ describe("agent enrichment harness", () => {
     expect(bundle.expected).toBeUndefined();
   });
 
+  it("fails with a recovery hint when the output directory has no run manifest", async () => {
+    const outputDir = join(tempDir, "missing-output");
+    await mkdir(outputDir, { recursive: true });
+
+    await expect(loadAgentOutput(outputDir)).rejects.toBeInstanceOf(AgentUsageError);
+    await expect(loadAgentOutput(outputDir)).rejects.toThrow(/allure agent latest/);
+  });
+
+  it("fails with a corruption hint when the run manifest is not valid JSON", async () => {
+    const outputDir = join(tempDir, "corrupt-output");
+    await mkdir(join(outputDir, "manifest"), { recursive: true });
+    await writeFile(join(outputDir, "manifest", "run.json"), "{ not valid json", "utf-8");
+
+    await expect(loadAgentOutput(outputDir)).rejects.toThrow(/corrupted/i);
+  });
+
   it("should reject scope drift from a real agent output directory", async () => {
     const outputDir = join(tempDir, "scope-drift-output");
     const expectationsPath = join(tempDir, "expected-scope.json");
@@ -931,6 +948,50 @@ describe("agent enrichment harness", () => {
         }),
       ]),
     );
+  });
+
+  it("does not emit a metadata-mismatch finding for a forbidden-scope test", async () => {
+    const outputDir = join(tempDir, "forbidden-metadata-output");
+    const expectationsPath = join(tempDir, "expected-forbidden-metadata.json");
+    // This test matches the expected full-name prefix but carries the forbidden label, so before the
+    // fix it produced both a forbidden finding and a spurious expected-label metadata mismatch.
+    const forbidden = createTestResult({
+      id: "tr-forbidden-meta",
+      historyId: "forbidden-meta-history",
+      name: "feature checkout should not run",
+      fullName: "feature checkout should not run",
+      labels: [{ name: "feature", value: "legacy" }],
+    });
+
+    await writeFile(
+      expectationsPath,
+      JSON.stringify({
+        goal: "Verify checkout",
+        task_id: "checkout",
+        expected: {
+          full_name_prefixes: ["feature checkout"],
+          label_values: { feature: "checkout" },
+        },
+        forbidden: {
+          label_values: { feature: "legacy" },
+        },
+      }),
+      "utf-8",
+    );
+
+    await new AgentPlugin({ outputDir, expectationsPath }).done(
+      createContext(),
+      createStore({
+        allTestResults: vi.fn().mockResolvedValue([forbidden]),
+        testsStatistic: vi.fn().mockResolvedValue({ total: 1, passed: 1 }),
+      }),
+    );
+
+    const bundle = await loadAgentOutput(outputDir);
+    const checkNames = bundle.findings.map((finding) => finding.check_name);
+
+    expect(checkNames).toContain("forbidden-label-observed");
+    expect(checkNames).not.toContain("metadata-mismatch");
   });
 
   it("should iterate when a failed test needs real steps and attachments", async () => {

--- a/packages/plugin-agent/test/harness.test.ts
+++ b/packages/plugin-agent/test/harness.test.ts
@@ -970,5 +970,4 @@ describe("agent enrichment harness", () => {
       ]),
     );
   });
-
 });

--- a/packages/plugin-agent/test/index.test.ts
+++ b/packages/plugin-agent/test/index.test.ts
@@ -2118,5 +2118,4 @@ notes:
     expect(indexContent).toContain("## Needs Attention First");
     expect(indexContent).toContain("None");
   });
-
 });

--- a/packages/plugin-agent/test/index.test.ts
+++ b/packages/plugin-agent/test/index.test.ts
@@ -762,8 +762,6 @@ describe("AgentPlugin", () => {
       expect(guide).toContain("## Review Completeness");
       expect(guide).toContain("## Partial Runtime Review");
       expect(guide).toContain("teach `runCommand` to emit a step");
-      expect(guide).toContain("`failed-without-useful-steps`");
-      expect(guide).toContain("`noop-dominated-steps`");
     });
   });
 
@@ -2121,106 +2119,4 @@ notes:
     expect(indexContent).toContain("None");
   });
 
-  it("should add evidence findings and rerun guidance when a failed test lacks signal", async () => {
-    const outputDir = join(tempDir, "rerun-guidance");
-    const testResult = createTestResult({
-      id: "tr-low-signal",
-      historyId: "low-signal-history",
-      fullName: "suite low signal",
-      status: "failed",
-      duration: 250,
-      error: {
-        message: "boom",
-      },
-    });
-    const store = createStore({
-      allTestResults: vi.fn().mockResolvedValue([testResult]),
-      testsStatistic: vi.fn().mockResolvedValue({ total: 1, failed: 1 }),
-    });
-
-    await new AgentPlugin({ outputDir }).done(createContext(), store);
-
-    const testContent = await readText(join(outputDir, "tests", "default", "low-signal-history.md"), "text/markdown");
-    const findingsManifest = await readJsonl<{
-      check_name: string;
-      subject?: unknown;
-      subject_ref?: string;
-    }>(join(outputDir, "manifest", "findings.jsonl"));
-
-    expect(testContent).toContain("A failed or broken test has no useful runtime steps.");
-    expect(testContent).toContain("A failed or broken test has no test-scoped attachments.");
-    expect(testContent).toContain("A nontrivial test run recorded no steps or fixture activity.");
-    expect(testContent).toContain("## Rerun Guidance");
-    expect(findingsManifest).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          check_name: "failed-without-useful-steps",
-          subject_ref: "tests/default/low-signal-history.md",
-        }),
-        expect.objectContaining({
-          check_name: "failed-without-attachments",
-          subject_ref: "tests/default/low-signal-history.md",
-        }),
-      ]),
-    );
-  });
-
-  it("should emit retry-evidence findings when retries do not add new signal", async () => {
-    const outputDir = join(tempDir, "retry-evidence");
-    const current = createTestResult({
-      id: "tr-current",
-      historyId: "retry-evidence-history",
-      fullName: "suite retry evidence",
-      status: "failed",
-      duration: 150,
-      start: 400,
-      error: {
-        message: "same failure",
-        trace: "same trace",
-      },
-    });
-    const retry = createTestResult({
-      id: "tr-retry",
-      historyId: "retry-evidence-history",
-      fullName: "suite retry evidence",
-      status: "failed",
-      isRetry: true,
-      duration: 150,
-      start: 300,
-      error: {
-        message: "same failure",
-        trace: "same trace",
-      },
-    });
-    const store = createStore({
-      allTestResults: vi.fn().mockResolvedValue([current]),
-      testsStatistic: vi.fn().mockResolvedValue({ total: 1, failed: 1, retries: 1 }),
-      retriesByTr: vi.fn().mockResolvedValue([retry]),
-    });
-
-    await new AgentPlugin({ outputDir }).done(createContext(), store);
-
-    const testContent = await readText(
-      join(outputDir, "tests", "default", "retry-evidence-history.md"),
-      "text/markdown",
-    );
-    const findingsManifest = await readJsonl<{
-      check_name: string;
-      severity: "info" | "warning" | "high";
-      subject?: unknown;
-      subject_ref?: string;
-    }>(join(outputDir, "manifest", "findings.jsonl"));
-
-    expect(testContent).toContain("Retries did not add any new observable evidence.");
-    expect(testContent).toContain("## Retry 1");
-    expect(findingsManifest).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          check_name: "retries-without-new-evidence",
-          severity: "info",
-          subject_ref: "tests/default/retry-evidence-history.md",
-        }),
-      ]),
-    );
-  });
 });

--- a/packages/plugin-agent/test/inline-expectations.test.ts
+++ b/packages/plugin-agent/test/inline-expectations.test.ts
@@ -107,6 +107,16 @@ describe("inline agent expectations", () => {
       input: { expectAttachmentFilters: ["type=image/png"] },
       expected: { evidence: { attachments: [{ content_type: "image/png" }] } },
     },
+    {
+      option: "--expect-attachment content-type with parameters",
+      input: { expectAttachmentFilters: ["content-type=text/html;charset=utf-8"] },
+      expected: { evidence: { attachments: [{ content_type: "text/html;charset=utf-8" }] } },
+    },
+    {
+      option: "--expect-label value containing =",
+      input: { expectLabels: ["config=a=b"] },
+      expected: { expected: { label_values: { config: ["a=b"] } } },
+    },
   ])("should parse $option", ({ input, expected }) => {
     expect(buildAgentInlineExpectations(input)).toEqual(expected);
   });

--- a/packages/plugin-agent/test/output-dir.test.ts
+++ b/packages/plugin-agent/test/output-dir.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { epic, feature, label, story } from "allure-js-commons";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { AgentUsageError } from "../src/errors.js";
+import { assertExplicitAgentOutputDirIsSafe } from "../src/output-dir.js";
+
+beforeEach(async () => {
+  await epic("coverage");
+  await feature("agent-mode");
+  await story("agent-output-dir");
+  await label("coverage", "agent-mode");
+});
+
+describe("explicit agent output dir safety", () => {
+  it("allows an absent directory", async () => {
+    await expect(
+      assertExplicitAgentOutputDirIsSafe(join(tmpdir(), `allure-agent-absent-${process.pid}`)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows an empty directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-empty-"));
+
+    try {
+      await expect(assertExplicitAgentOutputDirIsSafe(dir)).resolves.toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a non-empty directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-nonempty-"));
+    writeFileSync(join(dir, "keep.txt"), "x");
+
+    try {
+      await expect(assertExplicitAgentOutputDirIsSafe(dir)).rejects.toBeInstanceOf(AgentUsageError);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a path that is a file, not a directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "allure-agent-file-"));
+    const filePath = join(dir, "f.txt");
+    writeFileSync(filePath, "x");
+
+    try {
+      await expect(assertExplicitAgentOutputDirIsSafe(filePath)).rejects.toThrow(/not a directory/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/plugin-agent/test/query.test.ts
+++ b/packages/plugin-agent/test/query.test.ts
@@ -329,6 +329,25 @@ describe("agent query payloads", () => {
     }
   });
 
+  it("fails with a recovery hint when requested per-test markdown is missing", async () => {
+    // The fixture only writes suite-should-fail.md, so suite-should-pass.md is absent on disk.
+    await expect(
+      buildAgentQueryPayload(createAgentOutput(tempDir!), "test", {
+        labelFilters: [],
+        test: "suite should pass",
+        includeMarkdown: true,
+      }),
+    ).rejects.toThrow(AgentUsageError);
+
+    await expect(
+      buildAgentQueryPayload(createAgentOutput(tempDir!), "test", {
+        labelFilters: [],
+        test: "suite should pass",
+        includeMarkdown: true,
+      }),
+    ).rejects.toThrow(/include-markdown/);
+  });
+
   it("should reject ambiguous single-test queries and unsupported enum values", async () => {
     await attachJsonEvidence("invalid query option cases", [
       { view: "test", reason: "missing exact test selector" },

--- a/packages/plugin-agent/test/query.test.ts
+++ b/packages/plugin-agent/test/query.test.ts
@@ -303,6 +303,32 @@ describe("agent query payloads", () => {
     );
   });
 
+  it("does not read a per-test markdown_path that escapes the output directory", async () => {
+    const outsideName = `allure-agent-query-outside-${process.pid}.md`;
+    const outsidePath = join(tmpdir(), outsideName);
+    await writeFile(outsidePath, "OUTSIDE SECRET", "utf-8");
+
+    try {
+      const output = createAgentOutput(tempDir!);
+      const tampered: AgentOutputBundle = {
+        ...output,
+        findings: [],
+        tests: [{ ...output.tests[0], full_name: "evil test", markdown_path: `../${outsideName}` }],
+      };
+
+      const payload = await buildAgentQueryPayload(tampered, "test", {
+        labelFilters: [],
+        test: "evil test",
+        includeMarkdown: true,
+      });
+
+      expect(payload).toEqual(expect.objectContaining({ view: "test", markdown_path: null }));
+      expect(payload).not.toHaveProperty("markdown");
+    } finally {
+      await rm(outsidePath, { force: true });
+    }
+  });
+
   it("should reject ambiguous single-test queries and unsupported enum values", async () => {
     await attachJsonEvidence("invalid query option cases", [
       { view: "test", reason: "missing exact test selector" },

--- a/packages/plugin-agent/test/state.test.ts
+++ b/packages/plugin-agent/test/state.test.ts
@@ -365,6 +365,73 @@ describe("agent-state utils", () => {
     expect(fsModule.rename).toHaveBeenCalledWith(expect.stringMatching(/\.tmp$/), otherStatePath);
   });
 
+  it("should keep a still-running managed run whose process is alive but reap a crashed one", async () => {
+    const fsModule = await import("node:fs/promises");
+    const cwd = resolve("/repo");
+    const otherCwd = resolve("/running-repo");
+    const otherStatePath = repoStatePath(otherCwd);
+    const currentManaged = {
+      schema: "allure-agent-run/v1",
+      runId: "current-managed",
+      cwd,
+      outputDir: tempOutputPath("allure-agent-current"),
+      managedOutput: true,
+      command: "npm test current",
+      startedAt: 1777999999000,
+      status: "finished",
+      finishedAt: 1777999999000,
+      exitCode: 0,
+    };
+    // status "running" with a live pid: the run is genuinely in progress and must not be deleted.
+    const runningAlive = {
+      schema: "allure-agent-run/v1",
+      runId: "running-alive",
+      cwd: otherCwd,
+      outputDir: tempOutputPath("allure-agent-running-alive"),
+      managedOutput: true,
+      command: "npm test running",
+      startedAt: 1776276000000,
+      status: "running",
+      pid: process.pid,
+    };
+    // status "running" with a dead pid: the run crashed without writing finishedAt and may be reaped.
+    const runningCrashed = {
+      schema: "allure-agent-run/v1",
+      runId: "running-crashed",
+      cwd: otherCwd,
+      outputDir: tempOutputPath("allure-agent-running-crashed"),
+      managedOutput: true,
+      command: "npm test crashed",
+      startedAt: 1776276000000,
+      status: "running",
+      pid: 2147483646,
+    };
+    const now = 1778000000000;
+
+    (fsModule.readdir as Mock).mockResolvedValueOnce([repoStateEntry(cwd), repoStateEntry(otherCwd)]);
+    (fsModule.readFile as Mock)
+      .mockResolvedValueOnce(`${JSON.stringify(currentManaged)}\n`)
+      .mockResolvedValueOnce([runningAlive, runningCrashed].map((state) => JSON.stringify(state)).join("\n") + "\n")
+      .mockResolvedValueOnce([runningAlive, runningCrashed].map((state) => JSON.stringify(state)).join("\n") + "\n");
+
+    const result = await cleanupStaleAgentRunStates({
+      cwd,
+      now,
+      staleOutputTtlMs: 1,
+    });
+
+    expect(result.deleted).toEqual([runningCrashed]);
+    expect(result.retained).toEqual([runningAlive]);
+    expect(fsModule.rm).toHaveBeenCalledWith(runningCrashed.outputDir, { recursive: true, force: true });
+    expect(fsModule.rm).not.toHaveBeenCalledWith(runningAlive.outputDir, { recursive: true, force: true });
+    expect(fsModule.writeFile).toHaveBeenCalledWith(
+      expect.stringMatching(/\.tmp$/),
+      `${JSON.stringify(runningAlive)}\n`,
+      "utf-8",
+    );
+    expect(fsModule.rename).toHaveBeenCalledWith(expect.stringMatching(/\.tmp$/), otherStatePath);
+  });
+
   it("should skip locked stale registries unless the lock itself is stale", async () => {
     const fsModule = await import("node:fs/promises");
     const cwd = resolve("/repo");

--- a/packages/plugin-agent/test/state.test.ts
+++ b/packages/plugin-agent/test/state.test.ts
@@ -240,6 +240,67 @@ describe("agent-state utils", () => {
     expect(fsModule.rename).toHaveBeenCalledWith(expect.stringMatching(/\.tmp$/), statePath);
   });
 
+  it("should keep recently finished managed outputs so concurrent runs do not delete them", async () => {
+    const fsModule = await import("node:fs/promises");
+    const cwd = resolve("/repo");
+    const now = 1778000000000;
+    const oldSibling = {
+      schema: "allure-agent-run/v1",
+      runId: "old-sibling",
+      cwd,
+      outputDir: tempOutputPath("allure-agent-old-sibling"),
+      managedOutput: true,
+      command: "npm test old",
+      startedAt: now - 2 * 60 * 60 * 1000 - 1000,
+      status: "finished",
+      finishedAt: now - 2 * 60 * 60 * 1000,
+      exitCode: 0,
+    };
+    const recentSibling = {
+      schema: "allure-agent-run/v1",
+      runId: "recent-sibling",
+      cwd,
+      outputDir: tempOutputPath("allure-agent-recent-sibling"),
+      managedOutput: true,
+      command: "npm test recent",
+      startedAt: now - 70_000,
+      status: "finished",
+      finishedAt: now - 60_000,
+      exitCode: 0,
+    };
+    const currentRun = {
+      schema: "allure-agent-run/v1",
+      runId: "current",
+      cwd,
+      outputDir: tempOutputPath("allure-agent-current"),
+      managedOutput: true,
+      command: "npm test current",
+      startedAt: now - 10_000,
+      status: "finished",
+      finishedAt: now,
+      exitCode: 0,
+    };
+
+    (fsModule.readFile as Mock).mockResolvedValueOnce(
+      [oldSibling, recentSibling, currentRun].map((state) => JSON.stringify(state)).join("\n") + "\n",
+    );
+
+    const result = await cleanupAgentRunState({
+      cwd,
+      currentRunId: "current",
+      keepManagedRuns: 1,
+      managedOutputGraceMs: 60 * 60 * 1000,
+      now,
+    });
+
+    // Only the sibling finished beyond the grace window is removed; the recently finished sibling and
+    // the current run survive so concurrent agents can still read their output.
+    expect(result.deleted).toEqual([oldSibling]);
+    expect(result.retained).toEqual([recentSibling, currentRun]);
+    expect(fsModule.rm).toHaveBeenCalledWith(oldSibling.outputDir, { recursive: true, force: true });
+    expect(fsModule.rm).not.toHaveBeenCalledWith(recentSibling.outputDir, { recursive: true, force: true });
+  });
+
   it("should remove all managed finished outputs when retention is zero", async () => {
     const fsModule = await import("node:fs/promises");
     const cwd = resolve("/repo");

--- a/packages/plugin-agent/test/summary.test.ts
+++ b/packages/plugin-agent/test/summary.test.ts
@@ -102,7 +102,11 @@ describe("agent run summary", () => {
   it("omits optional sections for a clean pass with no findings or expectations", () => {
     const lines = formatAgentRunSummary({
       outputDir,
-      run: createRun({ actual_exit_code: 0, original_exit_code: 0, summary: { stats: { total: 3, passed: 3 } } as AgentRunManifest["summary"] }),
+      run: createRun({
+        actual_exit_code: 0,
+        original_exit_code: 0,
+        summary: { stats: { total: 3, passed: 3 } } as AgentRunManifest["summary"],
+      }),
     });
     const text = lines.join("\n");
 

--- a/packages/plugin-agent/test/summary.test.ts
+++ b/packages/plugin-agent/test/summary.test.ts
@@ -1,0 +1,160 @@
+import { join } from "node:path";
+
+import { epic, feature, label, story } from "allure-js-commons";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { AgentRunManifest } from "../src/harness.js";
+import type { AgentHumanReportStatus } from "../src/model.js";
+import { formatAgentRunSummary } from "../src/summary.js";
+
+beforeEach(async () => {
+  await epic("coverage");
+  await feature("agent-mode");
+  await story("agent-summary");
+  await label("coverage", "agent-mode");
+});
+
+const outputDir = "/abs/agent-output";
+
+const createRun = (overrides: Partial<AgentRunManifest> = {}): AgentRunManifest =>
+  ({
+    actual_exit_code: 1,
+    original_exit_code: 1,
+    summary: {
+      stats: { total: 9, passed: 8, failed: 1 },
+    },
+    paths: {
+      index_md: "index.md",
+      agents_md: "AGENTS.md",
+      tests_manifest: "manifest/tests.jsonl",
+      findings_manifest: "manifest/findings.jsonl",
+      process_logs: {
+        stdout: "artifacts/global/stdout.txt",
+        stderr: "artifacts/global/stderr.txt",
+      },
+    },
+    expectations_present: false,
+    expectation_result: { status: "matched", impact: "accept" },
+    check_summary: { total: 0, countsBySeverity: { high: 0, warning: 0, info: 0 }, countsByCategory: {} },
+    ...overrides,
+  }) as unknown as AgentRunManifest;
+
+describe("agent run summary", () => {
+  it("is compact and links the key artifacts with absolute paths", () => {
+    const lines = formatAgentRunSummary({ outputDir, run: createRun() });
+    const text = lines.join("\n");
+
+    expect(lines.length).toBeLessThanOrEqual(20);
+    expect(text).toContain("1 failed, 8 passed (9 total)");
+    expect(text).toContain("exit 1");
+    expect(text).toContain(join(outputDir, "index.md"));
+    expect(text).toContain(join(outputDir, "manifest/findings.jsonl"));
+    expect(text).toContain(join(outputDir, "manifest/tests.jsonl"));
+    expect(text).toContain(join(outputDir, "artifacts/global/stdout.txt"));
+    expect(text).toContain(join(outputDir, "artifacts/global/stderr.txt"));
+    expect(text).toContain(join(outputDir, "manifest", "run.json"));
+    expect(text).toContain(join(outputDir, "AGENTS.md"));
+    expect(text).toContain(`allure agent query --from ${outputDir}`);
+  });
+
+  it("surfaces findings, flaky count, and expectation status when present", () => {
+    const lines = formatAgentRunSummary({
+      outputDir,
+      run: createRun({
+        summary: { stats: { total: 9, passed: 6, failed: 1, flaky: 2 } } as AgentRunManifest["summary"],
+        expectations_present: true,
+        expectation_result: { status: "failed", impact: "reject" } as AgentRunManifest["expectation_result"],
+        check_summary: {
+          total: 3,
+          countsBySeverity: { high: 2, warning: 1, info: 0 },
+          countsByCategory: {} as AgentRunManifest["check_summary"]["countsByCategory"],
+        },
+      }),
+    });
+    const text = lines.join("\n");
+
+    expect(lines.length).toBeLessThanOrEqual(20);
+    expect(text).toContain("2 flaky");
+    expect(text).toContain("findings: 3 (2 high, 1 warning)");
+    expect(text).toContain("expectations: failed (reject)");
+  });
+
+  it("links the human report as an absolute markdown link only when generated", () => {
+    const generated = formatAgentRunSummary({
+      outputDir,
+      run: createRun(),
+      humanReport: { status: "generated", path: "awesome/index.html" } as AgentHumanReportStatus,
+    }).join("\n");
+
+    expect(generated).toContain(`Here is the report: [report](${join(outputDir, "awesome/index.html")})`);
+    // Must resolve to an absolute path, never link the relative manifest value directly.
+    expect(generated).not.toContain("[report](awesome/index.html)");
+
+    const skipped = formatAgentRunSummary({
+      outputDir,
+      run: createRun(),
+      humanReport: { status: "skipped", path: null } as AgentHumanReportStatus,
+    }).join("\n");
+
+    expect(skipped).not.toContain("Here is the report");
+  });
+
+  it("omits optional sections for a clean pass with no findings or expectations", () => {
+    const lines = formatAgentRunSummary({
+      outputDir,
+      run: createRun({ actual_exit_code: 0, original_exit_code: 0, summary: { stats: { total: 3, passed: 3 } } as AgentRunManifest["summary"] }),
+    });
+    const text = lines.join("\n");
+
+    expect(text).toContain("3 passed (3 total)");
+    expect(text).toContain("exit 0");
+    expect(text).not.toContain("findings:");
+    expect(text).not.toContain("expectations:");
+  });
+
+  it("includes global run time and a rerun-failed instruction when there are failures", () => {
+    const lines = formatAgentRunSummary({
+      outputDir,
+      run: createRun(),
+      durationMs: 75_000,
+      rerunCommand: "npm test",
+    });
+    const text = lines.join("\n");
+
+    expect(lines.length).toBeLessThanOrEqual(20);
+    expect(text).toContain("1m 15s");
+    expect(text).toContain("rerun failed: allure agent --rerun-latest --rerun-preset failed -- npm test");
+    expect(text).toContain("(reruns 1 failed test)");
+  });
+
+  it("counts failed and broken tests together for the rerun-failed instruction", () => {
+    const text = formatAgentRunSummary({
+      outputDir,
+      run: createRun({
+        summary: { stats: { total: 9, passed: 6, failed: 2, broken: 1 } } as AgentRunManifest["summary"],
+      }),
+      rerunCommand: "npm test",
+    }).join("\n");
+
+    expect(text).toContain("(reruns 3 failed tests)");
+  });
+
+  it("omits the rerun-failed instruction on a clean pass or when no command is available", () => {
+    const cleanPass = formatAgentRunSummary({
+      outputDir,
+      run: createRun({
+        actual_exit_code: 0,
+        original_exit_code: 0,
+        summary: { stats: { total: 3, passed: 3 } } as AgentRunManifest["summary"],
+      }),
+      rerunCommand: "npm test",
+    }).join("\n");
+
+    expect(cleanPass).not.toContain("rerun failed");
+
+    // Failures but no command to rerun (e.g. inspect mode) -> no rerun instruction.
+    const noCommand = formatAgentRunSummary({ outputDir, run: createRun() }).join("\n");
+
+    expect(noCommand).not.toContain("rerun failed");
+  });
+});

--- a/packages/plugin-agent/test/summary.test.ts
+++ b/packages/plugin-agent/test/summary.test.ts
@@ -123,7 +123,9 @@ describe("agent run summary", () => {
 
     expect(lines.length).toBeLessThanOrEqual(20);
     expect(text).toContain("1m 15s");
-    expect(text).toContain("rerun failed: allure agent --rerun-latest --rerun-preset failed -- npm test");
+    // Reruns target this run's output explicitly (concurrency-safe), not the cwd-global latest.
+    expect(text).toContain(`rerun failed: allure agent --rerun-from ${outputDir} --rerun-preset failed -- npm test`);
+    expect(text).not.toContain("--rerun-latest");
     expect(text).toContain("(reruns 1 failed test)");
   });
 


### PR DESCRIPTION
Allure agent mode now protects explicit output directories more carefully. Runs and inspect flows reject non-empty `--output` directories before any cleanup path runs, including invalid expectation handling, so a mistyped output path is much less likely to remove unrelated files.

Agent runs now print a compact post-run summary with the result count, exit code, expectation status, findings, key artifact paths, and rerun guidance, while preserving the test command’s own stdout and stderr inside the agent output. The latest, select, and query flows also provide clearer recovery messages and safer handling of paths inside agent output bundles.

Expectation parsing now accepts values that contain `=`, managed output cleanup is more robust for concurrent or crashed runs, and the agent no longer emits broad low-signal evidence heuristics that could distract from real scope, metadata, and expectation findings.