### PR TITLE
Scope titlePath group collapsing to appendTitlePath:true

### DIFF
--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -348,11 +348,12 @@ const buildTreeByTitlePath = (tests: AwesomeTestResult[]): TreeData<AwesomeTreeL
     }
   }
 
-  const treeByTitlePath = collapseTreeGroups(
-    createTreeByTitlePath<AwesomeTestResult>(testsWithTitlePath, leafFactory, undefined, (group, leaf) =>
-      incrementStatistic(group.statistic, leaf.status),
-    ) as TreeData<AwesomeTreeLeaf, AwesomeTreeGroup>,
-  );
+  const treeByTitlePath = createTreeByTitlePath<AwesomeTestResult>(
+    testsWithTitlePath,
+    leafFactory,
+    undefined,
+    (group, leaf) => incrementStatistic(group.statistic, leaf.status),
+  ) as TreeData<AwesomeTreeLeaf, AwesomeTreeGroup>;
 
   if (!testsWithoutTitlePath.length) {
     return treeByTitlePath;


### PR DESCRIPTION
## Summary
- Follow-up to #754, which merged before this fix was pushed to that branch.
- Only collapse resultless titlePath prefixes for the combined labels+titlePath tree (`groupBy` + `appendTitlePath: true`).
- The default titlePath-only tree (no `groupBy` configured) keeps its full folder structure unchanged.