### PR TITLE
fix(awesome): correct retry count on the Retries tab

### DIFF
--- a/packages/e2e/test/allure-awesome/features/retries.test.ts
+++ b/packages/e2e/test/allure-awesome/features/retries.test.ts
@@ -208,8 +208,8 @@ test.describe("retries", () => {
         const retryAt0 = testResultPage.getRetry(0);
         const retryAt1 = testResultPage.getRetry(1);
 
-        await expect(retryAt0.textLocator).toHaveText(/^Attempt 2 of 3 – \d+\/\d+\/\d+ at \d+:\d+:\d+$/);
-        await expect(retryAt1.textLocator).toHaveText(/^Attempt 1 of 3 – \d+\/\d+\/\d+ at \d+:\d+:\d+$/);
+        await expect(retryAt0.textLocator).toHaveText(/^Retry 2 of 2 – \d+\/\d+\/\d+ at \d+:\d+:\d+$/);
+        await expect(retryAt1.textLocator).toHaveText(/^Retry 1 of 2 – \d+\/\d+\/\d+ at \d+:\d+:\d+$/);
       });
 
       test("retry titles of tests with no timestampts have prefixes", async () => {
@@ -219,8 +219,8 @@ test.describe("retries", () => {
         const retryAt0 = testResultPage.getRetry(0);
         const retryAt1 = testResultPage.getRetry(1);
 
-        await expect(retryAt0.textLocator).toHaveText("Attempt 2 of 3");
-        await expect(retryAt1.textLocator).toHaveText("Attempt 1 of 3");
+        await expect(retryAt0.textLocator).toHaveText("Retry 2 of 2");
+        await expect(retryAt1.textLocator).toHaveText("Retry 1 of 2");
       });
     });
   });

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/TrRetriesItem.tsx
@@ -25,7 +25,7 @@ export const TrRetriesItem: FunctionalComponent<TrRetriesItemProps> = ({ testRes
   const { t } = useI18n("ui");
   const { t: controls } = useI18n("controls");
 
-  const retryTitlePrefix = t("attempt", { attempt, total: totalAttempts });
+  const retryTitlePrefix = t("retry", { attempt, total: totalAttempts });
   const convertedStop = stop ? timestampToDate(stop) : undefined;
   const retryTitle = convertedStop ? `${retryTitlePrefix} – ${convertedStop}` : retryTitlePrefix;
 

--- a/packages/web-awesome/src/components/TestResult/TrRetriesView/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrRetriesView/index.tsx
@@ -21,7 +21,7 @@ export const TrRetriesView: FunctionalComponent<{
             testResultItem={item as unknown as AwesomeTestResult}
             key={key}
             attempt={retries.length - key}
-            totalAttempts={retries.length + 1}
+            totalAttempts={retries.length}
           />
         ))
       ) : (

--- a/packages/web-awesome/src/locales/ar.json
+++ b/packages/web-awesome/src/locales/ar.json
@@ -150,6 +150,7 @@
     "copy": "نسخ",
     "copy-email": "نسخ البريد الإلكتروني",
     "attempt": "المحاولة {{attempt}} من {{total}}",
+    "retry": "إعادة المحاولة {{attempt}} من {{total}}",
     "at": "في",
     "generated": "تم الإنشاء",
     "variables": "المتغيرات",

--- a/packages/web-awesome/src/locales/az.json
+++ b/packages/web-awesome/src/locales/az.json
@@ -150,6 +150,7 @@
     "copy": "Kopyala",
     "copy-email": "E-poçtu kopyala",
     "attempt": "Cəhd {{attempt}} / {{total}}",
+    "retry": "Təkrar cəhd {{attempt}} / {{total}}",
     "at": "tarixində",
     "generated": "Yaradıldı",
     "variables": "Dəyişənlər",

--- a/packages/web-awesome/src/locales/de.json
+++ b/packages/web-awesome/src/locales/de.json
@@ -150,6 +150,7 @@
     "copy": "Kopieren",
     "copy-email": "E-Mail kopieren",
     "attempt": "Versuch {{attempt}} von {{total}}",
+    "retry": "Wiederholung {{attempt}} von {{total}}",
     "at": "bei",
     "generated": "Generiert",
     "variables": "Variablen",

--- a/packages/web-awesome/src/locales/en.json
+++ b/packages/web-awesome/src/locales/en.json
@@ -150,6 +150,7 @@
     "copy": "Copy",
     "copy-email": "Copy email",
     "attempt": "Attempt {{attempt}} of {{total}}",
+    "retry": "Retry {{attempt}} of {{total}}",
     "at": "at",
     "generated": "Generated",
     "variables": "Variables",

--- a/packages/web-awesome/src/locales/es.json
+++ b/packages/web-awesome/src/locales/es.json
@@ -150,6 +150,7 @@
     "copy": "Copiar",
     "copy-email": "Copiar correo",
     "attempt": "Intento {{attempt}} de {{total}}",
+    "retry": "Reintento {{attempt}} de {{total}}",
     "at": "a las",
     "generated": "Generado",
     "variables": "Variables",

--- a/packages/web-awesome/src/locales/fr.json
+++ b/packages/web-awesome/src/locales/fr.json
@@ -150,6 +150,7 @@
     "copy": "Copier",
     "copy-email": "Copier l'e-mail",
     "attempt": "Tentative {{attempt}} sur {{total}}",
+    "retry": "Reprise {{attempt}} sur {{total}}",
     "at": "à",
     "generated": "Généré",
     "variables": "Variables",

--- a/packages/web-awesome/src/locales/he.json
+++ b/packages/web-awesome/src/locales/he.json
@@ -150,6 +150,7 @@
     "copy": "העתק",
     "copy-email": "העתק אימייל",
     "attempt": "ניסיון {{attempt}} מתוך {{total}}",
+    "retry": "ניסיון חוזר {{attempt}} מתוך {{total}}",
     "at": "ב-",
     "generated": "נוצר",
     "variables": "משתנים",

--- a/packages/web-awesome/src/locales/hy.json
+++ b/packages/web-awesome/src/locales/hy.json
@@ -150,6 +150,7 @@
     "copy": "Պատճենել",
     "copy-email": "Պատճենել էլ. փոստը",
     "attempt": "Փորձ {{attempt}}-ից {{total}}-ը",
+    "retry": "Կրկնական փորձ {{attempt}} {{total}}-ից",
     "at": "է",
     "generated": "Ստեղծվել է",
     "variables": "Փոփոխականներ",

--- a/packages/web-awesome/src/locales/it.json
+++ b/packages/web-awesome/src/locales/it.json
@@ -150,6 +150,7 @@
     "copy": "Copia",
     "copy-email": "Copia email",
     "attempt": "Tentativo {{attempt}} di {{total}}",
+    "retry": "Ripetizione {{attempt}} di {{total}}",
     "at": "a",
     "generated": "Generato",
     "variables": "Variabili",

--- a/packages/web-awesome/src/locales/ja.json
+++ b/packages/web-awesome/src/locales/ja.json
@@ -150,6 +150,7 @@
     "copy": "コピー",
     "copy-email": "メールをコピー",
     "attempt": "試行 {{attempt}} 回目（全 {{total}} 回）",
+    "retry": "リトライ {{attempt}} 回目（全 {{total}} 回）",
     "at": "時",
     "generated": "生成日時",
     "variables": "変数",

--- a/packages/web-awesome/src/locales/ka.json
+++ b/packages/web-awesome/src/locales/ka.json
@@ -150,6 +150,7 @@
     "copy": "კოპირება",
     "copy-email": "ელფოსტის კოპირება",
     "attempt": "მცდელობა {{attempt}} {{total}}-დან",
+    "retry": "გამეორება {{attempt}} {{total}}-დან",
     "at": "ზე",
     "generated": "გენერირებულია",
     "variables": "ცვლადები",

--- a/packages/web-awesome/src/locales/kr.json
+++ b/packages/web-awesome/src/locales/kr.json
@@ -150,6 +150,7 @@
     "copy": "복사",
     "copy-email": "이메일 복사",
     "attempt": "시도 {{attempt}}/{{total}}",
+    "retry": "재시도 {{attempt}}/{{total}}",
     "at": "에서",
     "generated": "생성됨",
     "variables": "변수",

--- a/packages/web-awesome/src/locales/nl.json
+++ b/packages/web-awesome/src/locales/nl.json
@@ -150,6 +150,7 @@
     "copy": "Kopiëren",
     "copy-email": "E-mail kopiëren",
     "attempt": "Poging {{attempt}} van {{total}}",
+    "retry": "Nieuwe poging {{attempt}} van {{total}}",
     "at": "om",
     "generated": "Gegenereerd",
     "variables": "Variabelen",

--- a/packages/web-awesome/src/locales/pl.json
+++ b/packages/web-awesome/src/locales/pl.json
@@ -150,6 +150,7 @@
     "copy": "Skopuj",
     "copy-email": "Kopiuj e-mail",
     "attempt": "Próba {{attempt}} z {{total}}",
+    "retry": "Ponowienie {{attempt}} z {{total}}",
     "at": "w",
     "generated": "Wygenerowano",
     "variables": "Zmienne",

--- a/packages/web-awesome/src/locales/pt.json
+++ b/packages/web-awesome/src/locales/pt.json
@@ -150,6 +150,7 @@
     "copy": "Copiar",
     "copy-email": "Copiar e-mail",
     "attempt": "Tentativa {{attempt}} de {{total}}",
+    "retry": "Nova tentativa {{attempt}} de {{total}}",
     "at": "em",
     "generated": "Gerado",
     "variables": "Variáveis",

--- a/packages/web-awesome/src/locales/ru.json
+++ b/packages/web-awesome/src/locales/ru.json
@@ -150,6 +150,7 @@
     "copy": "Скопировать",
     "copy-email": "Скопировать email",
     "attempt": "Попытка {{attempt}} из {{total}}",
+    "retry": "Повтор {{attempt}} из {{total}}",
     "at": "в",
     "generated": "Сгенерировано",
     "variables": "Переменные",

--- a/packages/web-awesome/src/locales/sv.json
+++ b/packages/web-awesome/src/locales/sv.json
@@ -150,6 +150,7 @@
     "copy": "Kopiera",
     "copy-email": "Kopiera e-post",
     "attempt": "Försök {{attempt}} av {{total}}",
+    "retry": "Omförsök {{attempt}} av {{total}}",
     "at": "vid",
     "generated": "Genererad",
     "variables": "Variabler",

--- a/packages/web-awesome/src/locales/tr.json
+++ b/packages/web-awesome/src/locales/tr.json
@@ -150,6 +150,7 @@
     "copy": "Kopyala",
     "copy-email": "E-postayı kopyala",
     "attempt": "Deneme {{attempt}} / {{total}}",
+    "retry": "Yeniden deneme {{attempt}} / {{total}}",
     "at": "tarihinde",
     "generated": "Oluşturuldu",
     "variables": "Değişkenler",

--- a/packages/web-awesome/src/locales/uk.json
+++ b/packages/web-awesome/src/locales/uk.json
@@ -150,6 +150,7 @@
     "copy": "Скопіювати",
     "copy-email": "Скопіювати email",
     "attempt": "Спроба {{attempt}} з {{total}}",
+    "retry": "Повтор {{attempt}} з {{total}}",
     "at": "в",
     "generated": "Згенеровано",
     "variables": "Змінні",

--- a/packages/web-awesome/src/locales/zh-TW.json
+++ b/packages/web-awesome/src/locales/zh-TW.json
@@ -150,6 +150,7 @@
     "copy": "複製",
     "copy-email": "複製電子郵件",
     "attempt": "第 {{attempt}} 次嘗試，共 {{total}} 次",
+    "retry": "第 {{attempt}} 次重試，共 {{total}} 次",
     "at": "於",
     "generated": "已產生",
     "variables": "變數",

--- a/packages/web-awesome/src/locales/zh.json
+++ b/packages/web-awesome/src/locales/zh.json
@@ -150,6 +150,7 @@
     "copy": "复制",
     "copy-email": "复制邮箱",
     "attempt": "第 {{attempt}} 次尝试，共 {{total}} 次",
+    "retry": "第 {{attempt}} 次重试，共 {{total}} 次",
     "at": "在",
     "generated": "已生成",
     "variables": "变量",


### PR DESCRIPTION
## Summary
- The Retries tab counted the final (non-retry) execution in the displayed total (e.g. "Attempt 1 of 4" for a test with 3 retries), even though that execution is only shown on the Overview tab, not in Retries — confusing, since the "4th" item was never visible there.
- `totalAttempts` now equals the number of items actually listed in the tab, and the label reads "Retry" instead of "Attempt" to match the tab's scope.
- Added the new `retry` i18n string to all locale files.

Fixes #690