### PR TITLE
fix(ci): Support Azure DevOps classic release pipeline links

### DIFF
--- a/packages/ci/src/detectors/azure.ts
+++ b/packages/ci/src/detectors/azure.ts
@@ -15,6 +15,8 @@ export const getDefinitionID = (): string => getEnv("SYSTEM_DEFINITIONID");
 
 export const getProjectID = (): string => getEnv("SYSTEM_TEAMPROJECTID");
 
+export const isClassicRelease = (): boolean => !!getEnv("RELEASE_RELEASEID");
+
 const mapAzureRepositoryProvider = (provider: string): GitProvider | undefined => {
   switch (provider) {
     case "GitHub":
@@ -90,18 +92,34 @@ export const azure: CiDescriptor = {
   },
 
   get jobName(): string {
+    if (isClassicRelease()) {
+      return getEnv("RELEASE_DEFINITIONNAME");
+    }
+
     return getEnv("BUILD_DEFINITIONNAME");
   },
 
   get jobRunUid(): string {
+    if (isClassicRelease()) {
+      return getEnv("RELEASE_RELEASEID");
+    }
+
     return getBuildID();
   },
 
   get jobRunUrl(): string {
+    if (isClassicRelease()) {
+      return getEnv("RELEASE_RELEASEWEBURL");
+    }
+
     return `${getRootURL()}/${getProjectID()}/_build/results?buildId=${getBuildID()}`;
   },
 
   get jobRunName(): string {
+    if (isClassicRelease()) {
+      return getEnv("RELEASE_RELEASENAME");
+    }
+
     return getEnv("BUILD_BUILDNUMBER");
   },
 

--- a/packages/ci/test/detectors/azure.test.ts
+++ b/packages/ci/test/detectors/azure.test.ts
@@ -1,7 +1,14 @@
 import { story } from "allure-js-commons";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
-import { azure, getBuildID, getDefinitionID, getProjectID, getRootURL } from "../../src/detectors/azure.js";
+import {
+  azure,
+  getBuildID,
+  getDefinitionID,
+  getProjectID,
+  getRootURL,
+  isClassicRelease,
+} from "../../src/detectors/azure.js";
 import { getEnv } from "../../src/utils.js";
 
 beforeEach(async () => {
@@ -397,6 +404,82 @@ describe("azure", () => {
       });
 
       expect(azure.pullRequestUrl).toBe("");
+    });
+  });
+
+  describe("isClassicRelease", () => {
+    it("should return true when RELEASE_RELEASEID is set", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "RELEASE_RELEASEID") {
+          return "42";
+        }
+      });
+
+      expect(isClassicRelease()).toBe(true);
+    });
+
+    it("should return false when RELEASE_RELEASEID is not set", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "RELEASE_RELEASEID") {
+          return "";
+        }
+      });
+
+      expect(isClassicRelease()).toBe(false);
+    });
+  });
+
+  describe("classic release pipeline", () => {
+    it("should use RELEASE_DEFINITIONNAME for jobName", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "RELEASE_RELEASEID") {
+          return "42";
+        }
+
+        if (key === "RELEASE_DEFINITIONNAME") {
+          return "My Release Definition";
+        }
+      });
+
+      expect(azure.jobName).toBe("My Release Definition");
+    });
+
+    it("should use RELEASE_RELEASEID for jobRunUid", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "RELEASE_RELEASEID") {
+          return "42";
+        }
+      });
+
+      expect(azure.jobRunUid).toBe("42");
+    });
+
+    it("should use RELEASE_RELEASEWEBURL for jobRunUrl", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "RELEASE_RELEASEID") {
+          return "42";
+        }
+
+        if (key === "RELEASE_RELEASEWEBURL") {
+          return "https://dev.azure.com/organization/project/_releaseProgress?releaseId=42";
+        }
+      });
+
+      expect(azure.jobRunUrl).toBe("https://dev.azure.com/organization/project/_releaseProgress?releaseId=42");
+    });
+
+    it("should use RELEASE_RELEASENAME for jobRunName", () => {
+      (getEnv as Mock).mockImplementation((key: string) => {
+        if (key === "RELEASE_RELEASEID") {
+          return "42";
+        }
+
+        if (key === "RELEASE_RELEASENAME") {
+          return "Release-42";
+        }
+      });
+
+      expect(azure.jobRunName).toBe("Release-42");
     });
   });
 });


### PR DESCRIPTION
### Context

The Azure DevOps CI detector produces broken report links when running inside [classic release pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/?view=azure-devops). 

<img width="229" height="42" alt="image" src="https://github.com/user-attachments/assets/e667c2fd-d93f-48a9-9320-5ec5e4111517" />

The detector reads SYSTEM_COLLECTIONURI and builds a URL from it, but in classic releases Azure DevOps sets that variable to the VSRM API endpoint (vsrm.dev.azure.com) rather than the portal host (dev.azure.com). Combined with SYSTEM_TEAMPROJECTID being a GUID instead of a project name, and the path being hardcoded to _build/results, the result is a link that goes nowhere:

```
https://vsrm.dev.azure.com/myorg//2c7640cb-dbdc-4d89-98e6-98a71042ec75/_build/results?buildId=50548
```

This PR works by checking for the existence of the `RELEASE_RELEASEID` environment variable and then uses all of the `RELEASE_*` env vars  documented [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/variables?view=azure-devops&tabs=batch#release-variables) for link generation instead. It will a produce a url following this pattern. 

`https://dev.azure.com/{org}/{project}/_release?releaseId={RELEASE_RELEASEID}&_a=release-summary`

| Env var | Getter | Used for |
|---|---|---|
| `RELEASE_RELEASEID` | `jobRunUid` | Unique run identifier for history tracking |
| `RELEASE_RELEASEWEBURL` | `jobRunUrl` | Clickable link to the release in Azure DevOps portal |
| `RELEASE_RELEASENAME` | `jobRunName` | Display text shown on the link in the report header |
| `RELEASE_DEFINITIONNAME` | `jobName` | Pipeline name label in the report |

Currently, Allure 3 already works with the modern YAML Build pipelines.  This backports working links into the older Classic Release style.  The switch to YAML Build pipelines happened [in 2019](https://devblogs.microsoft.com/devops/whats-new-with-azure-pipelines/).  I made sure to avoid regressing the link building of  the newer-style Build pipeline.  Newer style build behavior is unchanged because the RELEASE_* variables this fix uses do not exist outside of classic release stages.

Tested on cloud-hosted Azure DevOps Services; on-prem [Azure DevOps Server](https://azure.microsoft.com/en-us/products/devops/server) behavior _should_ be identical but is untested.   YMMV

Note:  In Azure DevOps, one classic release has multiple environments.  This link will take you to the release overview.  We can get users closer to the test results by building environment-level links, but I wanted to keep this first round very simple.   Thanks. 

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
