### PR TITLE
fix: allow reusing the same attachment across multiple test results

### DIFF
--- a/packages/core/src/store/convert.ts
+++ b/packages/core/src/store/convert.ts
@@ -176,7 +176,11 @@ const processAttachmentLink = (
   // (AttachmentLinkExpected/AttachmentLinkLinked) or from an indexed result file
   // (AttachmentLinkFile); AttachmentLinkInvalid is never stored, since it's only produced
   // above for attachments without an originalFileName.
-  const previous = attachments.get(id) as AttachmentLinkFile | AttachmentLinkExpected | AttachmentLinkLinked | undefined;
+  const previous = attachments.get(id) as
+    | AttachmentLinkFile
+    | AttachmentLinkExpected
+    | AttachmentLinkLinked
+    | undefined;
 
   if (!previous) {
     const contentType: string | undefined = attach.contentType ?? lookupContentType(attach.originalFileName);

--- a/packages/core/src/store/convert.ts
+++ b/packages/core/src/store/convert.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type {
   AttachmentLink,
   AttachmentLinkExpected,
+  AttachmentLinkFile,
   AttachmentLinkInvalid,
   AttachmentLinkLinked,
   AttachmentTestStepResult,
@@ -171,7 +172,11 @@ const processAttachmentLink = (
 
   const id = md5(attach.originalFileName);
 
-  const previous: AttachmentLink | undefined = attachments.get(id);
+  // an entry in the map always originates either from an already-referenced attachment
+  // (AttachmentLinkExpected/AttachmentLinkLinked) or from an indexed result file
+  // (AttachmentLinkFile); AttachmentLinkInvalid is never stored, since it's only produced
+  // above for attachments without an originalFileName.
+  const previous = attachments.get(id) as AttachmentLinkFile | AttachmentLinkExpected | AttachmentLinkLinked | undefined;
 
   if (!previous) {
     const contentType: string | undefined = attach.contentType ?? lookupContentType(attach.originalFileName);
@@ -190,18 +195,24 @@ const processAttachmentLink = (
     return createAttachmentStep(linkExpected);
   }
 
-  // deny reusing same file multiple times
-  if (previous.used) {
-    return createAttachmentStep({
-      // random id to prevent collisions
-      id: randomUUID(),
-      originalFileName: undefined,
-      ext: "",
-      name: attach.name ?? attach.originalFileName ?? __unknown,
-      contentType: attach.contentType,
-      missed: true,
+  // the same physical file can legitimately be attached to multiple steps/test results
+  // (e.g. a shared report attached to every test case), so reuse the existing link
+  // instead of treating repeated references as invalid.
+  if (previous.missed) {
+    const link: AttachmentLinkExpected = {
+      ...previous,
+      id,
+      name: attach.name ?? previous.originalFileName,
+      contentType: attach.contentType ?? previous.contentType,
+      // if no extension is specified for originalFileName, we should use provided
+      // contentType in the link first, and only then rely on detected content type.
+      ext: extension(previous.originalFileName, attach.contentType) ?? previous.ext ?? "",
       used: true,
-    });
+      missed: true,
+    };
+    attachments.set(id, link);
+    visitAttachmentLink(link);
+    return createAttachmentStep(link);
   }
 
   const link: AttachmentLinkLinked = {

--- a/packages/core/test/store/convert.test.ts
+++ b/packages/core/test/store/convert.test.ts
@@ -215,6 +215,113 @@ describe("testResultRawToState", () => {
     });
   });
 
+  describe("reusing the same attachment across steps and test results (#433)", () => {
+    it("should link every reference to the same not-yet-resolved file, not just the first", async () => {
+      await issue("433");
+
+      const result = await functionUnderTest(
+        emptyStateData,
+        {
+          steps: [
+            { type: "attachment", name: "first", originalFileName: "shared-file.zip" },
+            { type: "attachment", name: "second", originalFileName: "shared-file.zip" },
+          ],
+        },
+        { readerId },
+      );
+
+      const [first, second] = result.steps as { link: Record<string, unknown> }[];
+      expect(first.link).toMatchObject({
+        name: "first",
+        originalFileName: "shared-file.zip",
+        used: true,
+        missed: true,
+      });
+      expect(second.link).toMatchObject({
+        id: first.link.id,
+        name: "second",
+        originalFileName: "shared-file.zip",
+        ext: ".zip",
+        used: true,
+        missed: true,
+      });
+    });
+
+    it("should link every reference to the same file across separate test results", async () => {
+      await issue("433");
+
+      const sharedStateData: StateData = { ...emptyStateData, attachments: new Map() };
+
+      const firstResult = await functionUnderTest(
+        sharedStateData,
+        { name: "test 1", steps: [{ type: "attachment", name: "first", originalFileName: "shared-file.zip" }] },
+        { readerId },
+      );
+      const secondResult = await functionUnderTest(
+        sharedStateData,
+        { name: "test 2", steps: [{ type: "attachment", name: "second", originalFileName: "shared-file.zip" }] },
+        { readerId },
+      );
+
+      const [firstStep] = firstResult.steps as { link: Record<string, unknown> }[];
+      const [secondStep] = secondResult.steps as { link: Record<string, unknown> }[];
+
+      expect(secondStep.link).toMatchObject({
+        id: firstStep.link.id,
+        originalFileName: "shared-file.zip",
+        used: true,
+        missed: true,
+      });
+    });
+
+    it("should link every reference to an already-resolved file with the resolved content metadata", async () => {
+      await issue("433");
+
+      const fileId = md5("shared-file.zip");
+      const sharedStateData: StateData = {
+        ...emptyStateData,
+        attachments: new Map([
+          [
+            fileId,
+            {
+              id: fileId,
+              used: false,
+              missed: false,
+              originalFileName: "shared-file.zip",
+              ext: ".zip",
+              contentType: "application/zip",
+              contentLength: 42,
+            },
+          ],
+        ]),
+      };
+
+      const firstResult = await functionUnderTest(
+        sharedStateData,
+        { name: "test 1", steps: [{ type: "attachment", name: "first", originalFileName: "shared-file.zip" }] },
+        { readerId },
+      );
+      const secondResult = await functionUnderTest(
+        sharedStateData,
+        { name: "test 2", steps: [{ type: "attachment", name: "second", originalFileName: "shared-file.zip" }] },
+        { readerId },
+      );
+
+      const [firstStep] = firstResult.steps as { link: Record<string, unknown> }[];
+      const [secondStep] = secondResult.steps as { link: Record<string, unknown> }[];
+
+      for (const step of [firstStep, secondStep]) {
+        expect(step.link).toMatchObject({
+          id: fileId,
+          originalFileName: "shared-file.zip",
+          contentLength: 42,
+          used: true,
+          missed: false,
+        });
+      }
+    });
+  });
+
   describe("a converted step", () => {
     it("should mark the message if it's contained in a sub-step", async () => {
       const result = await functionUnderTest(

--- a/packages/core/test/store/store.test.ts
+++ b/packages/core/test/store/store.test.ts
@@ -1250,7 +1250,7 @@ describe("attachments", () => {
     expect(a1Content).toEqual(rf2);
   });
 
-  it("should ignore duplicate attachment links", async () => {
+  it("should allow reusing the same attachment across multiple test results", async () => {
     const store = new DefaultAllureStore();
 
     const tr1: RawTestResult = {
@@ -1286,8 +1286,8 @@ describe("attachments", () => {
     const [a1] = await store.allAttachments({ includeUnused: true, includeMissed: true });
     expect(a1).toEqual(
       expect.objectContaining({
-        name: "attachment 1",
-        contentType: "application/vnd.allure.test",
+        name: "other attachment",
+        contentType: "application/vnd.allure.x-test",
         contentLength: rf1.getContentLength(),
         originalFileName: "tr1-source1.txt",
         used: true,
@@ -1305,13 +1305,13 @@ describe("attachments", () => {
         {
           type: "attachment",
           link: expect.objectContaining({
-            id: expect.any(String),
+            id: a1.id,
             used: true,
-            missed: true,
+            missed: false,
             contentType: "application/vnd.allure.x-test",
             name: "other attachment",
-            originalFileName: undefined,
-            ext: "",
+            originalFileName: "tr1-source1.txt",
+            ext: ".txt",
           }),
         },
       ]),


### PR DESCRIPTION
## Summary
- Previously, referencing the same `originalFileName` from more than one test step (e.g. a shared file attached to every test case) caused every reference after the first to be marked as `missed`, so the attachment showed up as empty/undownloadable in the report.
- `processAttachmentLink` now reuses the existing attachment link instead of denying repeated references, correctly reflecting whether the underlying content has been resolved yet.
- Adds direct unit coverage for `processAttachmentLink` reuse across steps and across separate test results, complementing the existing store-level integration test.

Fixes #433