### PR TITLE
update-limits-deps

### DIFF
--- a/.github/allure-bundle-size.baseline.json
+++ b/.github/allure-bundle-size.baseline.json
@@ -1,8 +1,8 @@
 {
   "rootPackage": "allure",
-  "measuredAt": "2026-08-21T14:49:38.462Z",
+  "measuredAt": "2026-09-02T07:44:48.293Z",
   "internalClosureCount": 34,
-  "selfBytes": 31870976,
-  "depsBytes": 65413120,
-  "totalBytes": 97284096
+  "selfBytes": 31776768,
+  "depsBytes": 65581056,
+  "totalBytes": 97357824
 }


### PR DESCRIPTION
Update the Allure bundle-size baseline using the Docker measurement flow.

Current main already exceeds the stored deps baseline by a small amount, while feature branches do not add new deps. This refreshes the baseline to the current main measurement.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
