### PR TITLE
fix: rotate durations chart bottom axis labels

### DIFF
--- a/packages/web-components/src/components/Charts/DurationsChartWidget/index.tsx
+++ b/packages/web-components/src/components/Charts/DurationsChartWidget/index.tsx
@@ -120,6 +120,7 @@ export const DurationsChartWidget: FunctionalComponent<Props> = (props) => {
         }
         formatIndexBy={(arg) => i18n("tooltips.durationRange", { from: arg.from ?? 0, to: arg.to })}
         formatBottomTick={(_, item) => i18n("ticks.durationRange", { from: item.from ?? 0, to: item.to })}
+        bottomTickRotation={45}
         bottomTickSize={chartData.length > 4 ? 10 : 12}
         formatLegendValue={({ value }) => {
           // Don't show zero values in legend


### PR DESCRIPTION
## Summary
- Durations / Durations-by-layer histogram X-axis labels (`0s - 1s 206ms`, …) overlap when `bottomTickRotation` stays at the BarChart default `0`.
- Set `bottomTickRotation={45}` on `DurationsChartWidget`, matching StatusDynamics, DurationDynamics, StabilityDistribution, and other BarChart widgets.

## Test plan
- [ ] Generate an Awesome/Dashboard report with `type: "durations"` (`groupBy: "none"` and `groupBy: "layer"`)
- [ ] Confirm bottom tick labels are rotated and readable with 5 buckets
- [ ] Confirm tooltip still shows the full duration range via `formatIndexBy`

Made with [Cursor](https://cursor.com)