### PR TITLE
fix(web-awesome): honor failed-only expansion for top-level steps

### DIFF
--- a/packages/web-awesome/src/components/TestResult/TrSteps/TrBodyItems.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/TrBodyItems.tsx
@@ -20,18 +20,15 @@ const getBodyItemKey = (item: TrBodyItem, index: number) => {
 
 export type TrBodyItemsProps = {
   bodyItems: TrBodyItem[];
-  isTopLevel?: boolean;
 };
 
-export const TrBodyItems: FunctionalComponent<TrBodyItemsProps> = ({ bodyItems, isTopLevel }) => {
+export const TrBodyItems: FunctionalComponent<TrBodyItemsProps> = ({ bodyItems }) => {
   return (
     <>
       {bodyItems.map((item, index) => {
         switch (item.type) {
           case "step":
-            return (
-              <TrStep item={item} stepIndex={index + 1} isTopLevel={isTopLevel} key={getBodyItemKey(item, index)} />
-            );
+            return <TrStep item={item} stepIndex={index + 1} key={getBodyItemKey(item, index)} />;
           case "attachment":
             return <TrAttachment item={item} stepIndex={index + 1} key={getBodyItemKey(item, index)} />;
           case "error":

--- a/packages/web-awesome/src/components/TestResult/TrSteps/TrStep.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/TrStep.tsx
@@ -16,7 +16,6 @@ import {
   collectExpandableStepNodes,
   hasStepContent,
   getStepTreeExpansionPolicy,
-  isOpenByDefaultForPolicy,
   isStepOpenedByDefault,
   type SubtreeNode,
 } from "@/components/TestResult/TrSteps/stepTreeExpansion";
@@ -71,25 +70,11 @@ export const TrStepsContent = (props: { item: TrStepItem }) => {
 export const TrStep: FunctionComponent<{
   item: TrStepItem;
   stepIndex?: number;
-  isTopLevel?: boolean;
-}> = ({ item, stepIndex, isTopLevel }) => {
-  const { item: stepData, bodyItems, suppressInlineError } = item;
-  const inlineError = {
-    message: stepData.message ?? stepData.error?.message,
-    trace: stepData.trace ?? stepData.error?.trace,
-    actual: stepData.error?.actual,
-    expected: stepData.error?.expected,
-  };
-  const hasInlineError = Boolean(
-    (inlineError.message || inlineError.trace || hasErrorDiff(inlineError)) &&
-    !stepData.hasSimilarErrorInSubSteps &&
-    !suppressInlineError,
-  );
+}> = ({ item, stepIndex }) => {
+  const { item: stepData, bodyItems } = item;
   const policy = getStepTreeExpansionPolicy();
   const hasContent = hasStepContent(item);
-  const openedByDefault = isTopLevel
-    ? isOpenByDefaultForPolicy(policy, true)
-    : isStepOpenedByDefault(policy, stepData.status, bodyItems);
+  const openedByDefault = isStepOpenedByDefault(policy, stepData.status, bodyItems);
   const isOpened = isTreeOpened(stepData.stepId, openedByDefault);
   const expandableDescendantNodes = collectExpandableStepNodes(bodyItems, policy);
   const hasExpandableDescendants = expandableDescendantNodes.length > 0;

--- a/packages/web-awesome/src/components/TestResult/TrSteps/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSteps/index.tsx
@@ -121,7 +121,7 @@ export const TrSteps: FunctionalComponent<TrStepsProps> = ({ bodyItems, id }) =>
       />
       {isOpened && (
         <div data-testid="test-result-steps-root" className={styles["test-result-steps-root"]}>
-          <TrBodyItems bodyItems={bodyItems} isTopLevel={true} />
+          <TrBodyItems bodyItems={bodyItems} />
         </div>
       )}
     </div>

--- a/packages/web-awesome/test/components/TestResult/TrSteps.test.tsx
+++ b/packages/web-awesome/test/components/TestResult/TrSteps.test.tsx
@@ -67,6 +67,31 @@ const failedStepWithContent = {
   bodyItems: [nestedPassedStep],
 } satisfies TrBodyItem;
 
+const createTopLevelStep = (index: number, status: "passed" | "failed"): TrBodyItem => ({
+  type: "step",
+  item: {
+    stepId: `step-${index}`,
+    name: `${status} step ${index}`,
+    status,
+    parameters: [],
+    message: status === "failed" ? "failed" : "",
+    trace: status === "failed" ? "trace" : "",
+    hasSimilarErrorInSubSteps: false,
+  },
+  suppressInlineError: false,
+  bodyItems: [
+    {
+      type: "attachment",
+      link: {
+        id: `attachment-${index}`,
+        source: `attachment-${index}.png`,
+        name: `attachment ${index}`,
+        contentType: "image/png",
+      },
+    },
+  ],
+});
+
 describe("components > TestResult > TrSteps", () => {
   beforeEach(() => {
     cleanup();
@@ -81,15 +106,15 @@ describe("components > TestResult > TrSteps", () => {
     expect(view.getByTestId("test-result-steps-root")).toBeInTheDocument();
   });
 
-  it("opens top-level passed steps by default even with expand_failed_only", () => {
-    const view = render(<TrStep item={passedStepWithContent} stepIndex={1} isTopLevel={true} />);
+  it("collapses top-level passed steps by default with expand_failed_only", () => {
+    const view = render(<TrStep item={passedStepWithContent} stepIndex={1} />);
 
-    expect(view.getByTestId("test-result-step-content")).toBeInTheDocument();
+    expect(view.queryByTestId("test-result-step-content")).not.toBeInTheDocument();
   });
 
   it("collapses top-level steps when policy is collapsed", () => {
     globalThis.allureReportOptions = { stepTreeExpansion: "collapsed" } as any;
-    const view = render(<TrStep item={passedStepWithContent} stepIndex={1} isTopLevel={true} />);
+    const view = render(<TrStep item={passedStepWithContent} stepIndex={1} />);
 
     expect(view.queryByTestId("test-result-step-content")).not.toBeInTheDocument();
   });
@@ -100,8 +125,20 @@ describe("components > TestResult > TrSteps", () => {
     expect(view.getByTestId("test-result-step-content")).toBeInTheDocument();
   });
 
+  it("opens only failed top-level steps by default in large flat step lists", () => {
+    const bodyItems = Array.from({ length: 750 }, (_, index) =>
+      createTopLevelStep(index, index % 25 === 0 ? "failed" : "passed"),
+    );
+    const view = render(<TrSteps id="large-test" bodyItems={bodyItems} />);
+
+    expect(view.getAllByTestId("test-result-step")).toHaveLength(750);
+    expect(view.getAllByTestId("test-result-step-content")).toHaveLength(30);
+    expect(view.getAllByTestId("test-result-attachment")).toHaveLength(30);
+  });
+
   it("collapses nested passed steps by default with expand_failed_only", () => {
-    const view = render(<TrStep item={passedStepWithContent} stepIndex={1} isTopLevel={true} />);
+    expandedTrees.value = new Set(["passed-step"]);
+    const view = render(<TrStep item={passedStepWithContent} stepIndex={1} />);
 
     expect(view.queryAllByTestId("test-result-step-content")).toHaveLength(1);
   });


### PR DESCRIPTION
Fix `stepTreeExpansion: "expand_failed_only"` so top-level passed steps are not expanded by default in the Awesome report.

Previously, `TrStep` treated every top-level step as opened by default, bypassing the failed-context expansion policy. On large flat step lists with attachments, this caused the details page to render all step contents immediately, which could freeze the browser.

fixes https://github.com/allure-framework/allure3/issues/881

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
