### PR TITLE
fix(directory-watcher): find allure-results in dot-prefixed dirs

### DIFF
--- a/packages/directory-watcher/src/watcher.ts
+++ b/packages/directory-watcher/src/watcher.ts
@@ -40,8 +40,10 @@ export const findMatching = async (
     for await (const dirent of dir) {
       const path = join(dirent.parentPath ?? dirent.path, dirent.name);
 
-      // shouldn't be looking in private folders
-      if (dirent.name.at(0) === "." || dirent.name === "node_modules") {
+      // .git and node_modules are always skipped: this watcher re-walks repeatedly on a
+      // short interval for the life of the run, unlike a one-off glob call, so recursing
+      // into them on every pass is wasteful.
+      if (dirent.name === ".git" || dirent.name === "node_modules") {
         continue;
       }
 

--- a/packages/directory-watcher/test/watcher.test.ts
+++ b/packages/directory-watcher/test/watcher.test.ts
@@ -423,6 +423,53 @@ describe("findMatching", () => {
 
     expect(result).does.not.contain(dir311);
   });
+
+  it("should find allure-results under a dot-prefixed ancestor directory", async () => {
+    const dotDir = await randomDirectory(fixturesDir, ".reports");
+    const allureResults = await randomDirectory(dotDir, "allure-results");
+    const file = await randomFile(allureResults);
+
+    const result = new Set<string>();
+    await findMatching(fixturesDir, result, (dirent) => dirent.isDirectory() && dirent.name === "allure-results");
+
+    expect(result).toHaveLength(1);
+    expect(result).toContain(allureResults);
+  });
+
+  it("should still skip node_modules and .git", async () => {
+    const nodeModulesDir = await randomDirectory(fixturesDir, "node_modules");
+    const allureResultsInNodeModules = await randomDirectory(nodeModulesDir, "allure-results");
+    await randomFile(allureResultsInNodeModules);
+
+    const gitDir = await randomDirectory(fixturesDir, ".git");
+    const allureResultsInGit = await randomDirectory(gitDir, "allure-results");
+    await randomFile(allureResultsInGit);
+
+    const dotDir = await randomDirectory(fixturesDir, ".reports");
+    const allureResults = await randomDirectory(dotDir, "allure-results");
+    await randomFile(allureResults);
+
+    const result = new Set<string>();
+    await findMatching(fixturesDir, result, (dirent) => dirent.isDirectory() && dirent.name === "allure-results");
+
+    expect(result).toHaveLength(1);
+    expect(result).toContain(allureResults);
+    expect(result).does.not.contain(allureResultsInNodeModules);
+    expect(result).does.not.contain(allureResultsInGit);
+  });
+
+  it("should find allure-results under nested dot-prefixed directories", async () => {
+    const dotDir1 = await randomDirectory(fixturesDir, ".a");
+    const dotDir2 = await randomDirectory(dotDir1, ".b");
+    const allureResults = await randomDirectory(dotDir2, "allure-results");
+    await randomFile(allureResults);
+
+    const result = new Set<string>();
+    await findMatching(fixturesDir, result, (dirent) => dirent.isDirectory() && dirent.name === "allure-results");
+
+    expect(result).toHaveLength(1);
+    expect(result).toContain(allureResults);
+  });
 });
 
 describe("difference", () => {


### PR DESCRIPTION
## Summary

- `findMatching` (used by `allure agent -- <cmd>` and `allure run -- <cmd>` to
  watch for `allure-results` directories while the test command runs)
  skipped every directory whose name starts with `.`. Results written under
  a dot-prefixed path, e.g. `.reports/allure-results/`, were silently
  missed, and the run was reported as `no tests` with a `no-tests-observed`
  finding.
- Other commands (`allure watch`, `allure agent inspect`, and the one-shot
  generators like `allure awesome`) resolve `allure-results` through a
  different, glob-based lookup that already passes `dot: true`, so they
  never had this problem.
- Fix: only skip `.git` and `node_modules` by name (both large, and never
  contain `allure-results`); stop skipping directories just for starting
  with `.`.

## Test plan

- `yarn vitest run` in `packages/directory-watcher` — 26/26 pass (new/
  updated cases: dot-prefixed discovery, `.git`/`node_modules` still
  skipped, nested dot-prefixed directories)
- `tsc --noEmit` — clean

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
