### PR TITLE
fix(core): honor appendHistory:false when historyPath is set

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -109,6 +109,7 @@ export class AllureReport {
   readonly #hideLabels: FullConfig["hideLabels"];
   readonly #output: string;
   readonly #history: AllureHistory | undefined;
+  readonly #appendHistory: boolean;
   readonly #allureServiceClient: AllureServiceApiClient | undefined;
   readonly #qualityGate: QualityGate | undefined;
   readonly #dump: string | undefined;
@@ -140,6 +141,7 @@ export class AllureReport {
       realTime,
       historyPath,
       historyLimit,
+      appendHistory,
       defaultLabels = {},
       variables = {},
       environment,
@@ -181,6 +183,7 @@ export class AllureReport {
     this.#hideLabels = hideLabels;
     this.#environments = environments ?? {};
     this.#globalAttachments = globalAttachments;
+    this.#appendHistory = appendHistory ?? true;
 
     if (qualityGate) {
       this.#qualityGate = new QualityGate(qualityGate);
@@ -1113,7 +1116,7 @@ export class AllureReport {
         } catch {}
       }
 
-      if (this.#history) {
+      if (this.#history && this.#appendHistory) {
         try {
           await this.#store.appendHistory(this.#historyDataPoint!);
         } catch (err) {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -192,6 +192,53 @@ describe("report", () => {
     expect(acceptedReader.read).toHaveBeenCalledWith(allureReport.store, resultFile);
   });
 
+  it("should not touch the history file when appendHistory is false", async () => {
+    const output = await mkdtemp(join(tmpdir(), "allure3-append-history-"));
+    const historyPath = join(await mkdtemp(join(tmpdir(), "allure3-append-history-data-")), "history.jsonl");
+    const initialHistoryContent = `${JSON.stringify({ uuid: "existing", name: "Existing run", timestamp: 1, knownTestCaseIds: [], metrics: {}, testResults: {} })}\n`;
+
+    await writeFile(historyPath, initialHistoryContent, "utf-8");
+
+    const config = await resolveConfig({
+      name: "Allure Report",
+      output,
+      historyPath,
+      appendHistory: false,
+    });
+
+    const allureReport = new AllureReport(config);
+
+    await allureReport.start();
+    await allureReport.done();
+
+    expect(await readFile(historyPath, "utf-8")).toEqual(initialHistoryContent);
+  });
+
+  it("should append to the history file when appendHistory is true", async () => {
+    const output = await mkdtemp(join(tmpdir(), "allure3-append-history-"));
+    const historyPath = join(await mkdtemp(join(tmpdir(), "allure3-append-history-data-")), "history.jsonl");
+    const initialHistoryContent = `${JSON.stringify({ uuid: "existing", name: "Existing run", timestamp: 1, knownTestCaseIds: [], metrics: {}, testResults: {} })}\n`;
+
+    await writeFile(historyPath, initialHistoryContent, "utf-8");
+
+    const config = await resolveConfig({
+      name: "Allure Report",
+      output,
+      historyPath,
+      appendHistory: true,
+    });
+
+    const allureReport = new AllureReport(config);
+
+    await allureReport.start();
+    await allureReport.done();
+
+    const historyContent = await readFile(historyPath, "utf-8");
+
+    expect(historyContent).not.toEqual(initialHistoryContent);
+    expect(historyContent.startsWith(initialHistoryContent)).toBe(true);
+  });
+
   it("should read result directory files with bounded concurrency", async () => {
     const previousConcurrency = process.env.ALLURE_READ_CONCURRENCY;
     const resultsDir = await mkdtemp(join(tmpdir(), "allure3-read-directory-"));


### PR DESCRIPTION
## Summary
- `AllureReport` computed the `appendHistory` config flag but never checked it before writing to the history file, so the history file was always appended to regardless of the setting.
- Now the history write is gated on `appendHistory` (defaults to `true`), matching the documented behavior.

Fixes #445