### PR TITLE
Add loaders for report data loading

### DIFF
--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -64,18 +64,72 @@ import type { AwesomeDataWriter, ReportFile } from "./writer.js";
 
 const require = createRequire(import.meta.url);
 
+const appLoader = `
+    <style>
+      .allure-app-loader {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        background: #f7f8fb;
+        color: #22252a;
+        font: 14px/20px Arial, Helvetica, sans-serif;
+      }
+
+      .allure-app-loader__spinner {
+        width: 32px;
+        height: 32px;
+        border: 3px solid rgba(34, 37, 42, 0.16);
+        border-bottom-color: #3d7eff;
+        border-radius: 50%;
+        animation: allure-app-loader-spin 0.7s linear infinite;
+      }
+
+      .allure-app-loader__text {
+        margin: 0;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .allure-app-loader {
+          background: #1c1c1e;
+          color: #e5e5e7;
+        }
+
+        .allure-app-loader__spinner {
+          border-color: rgba(229, 229, 231, 0.2);
+          border-bottom-color: #8ab4ff;
+        }
+      }
+
+      @keyframes allure-app-loader-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+`;
+
 const template = `<!DOCTYPE html>
 <html dir="ltr" lang="en">
 <head>
     <meta charset="utf-8">
     <title> {{ reportName }} </title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg width='32' height='32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M22.232 4.662a3.6 3.6 0 0 1 5.09.035c2.855 2.894 4.662 6.885 4.662 11.295a3.6 3.6 0 0 1-7.2 0c0-2.406-.981-4.61-2.587-6.24a3.6 3.6 0 0 1 .035-5.09Z' fill='url(%23a)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.392 3.6a3.6 3.6 0 0 1 3.6-3.6c4.41 0 8.401 1.807 11.296 4.662a3.6 3.6 0 1 1-5.056 5.126C20.602 8.18 18.398 7.2 15.992 7.2a3.6 3.6 0 0 1-3.6-3.6Z' fill='url(%23b)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M0 15.992C0 7.157 7.157 0 15.992 0a3.6 3.6 0 0 1 0 7.2A8.789 8.789 0 0 0 7.2 15.992c0 2.406.981 4.61 2.588 6.24a3.6 3.6 0 0 1-5.126 5.056C1.807 24.393 0 20.402 0 15.992Z' fill='url(%23c)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M4.661 22.232a3.6 3.6 0 0 1 5.091-.035c1.63 1.606 3.834 2.587 6.24 2.587a3.6 3.6 0 0 1 0 7.2c-4.41 0-8.401-1.807-11.295-4.661a3.6 3.6 0 0 1-.036-5.091Z' fill='url(%23d)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M28.384 12.392a3.6 3.6 0 0 1 3.6 3.6c0 8.835-7.157 15.992-15.992 15.992a3.6 3.6 0 0 1 0-7.2 8.789 8.789 0 0 0 8.792-8.792 3.6 3.6 0 0 1 3.6-3.6Z' fill='url(%23e)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M28.385 12.392a3.6 3.6 0 0 1 3.6 3.6v12.392a3.6 3.6 0 0 1-7.2 0V15.992a3.6 3.6 0 0 1 3.6-3.6Z' fill='url(%23f)'/%3E%3Cg clip-path='url(%23g)'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M22.232 4.662a3.6 3.6 0 0 1 5.091.035c2.855 2.894 4.662 6.885 4.662 11.295a3.6 3.6 0 0 1-7.2 0c0-2.406-.982-4.61-2.588-6.24a3.6 3.6 0 0 1 .035-5.09Z' fill='url(%23h)'/%3E%3C/g%3E%3Cdefs%3E%3ClinearGradient id='a' x1='26.4' y1='9.6' x2='28.8' y2='15' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237E22CE'/%3E%3Cstop offset='1' stop-color='%238B5CF6'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='26.8' y1='9.4' x2='17.8' y2='3.6' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23EF4444'/%3E%3Cstop offset='1' stop-color='%23DC2626'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='3.6' y1='14' x2='5.4' y2='24.8' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%2322C55E'/%3E%3Cstop offset='1' stop-color='%2315803D'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='4.8' y1='22.2' x2='14.4' y2='29.2' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%2394A3B8'/%3E%3Cstop offset='.958' stop-color='%2364748B'/%3E%3Cstop offset='1' stop-color='%2364748B'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='28.4' y1='22.173' x2='22.188' y2='28.384' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23D97706'/%3E%3Cstop offset='1' stop-color='%23FBBF24'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='29.2' y1='54.4' x2='30.626' y2='54.256' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23FBBF24'/%3E%3Cstop offset='1' stop-color='%23FBBF24'/%3E%3C/linearGradient%3E%3ClinearGradient id='h' x1='26.4' y1='9.6' x2='28.8' y2='15' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237E22CE'/%3E%3Cstop offset='1' stop-color='%238B5CF6'/%3E%3C/linearGradient%3E%3CclipPath id='g'%3E%3Cpath fill='%23fff' transform='translate(24.8 12)' d='M0 0h7.2v8H0z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E" />
+    ${appLoader}
     {{{ headTags }}}
     <script>
       window.allureReportOptions = {{{ reportOptions }}}
     </script>
 </head>
 <body>
+    <div id="allure-app-loader" class="allure-app-loader" role="status" aria-live="polite">
+      <div class="allure-app-loader__spinner" aria-hidden="true"></div>
+      <p class="allure-app-loader__text">Loading report...</p>
+    </div>
     <div id="app"></div>
     ${createBaseUrlScript()}
     <script>

--- a/packages/web-awesome/src/components/BaseLayout/index.tsx
+++ b/packages/web-awesome/src/components/BaseLayout/index.tsx
@@ -2,6 +2,7 @@ import { Loadable, PageLoader } from "@allurereport/web-components";
 
 import MainReport from "@/components/MainReport";
 import TestResult from "@/components/TestResult";
+import { TestResultLoader } from "@/components/TestResultLoader";
 import { focusTestResultPane, focusTreePane } from "@/stores/keyboard";
 import { rootTabRoute, testResultRoute } from "@/stores/router";
 import { testResultStore } from "@/stores/testResults";
@@ -30,7 +31,11 @@ export const BaseLayout = () => {
       >
         <Loadable
           source={testResultStore}
-          renderLoader={() => <PageLoader />}
+          renderLoader={() => (
+            <div className={styles.wrapper}>
+              <TestResultLoader />
+            </div>
+          )}
           transformData={(data) => data[testResultId]}
           renderData={(testResult) => (
             <>

--- a/packages/web-awesome/src/components/BaseLayout/styles.scss
+++ b/packages/web-awesome/src/components/BaseLayout/styles.scss
@@ -5,6 +5,7 @@
   color: var(--color-text-primary);
   font-size: 14px;
   height: 100%;
+  min-height: 0;
   overflow: auto;
   scrollbar-width: thin;
 }

--- a/packages/web-awesome/src/components/SplitLayout/index.tsx
+++ b/packages/web-awesome/src/components/SplitLayout/index.tsx
@@ -6,6 +6,7 @@ import { useMemo, useRef } from "preact/hooks";
 import MainReport from "@/components/MainReport";
 import SideBySide from "@/components/SideBySide";
 import TestResult from "@/components/TestResult";
+import { TestResultLoader } from "@/components/TestResultLoader";
 import { useI18n } from "@/stores";
 import { isSplitMode } from "@/stores/layout";
 import { rootTabRoute, testResultRoute } from "@/stores/router";
@@ -21,14 +22,6 @@ const MainReportWrapper = () => {
   return (
     <div className={styles.wrapper} ref={containerRef} data-tree-scroll-container>
       <MainReport />
-    </div>
-  );
-};
-
-const Loader = () => {
-  return (
-    <div className={styles.content}>
-      <PageLoader />
     </div>
   );
 };
@@ -50,14 +43,14 @@ export const SplitLayout = () => {
     return isTestResultRoute.value ? (
       <Loadable
         source={testResultStore}
-        renderLoader={() => <Loader />}
+        renderLoader={() => <TestResultLoader />}
         transformData={(allResults) => {
           if (testResultId in allResults) {
             return allResults[testResultId];
           }
         }}
         renderData={(tr) => {
-          return tr ? <TestResult testResult={tr} /> : <Loader />;
+          return tr ? <TestResult testResult={tr} /> : <TestResultLoader />;
         }}
       />
     ) : (

--- a/packages/web-awesome/src/components/TestResultLoader/index.tsx
+++ b/packages/web-awesome/src/components/TestResultLoader/index.tsx
@@ -1,0 +1,9 @@
+import { PageLoader } from "@allurereport/web-components";
+
+import * as styles from "./styles.scss";
+
+export const TestResultLoader = () => (
+  <div className={styles["test-result-loader"]}>
+    <PageLoader />
+  </div>
+);

--- a/packages/web-awesome/src/components/TestResultLoader/styles.scss
+++ b/packages/web-awesome/src/components/TestResultLoader/styles.scss
@@ -1,0 +1,11 @@
+.test-result-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  border-radius: 12px;
+  background: var(--color-bg-primary);
+  box-shadow: var(--shadow-small);
+}

--- a/packages/web-awesome/src/index.html
+++ b/packages/web-awesome/src/index.html
@@ -3,6 +3,52 @@
   <head>
     <title>Allure Awesome</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg width='32' height='32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M22.232 4.662a3.6 3.6 0 0 1 5.09.035c2.855 2.894 4.662 6.885 4.662 11.295a3.6 3.6 0 0 1-7.2 0c0-2.406-.981-4.61-2.587-6.24a3.6 3.6 0 0 1 .035-5.09Z' fill='url(%23a)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.392 3.6a3.6 3.6 0 0 1 3.6-3.6c4.41 0 8.401 1.807 11.296 4.662a3.6 3.6 0 1 1-5.056 5.126C20.602 8.18 18.398 7.2 15.992 7.2a3.6 3.6 0 0 1-3.6-3.6Z' fill='url(%23b)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M0 15.992C0 7.157 7.157 0 15.992 0a3.6 3.6 0 0 1 0 7.2A8.789 8.789 0 0 0 7.2 15.992c0 2.406.981 4.61 2.588 6.24a3.6 3.6 0 0 1-5.126 5.056C1.807 24.393 0 20.402 0 15.992Z' fill='url(%23c)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M4.661 22.232a3.6 3.6 0 0 1 5.091-.035c1.63 1.606 3.834 2.587 6.24 2.587a3.6 3.6 0 0 1 0 7.2c-4.41 0-8.401-1.807-11.295-4.661a3.6 3.6 0 0 1-.036-5.091Z' fill='url(%23d)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M28.384 12.392a3.6 3.6 0 0 1 3.6 3.6c0 8.835-7.157 15.992-15.992 15.992a3.6 3.6 0 0 1 0-7.2 8.789 8.789 0 0 0 8.792-8.792 3.6 3.6 0 0 1 3.6-3.6Z' fill='url(%23e)'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M28.385 12.392a3.6 3.6 0 0 1 3.6 3.6v12.392a3.6 3.6 0 0 1-7.2 0V15.992a3.6 3.6 0 0 1 3.6-3.6Z' fill='url(%23f)'/%3E%3Cg clip-path='url(%23g)'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M22.232 4.662a3.6 3.6 0 0 1 5.091.035c2.855 2.894 4.662 6.885 4.662 11.295a3.6 3.6 0 0 1-7.2 0c0-2.406-.982-4.61-2.588-6.24a3.6 3.6 0 0 1 .035-5.09Z' fill='url(%23h)'/%3E%3C/g%3E%3Cdefs%3E%3ClinearGradient id='a' x1='26.4' y1='9.6' x2='28.8' y2='15' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237E22CE'/%3E%3Cstop offset='1' stop-color='%238B5CF6'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='26.8' y1='9.4' x2='17.8' y2='3.6' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23EF4444'/%3E%3Cstop offset='1' stop-color='%23DC2626'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='3.6' y1='14' x2='5.4' y2='24.8' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%2322C55E'/%3E%3Cstop offset='1' stop-color='%2315803D'/%3E%3C/linearGradient%3E%3ClinearGradient id='d' x1='4.8' y1='22.2' x2='14.4' y2='29.2' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%2394A3B8'/%3E%3Cstop offset='.958' stop-color='%2364748B'/%3E%3Cstop offset='1' stop-color='%2364748B'/%3E%3C/linearGradient%3E%3ClinearGradient id='e' x1='28.4' y1='22.173' x2='22.188' y2='28.384' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23D97706'/%3E%3Cstop offset='1' stop-color='%23FBBF24'/%3E%3C/linearGradient%3E%3ClinearGradient id='f' x1='29.2' y1='54.4' x2='30.626' y2='54.256' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%23FBBF24'/%3E%3Cstop offset='1' stop-color='%23FBBF24'/%3E%3C/linearGradient%3E%3ClinearGradient id='h' x1='26.4' y1='9.6' x2='28.8' y2='15' gradientUnits='userSpaceOnUse'%3E%3Cstop stop-color='%237E22CE'/%3E%3Cstop offset='1' stop-color='%238B5CF6'/%3E%3C/linearGradient%3E%3CclipPath id='g'%3E%3Cpath fill='%23fff' transform='translate(24.8 12)' d='M0 0h7.2v8H0z'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E" />
+    <style>
+      .allure-app-loader {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483647;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        background: #f7f8fb;
+        color: #22252a;
+        font: 14px/20px Arial, Helvetica, sans-serif;
+      }
+
+      .allure-app-loader__spinner {
+        width: 32px;
+        height: 32px;
+        border: 3px solid rgba(34, 37, 42, 0.16);
+        border-bottom-color: #3d7eff;
+        border-radius: 50%;
+        animation: allure-app-loader-spin 0.7s linear infinite;
+      }
+
+      .allure-app-loader__text {
+        margin: 0;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .allure-app-loader {
+          background: #1c1c1e;
+          color: #e5e5e7;
+        }
+
+        .allure-app-loader__spinner {
+          border-color: rgba(229, 229, 231, 0.2);
+          border-bottom-color: #8ab4ff;
+        }
+      }
+
+      @keyframes allure-app-loader-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
     <script>
       (function () {
         const base = document.createElement("base");
@@ -39,6 +85,10 @@
     </script>
   </head>
   <body>
+    <div id="allure-app-loader" class="allure-app-loader" role="status" aria-live="polite">
+      <div class="allure-app-loader__spinner" aria-hidden="true"></div>
+      <p class="allure-app-loader__text">Loading report...</p>
+    </div>
     <div id="app"></div>
     <script>
       window.allure = window.allure || {};

--- a/packages/web-awesome/src/index.tsx
+++ b/packages/web-awesome/src/index.tsx
@@ -47,6 +47,10 @@ const isTestResultRoute = computed(
   () => testResultRoute.value.matches || Boolean(rootTabRoute.value.params.testResultId),
 );
 
+const removeInitialLoader = () => {
+  document.getElementById("allure-app-loader")?.remove();
+};
+
 const App = () => {
   const className = styles[`layout-${currentSection.value !== "default" ? currentSection.value : layoutStore.value}`];
   const [prefetched, setPrefetched] = useState(false);
@@ -86,6 +90,12 @@ const App = () => {
   useEffect(() => {
     prefetchData();
   }, []);
+
+  useEffect(() => {
+    if (prefetched) {
+      removeInitialLoader();
+    }
+  }, [prefetched]);
 
   useSignalEffect(() => {
     const envId = currentEnvironment.value;


### PR DESCRIPTION
## Summary
- add an inline startup loader to Awesome report HTML so both single-file and multi-file reports show progress while assets and report data are loading
- remove the startup loader after the Awesome app finishes its initial data prefetch
- reuse a consistent test result loader in base and split layouts

## Validation
- yarn workspace @allurereport/plugin-awesome build
- yarn workspace @allurereport/web-awesome build
- yarn allure agent --report off --goal "Validate awesome report HTML loader template changes" -- yarn workspace @allurereport/plugin-awesome test
- yarn allure agent --report off --goal "Validate web-awesome loader layout changes" -- yarn workspace @allurereport/web-awesome test
- yarn workspace @allurereport/plugin-awesome lint
- yarn workspace @allurereport/web-awesome lint

Notes: webpack reported existing bundle-size warnings during web-awesome build. Lint exits successfully but reports existing warnings in unrelated files.