### PR TITLE
fix(web-components): preserve <head> styles when rendering HTML attachments

### DIFF
--- a/packages/web-commons/src/sanitize.ts
+++ b/packages/web-commons/src/sanitize.ts
@@ -32,4 +32,10 @@ const HTML_DOCUMENT_SANITIZE_CONFIG = {
  * Sanitize a full HTML document (doctype/head/body) for rendering in a preview iframe,
  * preserving `<head>` content such as `<style>` and `<meta charset>`.
  */
-export const sanitizeHtmlDocument = (html: string) => sanitize(html, HTML_DOCUMENT_SANITIZE_CONFIG);
+export const sanitizeHtmlDocument = (html: string) => {
+  const sanitized = sanitize(html, HTML_DOCUMENT_SANITIZE_CONFIG);
+  // DOMPurify has no concept of a doctype node, so WHOLE_DOCUMENT always drops it. Re-add it
+  // unconditionally: without it the iframe renders in quirks mode, which affects box sizing and
+  // other layout rules regardless of what the original attachment declared.
+  return sanitized ? `<!DOCTYPE html>${sanitized}` : sanitized;
+};

--- a/packages/web-commons/src/sanitize.ts
+++ b/packages/web-commons/src/sanitize.ts
@@ -13,3 +13,23 @@ const IFRAME_SANITIZE_CONFIG = {
 };
 
 export const sanitizeIframeHtml = (html: string) => sanitize(html, IFRAME_SANITIZE_CONFIG);
+
+const HTML_DOCUMENT_SANITIZE_CONFIG = {
+  WHOLE_DOCUMENT: true,
+  // DOMPurify drops meta/link/title by default (they're treated as unsafe "document metadata" tags,
+  // not expected when sanitizing a snippet for insertion into an existing page). They're needed here
+  // to preserve an attachment's own stylesheet links and charset declaration.
+  ADD_TAGS: ["meta", "link", "title"],
+  ADD_ATTR: ["charset", "http-equiv", "content", "name", "rel", "href", "media", "property"],
+  // `base` can hijack how every relative url in the document resolves; `http-equiv` (e.g. meta refresh)
+  // can redirect the iframe on its own, without any script execution. Neither is needed to render an
+  // attachment, so both are dropped even though the sandboxed iframe has no allow-scripts.
+  FORBID_TAGS: ["base"],
+  FORBID_ATTR: ["http-equiv"],
+};
+
+/**
+ * Sanitize a full HTML document (doctype/head/body) for rendering in a preview iframe,
+ * preserving `<head>` content such as `<style>` and `<meta charset>`.
+ */
+export const sanitizeHtmlDocument = (html: string) => sanitize(html, HTML_DOCUMENT_SANITIZE_CONFIG);

--- a/packages/web-commons/test/sanitize.test.ts
+++ b/packages/web-commons/test/sanitize.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeHtmlDocument } from "../src/sanitize.js";
+
+describe("sanitizeHtmlDocument", () => {
+  it("preserves head styles and meta charset", () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>.zh{background:yellow;color:red;}</style>
+</head>
+<body>
+<div class="zh">你好世界</div>
+</body>
+</html>`;
+
+    const result = sanitizeHtmlDocument(html);
+
+    expect(result).toContain("<style>.zh{background:yellow;color:red;}</style>");
+    expect(result).toContain('charset="utf-8"');
+    expect(result).toContain("你好世界");
+  });
+
+  it("preserves linked stylesheets", () => {
+    const html = `<html><head><link rel="stylesheet" href="https://example.com/style.css"></head><body>hi</body></html>`;
+
+    const result = sanitizeHtmlDocument(html);
+
+    expect(result).toContain('<link rel="stylesheet" href="https://example.com/style.css">');
+  });
+
+  it("strips script tags", () => {
+    const html = `<html><head><script>alert(1)</script></head><body><script>alert(2)</script>hi</body></html>`;
+
+    const result = sanitizeHtmlDocument(html);
+
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("alert(1)");
+    expect(result).not.toContain("alert(2)");
+  });
+
+  it("strips base tags to prevent base-uri hijacking", () => {
+    const html = `<html><head><base href="https://evil.example"></head><body>hi</body></html>`;
+
+    const result = sanitizeHtmlDocument(html);
+
+    expect(result).not.toContain("<base");
+    expect(result).not.toContain("evil.example");
+  });
+
+  it("strips http-equiv attribute to prevent meta-refresh redirects", () => {
+    const html = `<html><head><meta http-equiv="refresh" content="0;url=https://evil.example"></head><body>hi</body></html>`;
+
+    const result = sanitizeHtmlDocument(html);
+
+    expect(result).not.toContain("http-equiv");
+  });
+});

--- a/packages/web-commons/test/sanitize.test.ts
+++ b/packages/web-commons/test/sanitize.test.ts
@@ -22,6 +22,16 @@ describe("sanitizeHtmlDocument", () => {
     expect(result).toContain("你好世界");
   });
 
+  it("always adds a doctype, so the iframe renders in standards mode", () => {
+    const withoutDoctype = sanitizeHtmlDocument(`<html><head></head><body>hi</body></html>`);
+    const withDoctype = sanitizeHtmlDocument(`<!DOCTYPE html><html><head></head><body>hi</body></html>`);
+
+    expect(withoutDoctype.toLowerCase()).toMatch(/^<!doctype html>/);
+    expect(withDoctype.toLowerCase()).toMatch(/^<!doctype html>/);
+    // DOMPurify has no doctype node, so it must not appear twice regardless of the input.
+    expect(withDoctype.toLowerCase().match(/<!doctype/g)).toHaveLength(1);
+  });
+
   it("preserves linked stylesheets", () => {
     const html = `<html><head><link rel="stylesheet" href="https://example.com/style.css"></head><body>hi</body></html>`;
 

--- a/packages/web-components/src/components/Attachment/HtmlPreview.tsx
+++ b/packages/web-components/src/components/Attachment/HtmlPreview.tsx
@@ -1,4 +1,4 @@
-import { sanitize } from "@allurereport/web-commons";
+import { sanitizeHtmlDocument } from "@allurereport/web-commons";
 import type { FunctionalComponent } from "preact";
 import { useEffect, useState } from "preact/hooks";
 
@@ -26,7 +26,7 @@ export const HtmlPreview: FunctionalComponent<HtmlAttachmentPreviewProps> = ({ a
   const [blobUrl, setBlobUrl] = useState<string>("");
 
   const rawText = attachment.text ?? "";
-  const sanitizedText = rawText.length > 0 ? sanitize(rawText) : "";
+  const sanitizedText = rawText.length > 0 ? sanitizeHtmlDocument(rawText) : "";
 
   useEffect(() => {
     if (sanitizedText) {


### PR DESCRIPTION
## Summary
- `HtmlPreview` sanitized HTML attachments with DOMPurify's default (`WHOLE_DOCUMENT: false`) config, which drops the entire `<head>` — including `<style>` blocks, `<link rel="stylesheet">`, and `<meta charset>`. Styled HTML attachments (e.g. text with custom background/foreground colors) rendered as unstyled plain text.
- Adds `sanitizeHtmlDocument()` in `web-commons`, which keeps `<head>` content while still forbidding `<base>` and the `http-equiv` attribute — both allow document-hijacking/redirect behavior without needing script execution, so they're stripped even though the preview iframe already has no `allow-scripts`.
- `HtmlPreview` now uses `sanitizeHtmlDocument()` instead of the unconfigured `sanitize()`.

Fixes #692