### PR TITLE
add resolution counters to summary stats

### DIFF
--- a/packages/core-api/src/aggregate.ts
+++ b/packages/core-api/src/aggregate.ts
@@ -14,4 +14,9 @@ export type Statistic = DiffStatistic & {
   total: number;
   retries?: number;
   flaky?: number;
+  resolutions?: {
+    issues?: number;
+    muted?: number;
+    accepted?: number;
+  };
 };

--- a/packages/core-api/src/utils/comparator.ts
+++ b/packages/core-api/src/utils/comparator.ts
@@ -63,7 +63,7 @@ export const byStatus: SortFunction<TestStatus | undefined> = () => {
   });
 };
 export const byStatistic: SortFunction<Statistic | undefined> = () => {
-  const compares = statusesList.map((status) => compareBy<Statistic>(status, reverse(ordinal()), 0));
+  const compares = statusesList.map((status) => compareBy<Statistic, TestStatus>(status, reverse(ordinal()), 0));
   return nullsLast(andThen(compares));
 };
 

--- a/packages/core-api/test/utils/comparator.test.ts
+++ b/packages/core-api/test/utils/comparator.test.ts
@@ -313,5 +313,22 @@ describe("comparator", () => {
       const result = [statistic1, statistic1, statistic2].sort(byStatistic());
       expect(result).toEqual([statistic2, statistic1, statistic1]);
     });
+
+    it("should ignore nested resolution counters", () => {
+      const statistic1: Statistic = {
+        failed: 1,
+        total: 1,
+        resolutions: { issues: 1 },
+      };
+      const statistic2: Statistic = {
+        failed: 2,
+        total: 2,
+        resolutions: { accepted: 2, muted: 1 },
+      };
+
+      const result = [statistic1, statistic2].sort(byStatistic());
+
+      expect(result).toEqual([statistic2, statistic1]);
+    });
   });
 });

--- a/packages/core/src/store/store.ts
+++ b/packages/core/src/store/store.ts
@@ -1383,6 +1383,22 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
 
   async testsStatistic(filter?: TestResultFilter) {
     const statistic: Statistic = { total: 0 };
+    const incrementResolution = (tr: TestResult) => {
+      if (tr.resolution === "issue") {
+        statistic.resolutions ??= {};
+        statistic.resolutions.issues = (statistic.resolutions.issues ?? 0) + 1;
+      }
+
+      if (tr.resolution === "muted") {
+        statistic.resolutions ??= {};
+        statistic.resolutions.muted = (statistic.resolutions.muted ?? 0) + 1;
+      }
+
+      if (tr.resolution === "accepted") {
+        statistic.resolutions ??= {};
+        statistic.resolutions.accepted = (statistic.resolutions.accepted ?? 0) + 1;
+      }
+    };
 
     for (const [, tr] of this.#testResults) {
       if (tr.isRetry) {
@@ -1408,6 +1424,8 @@ export class DefaultAllureStore implements AllureStore, ResultsVisitor {
       if (tr.transition === "new") {
         statistic.new = (statistic.new ?? 0) + 1;
       }
+
+      incrementResolution(tr);
 
       if (!statistic[tr.status]) {
         statistic[tr.status] = 0;

--- a/packages/core/test/store/store.test.ts
+++ b/packages/core/test/store/store.test.ts
@@ -365,6 +365,60 @@ describe("test results", () => {
     await expect(target.testResultsByResolutionIssueId("SHOP-1")).resolves.toEqual([]);
   });
 
+  it("should include resolution counters in test statistics", async () => {
+    const store = new DefaultAllureStore({
+      resolutionsConfig: {
+        links: { jira: { urlTemplate: "https://example.org/%s" } },
+        rules: [
+          {
+            resolution: "issue",
+            issue: { id: "SHOP-1", type: "jira" },
+            testCaseId: [md5("tc-issue")],
+          },
+          {
+            resolution: "muted",
+            comment: "muted failure",
+            testCaseId: [md5("tc-muted")],
+          },
+          {
+            resolution: "accepted",
+            comment: "accepted failure",
+            testCaseId: [md5("tc-accepted")],
+          },
+        ],
+      },
+    });
+
+    await store.visitTestResult(
+      { name: "issue latest", status: "failed", testId: "tc-issue", start: 1000 },
+      { readerId },
+    );
+    await store.visitTestResult({ name: "issue retry", status: "failed", testId: "tc-issue", start: 0 }, { readerId });
+    await store.visitTestResult({ name: "muted", status: "broken", testId: "tc-muted" }, { readerId });
+    await store.visitTestResult({ name: "accepted", status: "failed", testId: "tc-accepted" }, { readerId });
+    await store.visitTestResult({ name: "passed", status: "passed", testId: "tc-passed" }, { readerId });
+
+    await expect(store.testsStatistic()).resolves.toMatchObject({
+      total: 4,
+      failed: 2,
+      broken: 1,
+      passed: 1,
+      resolutions: {
+        issues: 1,
+        muted: 1,
+        accepted: 1,
+      },
+    });
+    await expect(store.testsStatistic((tr) => tr.status === "failed")).resolves.toMatchObject({
+      total: 2,
+      failed: 2,
+      resolutions: {
+        issues: 1,
+        accepted: 1,
+      },
+    });
+  });
+
   it("should mark retries as isRetry", async () => {
     const store = new DefaultAllureStore();
     const tr1: RawTestResult = {

--- a/packages/plugin-allure2/src/model.ts
+++ b/packages/plugin-allure2/src/model.ts
@@ -106,7 +106,9 @@ export interface Allure2TestResult {
 
 // report related models
 
-export const statisticKeys: (keyof Statistic)[] = ["failed", "broken", "skipped", "passed", "unknown", "total"];
+type StatisticKey = "failed" | "broken" | "skipped" | "passed" | "unknown" | "total";
+
+export const statisticKeys: StatisticKey[] = ["failed", "broken", "skipped", "passed", "unknown", "total"];
 
 export interface GroupTime {
   start?: number;

--- a/packages/plugin-api/test/summary.test.ts
+++ b/packages/plugin-api/test/summary.test.ts
@@ -101,7 +101,7 @@ describe("summary utils", () => {
       testResult({ id: "n1", name: "new", status: "passed", duration: 7 }),
       testResult({ id: "n2", name: "new-2", status: "failed", duration: 9 }),
     ];
-    const stats = { total: 3 } as any;
+    const stats = { total: 3, resolutions: { issues: 1, muted: 1, accepted: 1 } } as any;
     const historyReadHistory = vi.fn().mockResolvedValue([{ branch: "main" }]);
     const history = { readHistory: historyReadHistory } as unknown as AllureHistory;
     const store = {

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -48,6 +48,22 @@ const statisticByTestResults = async (
 ): Promise<Statistic> => {
   const statistic: Statistic = { total: 0 };
   const related = await store.relatedByTestResultIds(testResults.map(({ id }) => id));
+  const incrementResolution = (testResult: (typeof testResults)[number]) => {
+    if (testResult.resolution === "issue") {
+      statistic.resolutions ??= {};
+      statistic.resolutions.issues = (statistic.resolutions.issues ?? 0) + 1;
+    }
+
+    if (testResult.resolution === "muted") {
+      statistic.resolutions ??= {};
+      statistic.resolutions.muted = (statistic.resolutions.muted ?? 0) + 1;
+    }
+
+    if (testResult.resolution === "accepted") {
+      statistic.resolutions ??= {};
+      statistic.resolutions.accepted = (statistic.resolutions.accepted ?? 0) + 1;
+    }
+  };
 
   for (const testResult of testResults) {
     if (testResult.isRetry) {
@@ -67,6 +83,8 @@ const statisticByTestResults = async (
     if (testResult.transition === "new") {
       statistic.new = (statistic.new ?? 0) + 1;
     }
+
+    incrementResolution(testResult);
   }
 
   return statistic;

--- a/packages/plugin-awesome/test/plugin.test.ts
+++ b/packages/plugin-awesome/test/plugin.test.ts
@@ -16,7 +16,7 @@ beforeEach(async () => {
 
 // duplicated the code from core to avoid circular dependency
 export const getTestResultsStats = (trs: TestResult[], filter: (tr: TestResult) => boolean = () => true) => {
-  const trsToProcess = trs.filter(filter);
+  const trsToProcess = trs.filter((tr) => !tr.isRetry && filter(tr));
 
   return trsToProcess.reduce(
     (acc, test) => {
@@ -25,6 +25,21 @@ export const getTestResultsStats = (trs: TestResult[], filter: (tr: TestResult) 
       }
 
       acc[test.status]!++;
+
+      if (test.resolution === "issue") {
+        acc.resolutions ??= {};
+        acc.resolutions.issues = (acc.resolutions.issues ?? 0) + 1;
+      }
+
+      if (test.resolution === "muted") {
+        acc.resolutions ??= {};
+        acc.resolutions.muted = (acc.resolutions.muted ?? 0) + 1;
+      }
+
+      if (test.resolution === "accepted") {
+        acc.resolutions ??= {};
+        acc.resolutions.accepted = (acc.resolutions.accepted ?? 0) + 1;
+      }
 
       return acc;
     },
@@ -417,6 +432,11 @@ describe("plugin", () => {
         passed: 1,
         failed: 2,
         broken: 1,
+        resolutions: {
+          issues: 1,
+          muted: 1,
+          accepted: 1,
+        },
       });
       expect(JSON.parse(addedFiles.get("widgets/pie_chart.json")!.toString("utf-8"))).toMatchObject({
         percentage: 50,
@@ -521,7 +541,8 @@ describe("plugin", () => {
       const stagingTestResult = {
         id: "tr-staging",
         name: "staging test",
-        status: "passed",
+        status: "failed",
+        resolution: "accepted",
         environment: "staging",
         labels: [],
         parameters: [],
@@ -604,11 +625,17 @@ describe("plugin", () => {
 
       expect(JSON.parse(addedFiles.get("widgets/statistic.json")!.toString("utf-8"))).toEqual({
         total: 1,
-        passed: 1,
+        failed: 1,
+        resolutions: {
+          accepted: 1,
+        },
       });
       expect(JSON.parse(addedFiles.get("widgets/staging/statistic.json")!.toString("utf-8"))).toEqual({
         total: 1,
-        passed: 1,
+        failed: 1,
+        resolutions: {
+          accepted: 1,
+        },
       });
       expect(JSON.parse(addedFiles.get("widgets/default/statistic.json")!.toString("utf-8"))).toEqual({
         total: 0,
@@ -629,7 +656,8 @@ describe("plugin", () => {
       const qaATestResult = {
         id: "tr-qa-a",
         name: "qa a test",
-        status: "passed",
+        status: "broken",
+        resolution: "muted",
         environment: "QA",
         labels: [],
         parameters: [],
@@ -642,6 +670,7 @@ describe("plugin", () => {
         id: "tr-qa-b",
         name: "qa b test",
         status: "failed",
+        resolution: "issue",
         environment: "QA",
         labels: [],
         parameters: [],
@@ -732,11 +761,17 @@ describe("plugin", () => {
       ]);
       expect(JSON.parse(addedFiles.get("widgets/qa_a/statistic.json")!.toString("utf-8"))).toEqual({
         total: 1,
-        passed: 1,
+        broken: 1,
+        resolutions: {
+          muted: 1,
+        },
       });
       expect(JSON.parse(addedFiles.get("widgets/qa_b/statistic.json")!.toString("utf-8"))).toEqual({
         total: 1,
         failed: 1,
+        resolutions: {
+          issues: 1,
+        },
       });
       expect(store.environmentIdByTrId).toHaveBeenCalledWith("tr-qa-a");
       expect(store.environmentIdByTrId).toHaveBeenCalledWith("tr-qa-b");


### PR DESCRIPTION
Adds resolution category counters to Allure summary statistics so downstream consumers can render them from `summary.json` / `statistic.json`.


#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
