### PR TITLE
fix(plugin-awesome): apply plugin filter to per-environment statistics

### DIFF
--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -102,11 +102,27 @@ export class AwesomePlugin implements Plugin {
       }),
     );
 
+    const trsByEnvId = new Map<string, typeof allTrs>();
+
+    for (const tr of allTrs) {
+      const environmentId = envIdByTrId.get(tr.id);
+
+      if (!environmentId) {
+        continue;
+      }
+
+      const group = trsByEnvId.get(environmentId);
+
+      if (group) {
+        group.push(tr);
+      } else {
+        trsByEnvId.set(environmentId, [tr]);
+      }
+    }
+
     await Promise.all(
       environments.map(async ({ id }) => {
-        const envTrs = await store.testResultsByEnvironmentId(id, { includeRetries: true });
-
-        envStatistics.set(id, await statisticByTestResults(store, envTrs));
+        envStatistics.set(id, await statisticByTestResults(store, trsByEnvId.get(id) ?? []));
       }),
     );
 


### PR DESCRIPTION
## Summary
- Per-environment statistics (`statsByEnv` in `widgets/statistic.json` and `widgets/<env>/statistic.json`) were computed via `store.testResultsByEnvironmentId`, which has no `filter` parameter, while the global statistic used `store.testsStatistic(filter)`.
- When a `filter` option is configured for the awesome plugin, tests excluded from the global statistic still showed up in the per-environment breakdown, so per-env totals didn't match the overall report.
- Fix: reuse the already-filtered `allTrs` list (already fetched with the plugin's `filter`) and group it by environment locally instead of re-querying the store without the filter.