### PR TITLE
Fix classic report ignoring category rules with messageRegex/traceRegex

### DIFF
--- a/packages/plugin-classic/src/categories.ts
+++ b/packages/plugin-classic/src/categories.ts
@@ -29,13 +29,13 @@ export const matchCategories = (
 
 const categoryMatch = (
   category: ClassicCategory,
-  result: { statusMessage?: string; statusTrace?: string; status: TestStatus; flaky: boolean },
+  result: { message?: string; trace?: string; status: TestStatus; flaky: boolean },
 ): boolean => {
-  const { status, statusMessage, statusTrace, flaky } = result;
+  const { status, message, trace, flaky } = result;
   const matchesStatus =
     !category.matchedStatuses || category.matchedStatuses.length === 0 || category.matchedStatuses.includes(status);
-  const matchesMessage = match(category.messageRegex, statusMessage);
-  const matchesTrace = match(category.traceRegex, statusTrace);
+  const matchesMessage = match(category.messageRegex, message);
+  const matchesTrace = match(category.traceRegex, trace);
   const matchesFlaky = (category.flaky ?? flaky) === flaky;
   return matchesStatus && matchesMessage && matchesTrace && matchesFlaky;
 };

--- a/packages/plugin-classic/test/categories.test.ts
+++ b/packages/plugin-classic/test/categories.test.ts
@@ -38,7 +38,7 @@ describe("categories", () => {
       ],
       {
         status: "failed",
-        statusMessage: "hello here the result with some message and more",
+        message: "hello here the result with some message and more",
         flaky: false,
       },
     );
@@ -56,7 +56,7 @@ describe("categories", () => {
       ],
       {
         status: "failed",
-        statusMessage: "hello\n   here the result\nwith some message and\nmore\n",
+        message: "hello\n   here the result\nwith some message and\nmore\n",
         flaky: false,
       },
     );
@@ -74,7 +74,7 @@ describe("categories", () => {
       ],
       {
         status: "failed",
-        statusTrace: "hello here the result with some message and more",
+        trace: "hello here the result with some message and more",
         flaky: false,
       },
     );
@@ -92,12 +92,22 @@ describe("categories", () => {
       ],
       {
         status: "failed",
-        statusTrace: "hello\n   here the result\nwith some message and\nmore\n",
+        trace: "hello\n   here the result\nwith some message and\nmore\n",
         flaky: false,
       },
     );
     expect(matched).to.have.lengthOf(2, "should match provided category");
     expect(matched[0]).to.have.property("name", "some message category");
     expect(matched[1]).to.have.property("name", "all matched category");
+  });
+  it("should match by message using the generators.ts call shape (regression)", () => {
+    const matched = matchCategories([{ name: "network failure category", messageRegex: ".*connection refused.*" }], {
+      message: "Error: connect ECONNREFUSED 127.0.0.1:8080 (connection refused)",
+      trace: "at Object.connect (net.js:100:10)",
+      status: "failed",
+      flaky: false,
+    });
+    expect(matched).to.have.lengthOf(1, "should match category by messageRegex");
+    expect(matched[0]).to.have.property("name", "network failure category");
   });
 });


### PR DESCRIPTION
### Context

`categories.json` rules with `messageRegex` or `traceRegex` never match any
test result in the classic report — only status-only rules (including the
built-in "Product defects" / "Test defects" fallbacks) do. For example:

```json
{ "name": "Timeout", "matchedStatuses": ["failed"], "messageRegex": ".*timed out.*" }
```

A failing test whose message contains "timed out" still lands under
"Product defects" instead of "Timeout" — with no warning that the rule was
never even evaluated correctly.

**Root cause**: `generators.ts` builds the match input as `{message, trace,
status, flaky}`, but `categoryMatch` in `categories.ts` destructures
`statusMessage`/`statusTrace` from it. The names never matched, so those
fields were always `undefined`, and `match()` treats `undefined` as a
non-match whenever a regex is set.

`message`/`trace` is the correct naming for this plugin: `ClassicTestResult`
is built on `@allurereport/core-api`'s `TestResult`, whose error info is a
`TestError` (`{message, trace, actual, expected}`), and `generators.ts`
passes `error?.message`/`error?.trace` straight through under those same
keys.

`statusMessage`/`statusTrace` isn't a typo — it's the sibling plugin
`plugin-allure2`'s field name. `plugin-allure2/src/categories.ts` has
identical matching logic, but that plugin's own data model
(`Allure2TestResult`) defines `statusMessage`/`statusTrace` directly, and
its caller passes those same keys — so that plugin isn't affected by this
bug. The two `categories.ts` files are close enough to be evidently related
implementations; this one ended up carrying the other model's field names.

**Fix**: destructure `message`/`trace` in `categoryMatch`, matching both
the caller and the underlying `TestError` type. Added a regression test
using the exact call shape `generators.ts` uses; also fixed 4 existing
tests that were unintentionally exercising a call shape the real caller
never uses.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
