### PR TITLE
fix(core): ignore .tmp files when reading results directory

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -416,7 +416,7 @@ export class AllureReport {
 
       try {
         const entries = (await readdir(resultsDirPath, { withFileTypes: true }))
-          .filter((dirent) => dirent.isFile())
+          .filter((dirent) => dirent.isFile() && !dirent.name.endsWith(".tmp"))
           .sort((a, b) => a.name.localeCompare(b.name));
         const limit = pLimit(readConcurrency());
 

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -364,6 +364,36 @@ describe("report", () => {
     }
   });
 
+  it("should ignore .tmp files when reading result directory", async () => {
+    const resultsDir = await mkdtemp(join(tmpdir(), "allure3-read-directory-tmp-"));
+    const config = await resolveConfig({
+      name: "Allure Report",
+    });
+    const readFiles: string[] = [];
+    const reader: ResultsReader = {
+      matches: vi.fn().mockReturnValue(true),
+      read: vi.fn(async (_visitor, data) => {
+        readFiles.push(data.getOriginalFileName());
+
+        return true;
+      }),
+      readerId: () => "tmp-filter",
+    };
+
+    await writeFile(join(resultsDir, "result.json"), "{}");
+    await writeFile(join(resultsDir, "result.json.abc123.tmp"), "{}");
+
+    const allureReport = new AllureReport({
+      ...config,
+      readers: [reader],
+    });
+
+    await allureReport.start();
+    await allureReport.readDirectory(resultsDir);
+
+    expect(readFiles).toEqual(["result.json"]);
+  });
+
   it("should call plugins in specified order on start()", async () => {
     const p1 = createPlugin("p1");
     const p2 = createPlugin("p2");


### PR DESCRIPTION
## Summary
- readDirectory() now skips files ending in .tmp when scanning the results directory, so leftover/in-progress temp files aren't picked up as result files