### PR TITLE
fix(plugin-api): compute retryTests from store instead of unset tr.retries

### DIFF
--- a/packages/plugin-api/src/utils/summary.ts
+++ b/packages/plugin-api/src/utils/summary.ts
@@ -36,7 +36,8 @@ export const createPluginSummary = async (params: {
   const allTrs = await store.allTestResults({ filter });
   const mainBranchHistory = (await history?.readHistory?.({ branch: "" })) ?? [];
   const newTrs = await store.allNewTestResults(filter, mainBranchHistory);
-  const retryTrs = allTrs.filter((tr) => !!tr?.retries?.length);
+  const retryFlags = await Promise.all(allTrs.map(async (tr) => (await store.retriesByTr(tr)).length > 0));
+  const retryTrs = allTrs.filter((_, index) => retryFlags[index]);
   const flakyTrs = allTrs.filter((tr) => !!tr?.flaky);
   const duration = allTrs.reduce((acc, { duration: trDuration = 0 }) => acc + trDuration, 0);
   const worstStatus = getWorstStatus(allTrs.map(({ status }) => status));

--- a/packages/plugin-api/test/summary.test.ts
+++ b/packages/plugin-api/test/summary.test.ts
@@ -53,7 +53,6 @@ describe("summary utils", () => {
         status: "failed",
         duration: 10,
         stop: 100,
-        retries: [{ id: "r1" } as TestResult],
       }),
       testResult({ id: "t2", name: "two", status: "broken", duration: 20, stop: 250, flaky: true }),
       testResult({ id: "t3", name: "three", status: "passed", duration: 5, stop: 0 }),
@@ -70,6 +69,7 @@ describe("summary utils", () => {
       allTestResults: vi.fn().mockResolvedValue(allTrs),
       allNewTestResults: vi.fn().mockResolvedValue(newTrs),
       testsStatistic: vi.fn().mockResolvedValue(stats),
+      retriesByTr: vi.fn((tr: TestResult) => Promise.resolve(tr.id === "t1" ? [{ id: "r1" } as TestResult] : [])),
     };
     const summary = await createPluginSummary({
       name: "summary-name",
@@ -109,6 +109,7 @@ describe("summary utils", () => {
       allTestResults: vi.fn().mockResolvedValue([testResult({ status: "passed" })]),
       allNewTestResults: vi.fn().mockResolvedValue([]),
       testsStatistic: vi.fn().mockResolvedValue({ total: 1 }),
+      retriesByTr: vi.fn().mockResolvedValue([]),
     };
     const history = { readHistory: vi.fn().mockResolvedValue([]) } as unknown as AllureHistory;
     const summary = await createPluginSummary({

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -96,6 +96,7 @@ const fixtures: any = {
     },
     allNewTestResults: () => Promise.resolve([]),
     allCheckResults: () => Promise.resolve([]),
+    retriesByTr: () => Promise.resolve([]),
     testsStatistic: async (filter: (tr: TestResult) => boolean) => {
       const all = await fixtures.store.allTestResults();
 

--- a/packages/plugin-testops/test/utils.ts
+++ b/packages/plugin-testops/test/utils.ts
@@ -41,6 +41,7 @@ AllureStoreMock.prototype = {
   fixturesByTrId: vi.fn(),
   metadataByKey: vi.fn(),
   testsStatistic: vi.fn(),
+  retriesByTr: vi.fn().mockResolvedValue([]),
   qualityGateResults: vi.fn().mockResolvedValue([]),
 };
 


### PR DESCRIPTION
## Summary
- `createPluginSummary` filtered `retryTests` by `TestResult.retries`, a field that report generators (plugin-classic/plugin-awesome) only populate after the summary is already built — so `retryTests` in `summary.json` was always empty regardless of actual retries.
- Switched to `store.retriesByTr(tr)`, the same source `testsStatistic` already uses to compute `stats.retries`, so both numbers are now consistent.