### PR TITLE
fix(core): stop clearing retry ingest order between merged dumps

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -728,7 +728,12 @@ export class AllureReport {
     await rename(dumpTempPath, dumpPath);
   };
 
-  restoreState = async (dumps: string[]): Promise<void> =>
+  restoreState = async (dumps: string[]): Promise<void> => {
+    this.#store.resetIngestOrder();
+    await this.#restoreStateDumps(dumps);
+  };
+
+  #restoreStateDumps = async (dumps: string[]): Promise<void> =>
     measurePerf(PERF_METRIC_NAMES.restoreStateTotal, async () => {
       for (const dump of dumps) {
         await measurePerf(PERF_METRIC_NAMES.restoreStateDump, async () => {
@@ -779,7 +784,7 @@ export class AllureReport {
                     nestedDumpPaths.push(nestedDumpPath);
                   }
 
-                  await this.restoreState(nestedDumpPaths);
+                  await this.#restoreStateDumps(nestedDumpPaths);
                   return;
                 }
               }

--- a/packages/core/src/store/retrySubstore.ts
+++ b/packages/core/src/store/retrySubstore.ts
@@ -41,9 +41,11 @@ export class RetrySubstore {
     this.#testResultIngestIndexById.set(testResultId, this.#testResultIngestIndexById.size);
   }
 
-  restoreIngestOrder(restoredIds: string[] | undefined, hasTestResult: (testResultId: string) => boolean) {
+  resetIngestOrder() {
     this.#testResultIngestIndexById.clear();
+  }
 
+  restoreIngestOrder(restoredIds: string[] | undefined, hasTestResult: (testResultId: string) => boolean) {
     for (const id of restoredIds ?? []) {
       if (!hasTestResult(id) || this.#testResultIngestIndexById.has(id)) {
         continue;

--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -1150,6 +1150,10 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
     return this.#retriesByTr(tr);
   }
 
+  resetIngestOrder() {
+    this.#retrySubstore.resetIngestOrder();
+  }
+
   #historyByTr(tr: TestResult): HistoryTestResult[] | undefined {
     if (!this.#history) {
       return undefined;

--- a/packages/core/test/report.dumpRestore.test.ts
+++ b/packages/core/test/report.dumpRestore.test.ts
@@ -648,6 +648,68 @@ describe("AllureReport.restoreState (dump zip)", () => {
       await archive.close();
     }
   });
+
+  it("keeps ingest order across multiple dumps when resolving which retry attempt is primary", async () => {
+    const makeTr = (id: string, status: "passed" | "failed", testCaseId: string) => ({
+      id,
+      name: "flaky test",
+      status,
+      flaky: false,
+      muted: false,
+      known: false,
+      isRetry: false,
+      labels: [],
+      parameters: [],
+      links: [],
+      steps: [],
+      sourceMetadata: { readerId: "system", metadata: {} },
+      testCase: { id: testCaseId },
+    });
+    const firstAttempt = makeTr("yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy", "failed", "tc-shared");
+    const secondAttempt = makeTr("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "passed", "tc-shared");
+    const unrelated = makeTr("wwwwwwww-wwww-wwww-wwww-wwwwwwwwwwww", "passed", "tc-unrelated");
+
+    const flakyDumpPath = tempZipPath();
+    const unrelatedDumpPath = tempZipPath();
+
+    // firstAttempt is ingested (and listed) before secondAttempt within the same dump,
+    // so secondAttempt is the later/primary attempt and firstAttempt is its retry.
+    await writeDumpZip(flakyDumpPath, [], {
+      [AllureStoreDumpFiles.TestResults]: JSON.stringify({
+        [firstAttempt.id]: firstAttempt,
+        [secondAttempt.id]: secondAttempt,
+      }),
+      [AllureStoreDumpFiles.TestResultIngestOrder]: JSON.stringify([firstAttempt.id, secondAttempt.id]),
+    });
+    await writeDumpZip(unrelatedDumpPath, [], {
+      [AllureStoreDumpFiles.TestResults]: JSON.stringify({
+        [unrelated.id]: unrelated,
+      }),
+      [AllureStoreDumpFiles.TestResultIngestOrder]: JSON.stringify([unrelated.id]),
+    });
+
+    const config = await resolveConfig({ name: "Allure Report" });
+    const report = new AllureReport(config);
+
+    await step("restore the flaky-test dump followed by an unrelated dump", async () => {
+      await report.restoreState([flakyDumpPath, unrelatedDumpPath]);
+    });
+
+    await step("secondAttempt (ingested later) stays primary regardless of the later unrelated dump", async () => {
+      const allTrs = await report.store.allTestResults({ includeRetries: true });
+      const primary = allTrs.find((tr) => tr.id === secondAttempt.id)!;
+      const retry = allTrs.find((tr) => tr.id === firstAttempt.id)!;
+
+      expect(primary.isRetry).toBe(false);
+      expect(retry.isRetry).toBe(true);
+      await expect(report.store.retriesByTr(primary)).resolves.toEqual([expect.objectContaining({ id: retry.id })]);
+
+      const statistic = await report.store.testsStatistic();
+
+      expect(statistic).toEqual(expect.objectContaining({ passed: 2, retries: 1 }));
+      expect(statistic.failed).toBeUndefined();
+    });
+  });
 });
 
 describe("AllureReport.restoreState (zip path validation layers)", () => {

--- a/packages/core/test/store/retrySubstore.test.ts
+++ b/packages/core/test/store/retrySubstore.test.ts
@@ -297,13 +297,25 @@ describe("RetrySubstore", () => {
       expect(rs.ingestOrderIdsForDump()).toEqual([second.id, first.id]);
     });
 
-    it("clears ingest order on restore", () => {
+    it("resetIngestOrder clears recorded ingest order", () => {
       const rs = new RetrySubstore();
 
       rs.recordIngestOrder("a");
-      rs.restoreIngestOrder([], () => true);
+      rs.resetIngestOrder();
 
       expect(rs.ingestOrderIdsForDump()).toEqual([]);
+    });
+
+    it("accumulates ingest order across multiple restoreIngestOrder calls", () => {
+      const rs = new RetrySubstore();
+      const first = makeTr("first");
+      const second = makeTr("second");
+      const third = makeTr("third");
+
+      rs.restoreIngestOrder([first.id], () => true);
+      rs.restoreIngestOrder([second.id, third.id], () => true);
+
+      expect(rs.ingestOrderIdsForDump()).toEqual([first.id, second.id, third.id]);
     });
 
     it("keeps ingest order across retry substore reset", () => {


### PR DESCRIPTION
## Summary
- `RetrySubstore.restoreIngestOrder` cleared the whole ingest-order index on every call. `AllureReport.restoreState` calls `store.restoreState` once per dump in a loop (e.g. when merging dumps from sharded/parallel test runs via `--dump`), so after restoring N dumps only the *last* dump's test result ids kept a known ingest index — every earlier dump's ids fell back to index `-1`.
- For retry attempts that share a `retryHash` and have no (or equal) `start` timestamp, `RetrySubstore.#compareResults` breaks ties using that ingest index. With the index wiped for all but the last-restored dump, which attempt ends up "primary" (the one whose status is actually counted in `stats.passed/failed/...`) could depend on which unrelated dump happened to be restored afterward, rather than the real order in which the attempts were produced.
- Fix: split the "start fresh" and "merge this dump's order" responsibilities. `RetrySubstore` gets a separate `resetIngestOrder()`; `restoreIngestOrder` now only adds new ids without clearing existing ones. `AllureReport.restoreState` resets the ingest order once at the top-level call and delegates the per-dump loop (including the nested-archive recursion for dumps-of-dumps) to a private helper that no longer resets, so ingest order accumulates correctly across every dump in a single restore.
- Added a regression test (`report.dumpRestore.test.ts`) that restores two dumps — one holding two attempts of the same flaky test with no `start`, the other an unrelated dump — and asserts the later-ingested attempt stays primary (and its status is the one counted in `testsStatistic()`) regardless of the unrelated dump restored afterward. Verified this test fails without the fix and passes with it.