### PR TITLE
fix(plugin-testops): Align the upload payload with the backend contract

### DIFF
--- a/packages/plugin-testops/src/client.ts
+++ b/packages/plugin-testops/src/client.ts
@@ -55,6 +55,8 @@ class TestOpsClientError extends AxiosError<{
   request: ClientRequest;
 }
 
+const UNKNOWN_ERROR_MESSAGE = "Unknown error";
+const MAX_LAUNCH_NAME_LENGTH = 255;
 const CHUNK_SIZE = 100;
 const BULK_UPLOAD_CHUNK_SIZE = 1000;
 const MAX_REQUEST_RETRIES = 3;
@@ -284,7 +286,7 @@ export class TestOpsClient {
     this.#logger.verbose("Creating launch…");
     const data = await this.#client.post<TestOpsLaunch>("/api/launch", {
       body: {
-        name: launchName,
+        name: launchName.slice(0, MAX_LAUNCH_NAME_LENGTH),
         projectId: this.#projectId,
         autoclose: true,
         external: true,
@@ -447,7 +449,7 @@ export class TestOpsClient {
     await this.#client.post("/api/launch/error/bulk", {
       body: {
         launchId,
-        items: errors,
+        items: errors.map(({ message, trace }) => ({ message: message?.trim() || UNKNOWN_ERROR_MESSAGE, trace })),
       },
       onUploadProgress(progressEvent) {
         const total = progressEvent.total ?? 100;

--- a/packages/plugin-testops/src/model.ts
+++ b/packages/plugin-testops/src/model.ts
@@ -128,7 +128,6 @@ export type UploadTestResultDto = {
   trace?: string;
   hostId?: string;
   threadId?: string;
-  environment?: string;
   category?: UploadTestResultCategoryDto;
   namedEnv?: UploadTestResultNamedEnvDto;
   steps?: UploadTestResultStepDto[];

--- a/packages/plugin-testops/src/utils/testResults.ts
+++ b/packages/plugin-testops/src/utils/testResults.ts
@@ -119,7 +119,6 @@ export const toUploadTestResultDto = (tr: TestOpsPluginTestResult): UploadTestRe
     trace: (tr as { trace?: string }).trace,
     hostId: tr.hostId,
     threadId: tr.threadId,
-    environment: tr.environment,
     ...(category ? { category } : {}),
     ...(typeof tr.namedEnv?.id === "number" ? { namedEnv: { id: tr.namedEnv.id } } : {}),
     steps: tr.steps?.map(toUploadStepDto),

--- a/packages/plugin-testops/test/client.test.ts
+++ b/packages/plugin-testops/test/client.test.ts
@@ -522,6 +522,30 @@ describe("testops http client", () => {
       );
     });
 
+    it("should trim launch names longer than the 255 chars the server accepts", async () => {
+      AxiosMock.post.mockImplementation((url: string) => {
+        if (url === "/api/launch") {
+          return Promise.resolve({ data: fixtures.launch });
+        }
+
+        return Promise.resolve({ data: {} });
+      });
+
+      const client = new TestOpsClient({
+        accessToken: fixtures.accessToken,
+        projectId: fixtures.projectId,
+        baseUrl: fixtures.endpoint,
+      });
+
+      await client.createLaunch("a".repeat(300), []);
+
+      expect(AxiosMock.post).toHaveBeenCalledWith(
+        "/api/launch",
+        expect.objectContaining({ name: "a".repeat(255) }),
+        expect.anything(),
+      );
+    });
+
     it("should include gitContext on /api/launch when provided", async () => {
       const gitContext = {
         contextType: "standalone" as const,
@@ -908,6 +932,49 @@ describe("testops http client", () => {
         }),
       );
     });
+
+    it("should replace blank error messages so the batch isn't rejected", async () => {
+      AxiosMock.post.mockImplementation((url: string) => {
+        if (url === "/api/launch") {
+          return Promise.resolve({ data: fixtures.launch });
+        }
+
+        if (url === "/api/upload/session") {
+          return Promise.resolve({ data: { id: 1 } });
+        }
+
+        return Promise.resolve({ data: {} });
+      });
+
+      const client = new TestOpsClient({
+        accessToken: fixtures.accessToken,
+        projectId: fixtures.projectId,
+        baseUrl: fixtures.endpoint,
+      });
+
+      await client.createLaunch(fixtures.launchName, fixtures.launchTags);
+      await client.createSession();
+      await client.uploadGlobalErrors([
+        { trace: "at foo.ts:1" } as TestError,
+        { message: "   ", trace: "at bar.ts:2" } as TestError,
+        { message: "Something went wrong" } as TestError,
+      ]);
+
+      expect(AxiosMock.post).toHaveBeenCalledWith(
+        "/api/launch/error/bulk",
+        {
+          launchId: fixtures.launch.id,
+          items: [
+            { message: "Unknown error", trace: "at foo.ts:1" },
+            { message: "Unknown error", trace: "at bar.ts:2" },
+            { message: "Something went wrong", trace: undefined },
+          ],
+        },
+        expect.objectContaining({
+          onUploadProgress: expect.any(Function),
+        }),
+      );
+    });
   });
 
   describe("uploadTestResults", () => {
@@ -1067,7 +1134,6 @@ describe("testops http client", () => {
           uuid: "tr-1",
           name: "Test",
           status: "passed",
-          environment: "chrome",
           category: {
             externalId: "123",
             grouping: [{ key: "status", value: "passed", name: "status: passed" }],
@@ -1443,7 +1509,7 @@ describe("testops http client", () => {
       expect(uploadCall).toBeTruthy();
       const uploadBody = uploadCall?.[1] as any;
       expect(uploadBody.testSessionId).toBe(1);
-      expect(uploadBody.results?.[0]?.environment).toBe("chrome");
+      expect(uploadBody.results?.[0]).not.toHaveProperty("environment");
     });
 
     it("should create distinct named environments for different env ids sharing one display name", async () => {
@@ -1525,7 +1591,7 @@ describe("testops http client", () => {
       const uploadCall = AxiosMock.post.mock.calls.find((call: any[]) => call[0] === "/api/upload/test-result");
       expect(uploadCall).toBeTruthy();
       const uploadBody = uploadCall?.[1] as any;
-      expect(uploadBody.results?.[0]?.environment).toBe("qa_a");
+      expect(uploadBody.results?.[0]).not.toHaveProperty("environment");
     });
 
     it("should not create named environments when test results have no environment", async () => {


### PR DESCRIPTION
### Context

Three defects found by comparing what the plugin uploads against what the TestOps API accepts. They are independent of each other and of #888, which fixes the `ci` block of the same request.

**A blank error message rejects the whole batch.** Global errors come from the results files test framework adapters write, and their message is optional in our model — nothing validates it on the way in. TestOps requires a non-blank message and rejects the entire bulk request when one item lacks it, so a single untitled error dropped every valid error uploaded alongside it. A placeholder is sent instead, keeping the trace. This became easier to hit once every not-yet-uploaded error started being sent rather than only the last one.

**A long launch name fails launch creation.** TestOps accepts a launch name of at most 255 characters and fails the request otherwise, so a longer report title killed the upload before it started. The name is trimmed to the accepted length now.

**`environment` was sent into the void.** The upload API has no `environment` property on a test result, so the value was dropped on arrival; the binding it was meant to carry travels in `namedEnv`, which is sent next to it. The dead field is gone from the payload and from the type that mirrors the API.

#### Checklist

- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
