### PR TITLE
fix(awesome): show the selected environment's launch interval in the report header

### DIFF
--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -634,6 +634,7 @@ export const generateStaticFiles = async (
     reportName: string;
     executor?: AwesomeExecutorInfo;
     runSummary?: AwesomeRunSummary;
+    runSummaryByEnv?: Record<string, AwesomeRunSummary>;
   },
 ) => {
   const {
@@ -653,6 +654,7 @@ export const generateStaticFiles = async (
     ci,
     executor,
     runSummary,
+    runSummaryByEnv,
     stepTreeExpansion,
     defaultSortBy,
   } = payload;
@@ -715,6 +717,7 @@ export const generateStaticFiles = async (
     ci,
     executor,
     runSummary,
+    runSummaryByEnv,
     layout,
     allureVersion,
     sections,

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -7,7 +7,7 @@ import {
   createPluginSummary,
 } from "@allurereport/plugin-api";
 import { preciseTreeLabels } from "@allurereport/plugin-api";
-import type { AwesomeExecutorInfo } from "@allurereport/web-awesome";
+import type { AwesomeExecutorInfo, AwesomeRunSummary } from "@allurereport/web-awesome";
 
 import { applyCategoriesToTestResults, generateCategories } from "./categories.js";
 import { generateTimeline } from "./generateTimeline.js";
@@ -126,6 +126,16 @@ export class AwesomePlugin implements Plugin {
       }),
     );
 
+    const runSummaryByEnv: Record<string, AwesomeRunSummary> = {};
+
+    for (const { id } of environments) {
+      const envRunSummary = getRunSummary(trsByEnvId.get(id) ?? []);
+
+      if (envRunSummary) {
+        runSummaryByEnv[id] = envRunSummary;
+      }
+    }
+
     await generateStatistic(this.#writer!, {
       stats: statistics,
       statsByEnv: envStatistics,
@@ -219,6 +229,7 @@ export class AwesomePlugin implements Plugin {
       ci: context.ci,
       executor,
       runSummary,
+      runSummaryByEnv,
       reportDataFiles,
     });
   };

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -753,20 +753,32 @@ describe("plugin", () => {
   });
 
   describe("report assets", () => {
+    const environmentIdOf = (tr: TestResult) => tr.environment ?? "default";
+
     const makeSingleFileStore = (testResults: TestResult[], metadata: Record<string, unknown> = {}): AllureStore =>
       ({
         metadataByKey: vi.fn(async (key: string) => metadata[key]),
-        allEnvironments: vi.fn().mockResolvedValue(["default"]),
-        allEnvironmentIdentities: vi
-          .fn()
-          .mockResolvedValue([{ id: "default", name: "default" } satisfies EnvironmentIdentity]),
+        allEnvironments: vi.fn(async () => [...new Set(testResults.map(environmentIdOf))]),
+        allEnvironmentIdentities: vi.fn(
+          async () =>
+            [...new Set(testResults.map(environmentIdOf))].map((id) => ({
+              id,
+              name: id,
+            })) satisfies EnvironmentIdentity[],
+        ),
         allAttachments: vi.fn().mockResolvedValue([]),
         allTestResults: vi.fn(async (options?: { includeRetries?: boolean; filter?: (tr: TestResult) => boolean }) => {
           const trs = options?.filter ? testResults.filter(options.filter) : testResults;
           return trs;
         }),
-        testResultsByEnvironmentId: vi.fn().mockResolvedValue(testResults),
-        environmentIdByTrId: vi.fn().mockResolvedValue("default"),
+        testResultsByEnvironmentId: vi.fn(async (envId: string) =>
+          testResults.filter((tr) => environmentIdOf(tr) === envId),
+        ),
+        environmentIdByTrId: vi.fn(async (trId: string) => {
+          const tr = testResults.find(({ id }) => id === trId);
+
+          return tr ? environmentIdOf(tr) : undefined;
+        }),
         testsStatistic: vi.fn(async (filter: (tr: TestResult) => boolean) => getTestResultsStats(testResults, filter)),
         allTestEnvGroups: vi.fn().mockResolvedValue([]),
         allGlobalAttachments: vi.fn().mockResolvedValue([]),
@@ -985,6 +997,59 @@ describe("plugin", () => {
         duration: 2000,
       });
       expect(reportOptions.executor).toEqual(executor);
+    });
+
+    it("should include a separate launch interval for every environment", async () => {
+      const testResults: TestResult[] = [
+        {
+          id: "tr-staging",
+          name: "staging test",
+          status: "passed",
+          environment: "staging",
+          start: 1000,
+          stop: 3000,
+          labels: [],
+        },
+        {
+          id: "tr-staging-retry",
+          name: "staging test",
+          status: "failed",
+          environment: "staging",
+          isRetry: true,
+          start: 500,
+          stop: 900,
+          labels: [],
+        },
+        {
+          id: "tr-prod",
+          name: "prod test",
+          status: "passed",
+          environment: "prod",
+          start: 10_000,
+          stop: 12_500,
+          labels: [],
+        },
+      ] as unknown as TestResult[];
+      const addedFiles = new Map<string, Buffer>();
+      const reportFiles: ReportFiles = {
+        addFile: vi.fn(async (path: string, data: Buffer) => {
+          addedFiles.set(path, data);
+          return path;
+        }),
+      };
+      const plugin = new AwesomePlugin({ singleFile: true });
+
+      await plugin.start(makeSingleFileContext(reportFiles));
+      await plugin.done(makeSingleFileContext(reportFiles), makeSingleFileStore(testResults));
+
+      const reportOptions = extractReportOptions(addedFiles.get("index.html")?.toString("utf-8") ?? "");
+
+      // The report-wide summary still spans everything, the per-environment ones must not.
+      expect(reportOptions.runSummary).toEqual({ start: 500, stop: 12_500, duration: 12_000 });
+      expect(reportOptions.runSummaryByEnv).toEqual({
+        staging: { start: 500, stop: 3000, duration: 2500 },
+        prod: { start: 10_000, stop: 12_500, duration: 2500 },
+      });
     });
   });
 });

--- a/packages/web-awesome/src/components/ReportHeader/index.tsx
+++ b/packages/web-awesome/src/components/ReportHeader/index.tsx
@@ -7,6 +7,7 @@ import { ReportHeaderLogo } from "@/components/ReportHeader/ReportHeaderLogo";
 import { ReportHeaderPie } from "@/components/ReportHeader/ReportHeaderPie";
 import { TrStatus } from "@/components/TestResult/TrStatus";
 import { useI18n } from "@/stores";
+import { currentEnvironment } from "@/stores/env";
 import { globalsStore } from "@/stores/globals";
 import { timestampToDate } from "@/utils/time";
 
@@ -22,11 +23,15 @@ const reportDateOptions: Intl.DateTimeFormatOptions = {
 };
 
 export const ReportHeader = () => {
-  const { reportName, createdAt, runSummary } = getReportOptions<AwesomeReportOptions>() ?? {};
+  const { reportName, createdAt, runSummary, runSummaryByEnv } = getReportOptions<AwesomeReportOptions>() ?? {};
   const { t } = useI18n("ui");
+  const environmentId = currentEnvironment.value;
+  // With a single environment selected, show that environment's own launch interval instead of the
+  // report-wide one, which spans the earliest start and the latest stop across all environments.
+  const selectedRunSummary = environmentId ? runSummaryByEnv?.[environmentId] : runSummary;
   const formattedCreatedAt = timestampToDate(createdAt as number, reportDateOptions);
-  const formattedReportTime = runSummary
-    ? `${timestampToDate(runSummary.start, reportDateOptions)} (${formatDuration(runSummary.duration)})`
+  const formattedReportTime = selectedRunSummary
+    ? `${timestampToDate(selectedRunSummary.start, reportDateOptions)} (${formatDuration(selectedRunSummary.duration)})`
     : formattedCreatedAt;
 
   return (

--- a/packages/web-awesome/test/components/ReportHeader.test.tsx
+++ b/packages/web-awesome/test/components/ReportHeader.test.tsx
@@ -36,6 +36,10 @@ vi.mock("@/stores", () => ({
   }),
 }));
 
+const { currentEnvironment } = vi.hoisted(() => ({ currentEnvironment: { value: "" } }));
+
+vi.mock("@/stores/env", () => ({ currentEnvironment }));
+
 vi.mock("@/utils/time", () => ({
   timestampToDate: (value: number, options?: Intl.DateTimeFormatOptions) =>
     `${options?.month === "long" ? "long" : "default"}:${value}`,
@@ -43,6 +47,7 @@ vi.mock("@/utils/time", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  currentEnvironment.value = "";
 });
 
 describe("components > ReportHeader", () => {
@@ -73,5 +78,39 @@ describe("components > ReportHeader", () => {
     render(<ReportHeader />);
 
     expect(screen.getByTestId("report-data")).toHaveTextContent("long:10");
+  });
+
+  it("should render the selected environment's launch start time instead of the report-wide one", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      reportName: "Wrike report",
+      createdAt: 42,
+      runSummary: { start: 1000, stop: 12_500, duration: 11_500 },
+      runSummaryByEnv: {
+        staging: { start: 1000, stop: 3000, duration: 2000 },
+        prod: { start: 10_000, stop: 12_500, duration: 2500 },
+      },
+    });
+    currentEnvironment.value = "prod";
+
+    render(<ReportHeader />);
+
+    // "long:1000" (the report-wide start) is not a substring of the rendered "long:10000".
+    expect(screen.getByTestId("report-data")).toHaveTextContent("long:10000");
+  });
+
+  it("should fall back to generated time when the selected environment has no launch interval", () => {
+    (getReportOptions as Mock).mockReturnValue({
+      reportName: "Wrike report",
+      createdAt: 42,
+      runSummary: { start: 1000, stop: 12_500, duration: 11_500 },
+      runSummaryByEnv: {
+        staging: { start: 1000, stop: 3000, duration: 2000 },
+      },
+    });
+    currentEnvironment.value = "prod";
+
+    render(<ReportHeader />);
+
+    expect(screen.getByTestId("report-data")).toHaveTextContent("long:42");
   });
 });

--- a/packages/web-awesome/types.d.ts
+++ b/packages/web-awesome/types.d.ts
@@ -47,6 +47,7 @@ export type AwesomeReportOptions = {
   ci?: CiDescriptor;
   executor?: AwesomeExecutorInfo;
   runSummary?: AwesomeRunSummary;
+  runSummaryByEnv?: Record<string, AwesomeRunSummary>;
   stepTreeExpansion?: StepTreeExpansion;
   defaultSortBy?: string;
 };


### PR DESCRIPTION
### Context                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                               
  In a report with several environments, the header always showed the earliest test start                                                                                                                      
  across *all* environments, with a duration spanning the earliest start to the latest stop.                                                                                                                   
  The value did not match the environment selected in the picker and never changed on switch,                                                                                                                  
  because `runSummary` is computed once over all test results and read from the static                                                                                                                         
  `reportOptions`.                                                                                                                                                                                             
                                                                                                                                                                                                               
  This computes a run summary per environment from the `trsByEnvId` map that                                                                                                                                   
  `AwesomePlugin#generate` already builds (same place `envStatistics` is filled) and embeds it                                                                                                                 
  as `runSummaryByEnv` in the report options. `ReportHeader` reads `currentEnvironment` and                                                                                                                    
  picks the matching interval.                                                                                                                                                                                 
                                                                                                                                                                                                               
  Behaviour with two environments (foo: 2026-01-15, 1 min / bar: 2026-08-05, 5 s):                                                                                                                             
                                                                                                                                                                                                               
  | Selection | Before | After |                                                                                                                                                                               
  | --- | --- | --- |                                                                                                                                                                                          
  | All | `January 15, 2026 at 9:00:00 AM (202d 6h)` | unchanged |                                                                                                                                             
  | foo | `January 15, 2026 at 9:00:00 AM (202d 6h)` | `January 15, 2026 at 9:00:00 AM (1m 0s)` |                                                                                                              
  | bar | `January 15, 2026 at 9:00:00 AM (202d 6h)` | `August 5, 2026 at 4:00:00 PM (5s 0ms)` |                                                                                                               
                                                                                                                                                                                                               
  "All" keeps the report-wide summary, and an environment without usable timings still falls                                                                                                                   
  back to `createdAt`. The data lives in `reportOptions` rather than a separate widget file, so                                                                                                                
  the header updates immediately on environment switch without an extra fetch or loading state.    

The regression came in with 683d2343 (#673), which replaced the rendered `createdAt` with
`runSummary.start` + `formatDuration(runSummary.duration)`.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3