### PR TITLE
Collapse titlePath prefixes with no results in Awesome

### DIFF
--- a/packages/plugin-api/src/utils/tree.ts
+++ b/packages/plugin-api/src/utils/tree.ts
@@ -377,6 +377,60 @@ export const transformTree = <L, G>(
   return processTree(tree, { transform: transformer });
 };
 
+const DEFAULT_GROUP_PATH_SEPARATOR = " > ";
+
+/**
+ * Mutates the given tree by merging chains of groups that have no leaves of their own
+ * and exactly one child group into a single group, e.g. `folder1 > folderEmpty > folder3`.
+ * Mirrors how GitHub collapses directories that only contain a single subdirectory.
+ * Returns the link to the same tree.
+ */
+export const collapseTreeGroups = <L, G extends DefaultTreeGroup>(
+  tree: TreeData<L, G>,
+  separator: string = DEFAULT_GROUP_PATH_SEPARATOR,
+): TreeData<L, G> => {
+  const { root } = tree;
+  const groupsById = tree.groupsById as unknown as Record<string, TreeGroup<DefaultTreeGroup>>;
+  const visited = new Set<string>();
+
+  const collapseChildren = (node: WithChildren) => {
+    node.groups?.forEach((groupId) => {
+      if (visited.has(groupId)) {
+        return;
+      }
+      visited.add(groupId);
+
+      const group = groupsById[groupId];
+
+      if (!group) {
+        return;
+      }
+
+      while (!group.leaves?.length && group.groups?.length === 1) {
+        const child = groupsById[group.groups[0] as string];
+
+        if (!child) {
+          break;
+        }
+
+        group.name = `${group.name}${separator}${child.name}`;
+        group.groups = child.groups;
+        group.leaves = child.leaves;
+        group.statistic = child.statistic;
+
+        delete groupsById[child.nodeId];
+        visited.delete(child.nodeId);
+      }
+
+      collapseChildren(group);
+    });
+  };
+
+  collapseChildren(root);
+
+  return tree;
+};
+
 export const createTreeByTitlePath = <T = TestResult, L = DefaultTreeLeaf, G = DefaultTreeGroup>(
   data: T[],
   leafFactory?: (item: T) => TreeLeaf<L>,

--- a/packages/plugin-api/test/tree.test.ts
+++ b/packages/plugin-api/test/tree.test.ts
@@ -6,7 +6,9 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   byLabels,
+  collapseTreeGroups,
   createTreeByLabels,
+  createTreeByTitlePath,
   filterTree,
   filterTreeLabels,
   preciseTreeLabels,
@@ -623,5 +625,118 @@ describe("byLabels", () => {
     } as TestResult;
 
     expect(byLabels(tr1, ["parentSuite", "suite", "subSuite"])).toEqual([["A"], ["C"]]);
+  });
+});
+
+describe("collapseTreeGroups", () => {
+  it("merges a chain of resultless single-child groups into one", () => {
+    const tree = {
+      root: { leaves: [], groups: ["g1"] },
+      leavesById: { l1: { nodeId: "l1", name: "file.spec.ts" } },
+      groupsById: {
+        g1: { nodeId: "g1", name: "folder1", groups: ["g2"], leaves: [], statistic: { total: 1 } },
+        g2: { nodeId: "g2", name: "folderEmpty", groups: ["g3"], leaves: [], statistic: { total: 1 } },
+        g3: { nodeId: "g3", name: "folder3", groups: [], leaves: ["l1"], statistic: { total: 1 } },
+      },
+    };
+
+    const result = collapseTreeGroups(tree as unknown as TreeData<any, any>);
+
+    expect(result.root.groups).toEqual(["g1"]);
+    expect(Object.keys(result.groupsById)).toEqual(["g1"]);
+    expect(result.groupsById.g1).toMatchObject({
+      nodeId: "g1",
+      name: "folder1 > folderEmpty > folder3",
+      groups: [],
+      leaves: ["l1"],
+      statistic: { total: 1 },
+    });
+  });
+
+  it("supports a custom separator", () => {
+    const tree = {
+      root: { leaves: [], groups: ["g1"] },
+      leavesById: {},
+      groupsById: {
+        g1: { nodeId: "g1", name: "folder1", groups: ["g2"], leaves: [] },
+        g2: { nodeId: "g2", name: "folder2", groups: [], leaves: ["l1"] },
+      },
+    };
+
+    const result = collapseTreeGroups(tree as unknown as TreeData<any, any>, "/");
+
+    expect(result.groupsById.g1.name).toBe("folder1/folder2");
+  });
+
+  it("does not collapse a group that has leaves of its own", () => {
+    const tree = {
+      root: { leaves: [], groups: ["g1"] },
+      leavesById: {},
+      groupsById: {
+        g1: { nodeId: "g1", name: "folder1", groups: ["g2"], leaves: ["l0"] },
+        g2: { nodeId: "g2", name: "folder2", groups: [], leaves: ["l1"] },
+      },
+    };
+
+    const result = collapseTreeGroups(tree as unknown as TreeData<any, any>);
+
+    expect(result.groupsById.g1.name).toBe("folder1");
+    expect(result.groupsById.g1.groups).toEqual(["g2"]);
+    expect(result.groupsById.g2.name).toBe("folder2");
+  });
+
+  it("does not collapse a group with more than one child group", () => {
+    const tree = {
+      root: { leaves: [], groups: ["g1"] },
+      leavesById: {},
+      groupsById: {
+        g1: { nodeId: "g1", name: "folder1", groups: ["g2", "g3"], leaves: [] },
+        g2: { nodeId: "g2", name: "folder2", groups: [], leaves: ["l1"] },
+        g3: { nodeId: "g3", name: "folder3", groups: [], leaves: ["l2"] },
+      },
+    };
+
+    const result = collapseTreeGroups(tree as unknown as TreeData<any, any>);
+
+    expect(result.groupsById.g1.name).toBe("folder1");
+    expect(result.groupsById.g1.groups).toEqual(["g2", "g3"]);
+  });
+
+  it("collapses independent sibling branches and nested groups below the merged chain", () => {
+    const tree = {
+      root: { leaves: [], groups: ["a1", "b1"] },
+      leavesById: {},
+      groupsById: {
+        a1: { nodeId: "a1", name: "a1", groups: ["a2"], leaves: [] },
+        a2: { nodeId: "a2", name: "a2", groups: ["a3", "a4"], leaves: [] },
+        a3: { nodeId: "a3", name: "a3", groups: [], leaves: ["l1"] },
+        a4: { nodeId: "a4", name: "a4", groups: [], leaves: ["l2"] },
+        b1: { nodeId: "b1", name: "b1", groups: [], leaves: ["l3"] },
+      },
+    };
+
+    const result = collapseTreeGroups(tree as unknown as TreeData<any, any>);
+
+    expect(result.root.groups).toEqual(["a1", "b1"]);
+    expect(result.groupsById.a1.name).toBe("a1 > a2");
+    expect(result.groupsById.a1.groups).toEqual(["a3", "a4"]);
+    expect(result.groupsById.a2).toBeUndefined();
+    expect(result.groupsById.b1.name).toBe("b1");
+  });
+
+  it("collapses empty titlePath prefixes produced by createTreeByTitlePath", () => {
+    const tr = itResult({
+      name: "should pass",
+      titlePath: ["folder1", "folderEmpty", "folder3", "file.spec.ts"],
+    });
+
+    const tree = collapseTreeGroups(createTreeByTitlePath([tr]));
+
+    expect(tree.root.groups).toHaveLength(1);
+    const group = tree.groupsById[tree.root.groups![0]];
+
+    expect(group.name).toBe("folder1 > folderEmpty > folder3 > file.spec.ts");
+    expect(group.leaves).toEqual([tr.id]);
+    expect(group.groups ?? []).toHaveLength(0);
   });
 });

--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -37,6 +37,7 @@ import type {
   ResultFile,
 } from "@allurereport/plugin-api";
 import {
+  collapseTreeGroups,
   createTreeByLabels,
   createTreeByLabelsAndTitlePath,
   createTreeByTitlePath,
@@ -347,12 +348,11 @@ const buildTreeByTitlePath = (tests: AwesomeTestResult[]): TreeData<AwesomeTreeL
     }
   }
 
-  const treeByTitlePath = createTreeByTitlePath<AwesomeTestResult>(
-    testsWithTitlePath,
-    leafFactory,
-    undefined,
-    (group, leaf) => incrementStatistic(group.statistic, leaf.status),
-  ) as TreeData<AwesomeTreeLeaf, AwesomeTreeGroup>;
+  const treeByTitlePath = collapseTreeGroups(
+    createTreeByTitlePath<AwesomeTestResult>(testsWithTitlePath, leafFactory, undefined, (group, leaf) =>
+      incrementStatistic(group.statistic, leaf.status),
+    ) as TreeData<AwesomeTreeLeaf, AwesomeTreeGroup>,
+  );
 
   if (!testsWithoutTitlePath.length) {
     return treeByTitlePath;
@@ -419,12 +419,14 @@ const buildTreeByLabelsAndTitlePathCombined = (
   tests: AwesomeTestResult[],
   labels: string[],
 ): TreeData<AwesomeTreeLeaf, AwesomeTreeGroup> =>
-  createTreeByLabelsAndTitlePath<AwesomeTestResult, AwesomeTreeLeaf, AwesomeTreeGroup>(
-    tests,
-    labels,
-    leafFactory,
-    undefined,
-    (group: AwesomeTreeGroup, leaf: AwesomeTreeLeaf) => incrementStatistic(group.statistic, leaf.status),
+  collapseTreeGroups(
+    createTreeByLabelsAndTitlePath<AwesomeTestResult, AwesomeTreeLeaf, AwesomeTreeGroup>(
+      tests,
+      labels,
+      leafFactory,
+      undefined,
+      (group: AwesomeTreeGroup, leaf: AwesomeTreeLeaf) => incrementStatistic(group.statistic, leaf.status),
+    ),
   );
 
 const leafFactory = ({


### PR DESCRIPTION
## Summary
- Merge chains of tree groups that have no results of their own and exactly one child group into a single group (e.g. `folder1 > folderEmpty > folder3`), mirroring how GitHub collapses directories that only contain a single subdirectory.
- Applied to the Awesome report's titlePath-based tree (both the default titlePath tree and the combined labels+titlePath tree); the pure labels tree is left untouched.