### PR TITLE
feat(core): write local artifacts manifest

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -27,6 +27,10 @@ export interface FullConfig
   categories?: CategoriesConfig;
   globalAttachments?: string[];
   /**
+   * Working directory used for resolving input patterns and local artifact paths.
+   */
+  cwd?: string;
+  /**
    * Normalized results directory patterns from config (unset when empty / only empty-string entries).
    */
   resultsDir?: string[];

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -25,6 +25,7 @@ import { assertValidPluginIdForWindows, isWindows } from "./utils/windows.js";
 type PluginConstructor = new (options?: Record<string, any>, context?: PluginConstructorContext) => Plugin;
 
 export interface ConfigOverride {
+  cwd?: string;
   name?: Config["name"];
   output?: Config["output"];
   open?: Config["open"];
@@ -334,6 +335,7 @@ export const resolveConfig = async (config: Config, override: ConfigOverride = {
       ? { ...(config.resolutions ?? { rules: [] }), knownIssuesPath }
       : undefined;
   const output = resolve(override.output ?? config.output ?? "./allure-report");
+  const cwd = resolve(override.cwd ?? process.cwd());
   const variables = config.variables ?? {};
   const resultsDir = normalizeResultsDir(config.resultsDir);
   let pluginInstances: PluginInstance[] = [];
@@ -363,6 +365,7 @@ export const resolveConfig = async (config: Config, override: ConfigOverride = {
 
   return {
     name,
+    cwd,
     output,
     open,
     port,
@@ -446,7 +449,7 @@ export const readConfig = async (
       config = DEFAULT_CONFIG;
   }
 
-  const fullConfig = await resolveConfig(config, override);
+  const fullConfig = await resolveConfig(config, { ...override, cwd });
 
   return fullConfig;
 };

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -4,7 +4,7 @@ import { once } from "node:events";
 import { createReadStream, createWriteStream, existsSync, readFileSync, type ReadStream } from "node:fs";
 import { lstat, mkdtemp, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 
 import { detect } from "@allurereport/ci";
@@ -52,6 +52,14 @@ import { DefaultPluginState, PluginFiles } from "./plugin.js";
 import { QualityGate, type QualityGateState } from "./qualityGate/index.js";
 import { writeKnownIssues } from "./resolutions.js";
 import { DefaultAllureStore } from "./store/store.js";
+import {
+  ARTIFACTS_MANIFEST_FILENAME,
+  type ReportArtifact,
+  type ReportArtifactsManifest,
+  type RestoreStateDumpInput,
+  createReportArtifact,
+  deduplicateDumpInputs,
+} from "./utils/artifacts.js";
 import { environmentIdentityById, environmentIdentityByName } from "./utils/environment.js";
 import { RealtimeEventsDispatcher, RealtimeSubscriber } from "./utils/event.js";
 import {
@@ -74,38 +82,11 @@ const DEFAULT_READ_CONCURRENCY = 64;
 const MAX_READ_CONCURRENCY = 256;
 const TEST_RESULTS_REGISTRY_FILENAME = "test-results.json";
 const QUALITY_GATE_RESULTS_FILENAME = "quality-gate.json";
-const ARTIFACTS_MANIFEST_FILENAME = "artifacts.json";
 const ROOT_INTEGRATION_FILENAMES = new Set([
   TEST_RESULTS_REGISTRY_FILENAME,
   QUALITY_GATE_RESULTS_FILENAME,
   ARTIFACTS_MANIFEST_FILENAME,
 ]);
-const OUTSIDE_CWD_ARTIFACT_PREFIX = "<outside-cwd>";
-
-type ReportArtifactsDump = {
-  path: string;
-  status: "expanded" | "failed" | "missing" | "restored";
-  error?: string;
-};
-
-type ReportArtifactsGlobalAttachment = {
-  name: string;
-  path: string;
-};
-
-type ReportArtifactsManifest = {
-  schemaVersion: 1;
-  dumps: ReportArtifactsDump[];
-  globalAttachments: {
-    patterns: string[];
-    files: ReportArtifactsGlobalAttachment[];
-  };
-};
-
-type RestoreStateDumpInput = {
-  displayPath?: string;
-  path: string;
-};
 
 const readConcurrency = () => {
   const parsed = Number.parseInt(process.env.ALLURE_READ_CONCURRENCY ?? "", 10);
@@ -127,39 +108,6 @@ const remoteReportParams = (ci: CiDescriptor | undefined): { repo?: string; bran
 };
 
 const errorDetails = (err: unknown): string => (err instanceof Error ? (err.stack ?? err.message) : String(err));
-
-const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
-
-const normalizeReportArtifactPath = (filePath: string): string => {
-  const cwd = resolve(process.cwd());
-  const cwdWithSep = cwd.endsWith(sep) ? cwd : `${cwd}${sep}`;
-  const absoluteFilePath = resolve(filePath);
-
-  if (absoluteFilePath === cwd) {
-    return ".";
-  }
-
-  if (absoluteFilePath.startsWith(cwdWithSep)) {
-    return relative(cwd, absoluteFilePath).split(sep).join("/");
-  }
-
-  return `${OUTSIDE_CWD_ARTIFACT_PREFIX}/${basename(absoluteFilePath)}`;
-};
-
-const normalizeZipEntryPath = (entryName: string): string => entryName.split("\\").join("/");
-
-const artifactErrorMessage = (err: unknown, filePath: string): string => {
-  const message = errorMessage(err);
-  const artifactPath = normalizeReportArtifactPath(filePath);
-  const inputPath = filePath.split(sep).join("/");
-  const absolutePath = resolve(filePath);
-  const absoluteManifestPath = absolutePath.split(sep).join("/");
-
-  return [...new Set([absolutePath, absoluteManifestPath, filePath, inputPath])].reduce(
-    (acc, path) => acc.split(path).join(artifactPath),
-    message,
-  );
-};
 
 const closeReadStream = async (stream: ReadStream): Promise<void> => {
   if (stream.closed) {
@@ -195,8 +143,8 @@ export class AllureReport {
   readonly #environments: NonNullable<FullConfig["environments"]>;
   readonly #globalAttachments: FullConfig["globalAttachments"];
   readonly #knownIssuesPath: string | undefined;
-
   #dumpTempDirs: string[] = [];
+  #cwd?: string;
   #state?: Record<string, PluginState>;
   #executionStage: "init" | "running" | "done" = "init";
   #historyDataPoint?: HistoryDataPoint;
@@ -204,9 +152,7 @@ export class AllureReport {
   #testResultsRegistryPath?: string;
   #summariesByPluginId: Map<string, PluginSummary> = new Map();
   #publishedRemoteHrefs: Set<string> = new Set();
-  #artifactsDumps: ReportArtifactsDump[] = [];
-  #globalAttachmentPatterns: string[] = [];
-  #globalAttachmentFilesByPath: Map<string, ReportArtifactsGlobalAttachment> = new Map();
+  #artifactFilesByPath: Map<string, ReportArtifact> = new Map();
   #published = false;
   #endGeneratePerfSpan?: () => void;
 
@@ -238,6 +184,7 @@ export class AllureReport {
       categories,
       allureService,
       globalAttachments,
+      cwd,
     } = opts;
     const allureServiceAccessToken = allureService?.accessToken;
 
@@ -255,6 +202,7 @@ export class AllureReport {
     }
 
     this.reportUuid = randomUUID();
+    this.#cwd = cwd ? resolve(cwd) : undefined;
     this.#ci = detect();
 
     const reportTitleSuffix = this.#ci?.pullRequestName ?? this.#ci?.jobRunName;
@@ -611,6 +559,12 @@ export class AllureReport {
     });
   };
 
+  #getCwd = (): string => {
+    this.#cwd ??= resolve(process.cwd());
+
+    return this.#cwd;
+  };
+
   start = async (): Promise<void> => {
     await this.#store.readHistory();
 
@@ -625,34 +579,24 @@ export class AllureReport {
     this.#executionStage = "running";
     this.#endGeneratePerfSpan = startPerfSpan(PERF_METRIC_NAMES.generateTotal);
 
-    const cwd = resolve(process.cwd());
-    const cwdWithSep = cwd.endsWith(sep) ? cwd : `${cwd}${sep}`;
-    this.#globalAttachmentPatterns = [...(this.#globalAttachments ?? [])];
-
     if (this.#globalAttachments?.length) {
+      const cwd = this.#getCwd();
       const matchedFiles = new Set<string>();
 
       for (const pattern of this.#globalAttachments) {
         const files = await glob(pattern, { cwd, nodir: true, absolute: true });
 
-        files.forEach((filePath) => matchedFiles.add(filePath));
+        files.forEach((filePath) => matchedFiles.add(resolve(cwd, filePath)));
       }
 
-      for (const filePath of matchedFiles) {
-        const absoluteFilePath = resolve(filePath);
-        const isInsideCwd = absoluteFilePath === cwd || absoluteFilePath.startsWith(cwdWithSep);
-
-        if (!isInsideCwd) {
-          continue;
-        }
-
+      for (const absoluteFilePath of matchedFiles) {
         const originalFileName = basename(absoluteFilePath);
 
         this.#realtimeChannel.dispatcher.sendGlobalAttachment(
           new PathResultFile(absoluteFilePath, originalFileName),
           originalFileName,
         );
-        this.#recordGlobalAttachment(absoluteFilePath, originalFileName);
+        this.#recordArtifact(absoluteFilePath, originalFileName);
       }
     }
 
@@ -849,38 +793,28 @@ export class AllureReport {
 
   restoreState = async (dumps: string[]): Promise<void> => {
     this.#store.resetIngestOrder();
-    await this.#restoreStateDumps(dumps.map((path) => ({ path })));
+    await this.#restoreStateDumps(dumps.map((path) => ({ artifactPath: path, path })));
   };
 
-  #recordArtifactsDump = (dump: ReportArtifactsDump): void => {
-    this.#artifactsDumps.push(dump);
-  };
+  #recordArtifact = (filePath: string, name = basename(filePath)): void => {
+    const artifact = createReportArtifact(filePath, this.#getCwd(), name);
 
-  #recordGlobalAttachment = (filePath: string, name: string): void => {
-    const absoluteFilePath = resolve(filePath);
-
-    if (!this.#globalAttachmentFilesByPath.has(absoluteFilePath)) {
-      this.#globalAttachmentFilesByPath.set(absoluteFilePath, {
-        name,
-        path: normalizeReportArtifactPath(absoluteFilePath),
-      });
+    if (!this.#artifactFilesByPath.has(artifact.path)) {
+      this.#artifactFilesByPath.set(artifact.path, artifact);
     }
   };
 
-  #restoreStateDumps = async (dumps: RestoreStateDumpInput[]): Promise<void> =>
+  #restoreStateDumps = async (dumps: RestoreStateDumpInput[]): Promise<number> =>
     measurePerf(PERF_METRIC_NAMES.restoreStateTotal, async () => {
-      for (const { displayPath, path: dump } of dumps) {
-        const artifactDumpPath = displayPath ?? normalizeReportArtifactPath(dump);
+      let restoredCount = 0;
+
+      for (const { artifactPath, path: dump, recordArtifact = true } of deduplicateDumpInputs(dumps, this.#getCwd())) {
+        const artifactFilePath = artifactPath ?? dump;
 
         await measurePerf(PERF_METRIC_NAMES.restoreStateDump, async () => {
           if (!existsSync(dump)) {
             console.error(`Failed to restore state from "${dump}", continuing without it`);
             console.error("Dump file does not exist");
-            this.#recordArtifactsDump({
-              path: artifactDumpPath,
-              status: "missing",
-              error: "Dump file does not exist",
-            });
             return;
           }
 
@@ -923,16 +857,22 @@ export class AllureReport {
 
                     await writeFile(nestedDumpPath, await dumpArchive.entryData(entryName));
                     nestedDumps.push({
-                      displayPath: `${artifactDumpPath}!/${normalizeZipEntryPath(entryName)}`,
+                      artifactPath: artifactFilePath,
                       path: nestedDumpPath,
+                      recordArtifact: false,
                     });
                   }
 
-                  this.#recordArtifactsDump({
-                    path: artifactDumpPath,
-                    status: "expanded",
-                  });
-                  await this.#restoreStateDumps(nestedDumps);
+                  const nestedRestoredCount = await this.#restoreStateDumps(nestedDumps);
+
+                  if (nestedRestoredCount > 0) {
+                    restoredCount += 1;
+
+                    if (recordArtifact) {
+                      this.#recordArtifact(artifactFilePath);
+                    }
+                  }
+
                   return;
                 }
               }
@@ -1061,10 +1001,11 @@ export class AllureReport {
               );
 
               console.info(`Successfully restored state from "${dump}"`);
-              this.#recordArtifactsDump({
-                path: artifactDumpPath,
-                status: "restored",
-              });
+              restoredCount += 1;
+
+              if (recordArtifact) {
+                this.#recordArtifact(artifactFilePath);
+              }
             } catch (err) {
               restoreError = err;
               throw err;
@@ -1081,14 +1022,11 @@ export class AllureReport {
           } catch (err) {
             console.error(`Failed to restore state from "${dump}", continuing without it`);
             console.error(errorDetails(err));
-            this.#recordArtifactsDump({
-              path: artifactDumpPath,
-              status: "failed",
-              error: artifactErrorMessage(err, dump),
-            });
           }
         });
       }
+
+      return restoredCount;
     });
 
   #getReportsToPublish = async (): Promise<PluginReportFile[]> => {
@@ -1198,22 +1136,11 @@ export class AllureReport {
   };
 
   #finishArtifactsManifest = async (): Promise<void> => {
-    if (
-      this.#artifactsDumps.length === 0 &&
-      this.#globalAttachmentPatterns.length === 0 &&
-      this.#globalAttachmentFilesByPath.size === 0
-    ) {
+    if (this.#artifactFilesByPath.size === 0) {
       return;
     }
 
-    const manifest: ReportArtifactsManifest = {
-      schemaVersion: 1,
-      dumps: this.#artifactsDumps,
-      globalAttachments: {
-        patterns: this.#globalAttachmentPatterns,
-        files: [...this.#globalAttachmentFilesByPath.values()],
-      },
-    };
+    const manifest: ReportArtifactsManifest = [...this.#artifactFilesByPath.values()];
 
     try {
       await writeFile(join(this.#output, ARTIFACTS_MANIFEST_FILENAME), JSON.stringify(manifest));

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -4,7 +4,7 @@ import { once } from "node:events";
 import { createReadStream, createWriteStream, existsSync, readFileSync, type ReadStream } from "node:fs";
 import { lstat, mkdtemp, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 
 import { detect } from "@allurereport/ci";
@@ -74,7 +74,38 @@ const DEFAULT_READ_CONCURRENCY = 64;
 const MAX_READ_CONCURRENCY = 256;
 const TEST_RESULTS_REGISTRY_FILENAME = "test-results.json";
 const QUALITY_GATE_RESULTS_FILENAME = "quality-gate.json";
-const ROOT_INTEGRATION_FILENAMES = new Set([TEST_RESULTS_REGISTRY_FILENAME, QUALITY_GATE_RESULTS_FILENAME]);
+const ARTIFACTS_MANIFEST_FILENAME = "artifacts.json";
+const ROOT_INTEGRATION_FILENAMES = new Set([
+  TEST_RESULTS_REGISTRY_FILENAME,
+  QUALITY_GATE_RESULTS_FILENAME,
+  ARTIFACTS_MANIFEST_FILENAME,
+]);
+const OUTSIDE_CWD_ARTIFACT_PREFIX = "<outside-cwd>";
+
+type ReportArtifactsDump = {
+  path: string;
+  status: "expanded" | "failed" | "missing" | "restored";
+  error?: string;
+};
+
+type ReportArtifactsGlobalAttachment = {
+  name: string;
+  path: string;
+};
+
+type ReportArtifactsManifest = {
+  schemaVersion: 1;
+  dumps: ReportArtifactsDump[];
+  globalAttachments: {
+    patterns: string[];
+    files: ReportArtifactsGlobalAttachment[];
+  };
+};
+
+type RestoreStateDumpInput = {
+  displayPath?: string;
+  path: string;
+};
 
 const readConcurrency = () => {
   const parsed = Number.parseInt(process.env.ALLURE_READ_CONCURRENCY ?? "", 10);
@@ -96,6 +127,39 @@ const remoteReportParams = (ci: CiDescriptor | undefined): { repo?: string; bran
 };
 
 const errorDetails = (err: unknown): string => (err instanceof Error ? (err.stack ?? err.message) : String(err));
+
+const errorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+const normalizeReportArtifactPath = (filePath: string): string => {
+  const cwd = resolve(process.cwd());
+  const cwdWithSep = cwd.endsWith(sep) ? cwd : `${cwd}${sep}`;
+  const absoluteFilePath = resolve(filePath);
+
+  if (absoluteFilePath === cwd) {
+    return ".";
+  }
+
+  if (absoluteFilePath.startsWith(cwdWithSep)) {
+    return relative(cwd, absoluteFilePath).split(sep).join("/");
+  }
+
+  return `${OUTSIDE_CWD_ARTIFACT_PREFIX}/${basename(absoluteFilePath)}`;
+};
+
+const normalizeZipEntryPath = (entryName: string): string => entryName.split("\\").join("/");
+
+const artifactErrorMessage = (err: unknown, filePath: string): string => {
+  const message = errorMessage(err);
+  const artifactPath = normalizeReportArtifactPath(filePath);
+  const inputPath = filePath.split(sep).join("/");
+  const absolutePath = resolve(filePath);
+  const absoluteManifestPath = absolutePath.split(sep).join("/");
+
+  return [...new Set([absolutePath, absoluteManifestPath, filePath, inputPath])].reduce(
+    (acc, path) => acc.split(path).join(artifactPath),
+    message,
+  );
+};
 
 const closeReadStream = async (stream: ReadStream): Promise<void> => {
   if (stream.closed) {
@@ -140,6 +204,9 @@ export class AllureReport {
   #testResultsRegistryPath?: string;
   #summariesByPluginId: Map<string, PluginSummary> = new Map();
   #publishedRemoteHrefs: Set<string> = new Set();
+  #artifactsDumps: ReportArtifactsDump[] = [];
+  #globalAttachmentPatterns: string[] = [];
+  #globalAttachmentFilesByPath: Map<string, ReportArtifactsGlobalAttachment> = new Map();
   #published = false;
   #endGeneratePerfSpan?: () => void;
 
@@ -560,6 +627,7 @@ export class AllureReport {
 
     const cwd = resolve(process.cwd());
     const cwdWithSep = cwd.endsWith(sep) ? cwd : `${cwd}${sep}`;
+    this.#globalAttachmentPatterns = [...(this.#globalAttachments ?? [])];
 
     if (this.#globalAttachments?.length) {
       const matchedFiles = new Set<string>();
@@ -584,6 +652,7 @@ export class AllureReport {
           new PathResultFile(absoluteFilePath, originalFileName),
           originalFileName,
         );
+        this.#recordGlobalAttachment(absoluteFilePath, originalFileName);
       }
     }
 
@@ -780,16 +849,38 @@ export class AllureReport {
 
   restoreState = async (dumps: string[]): Promise<void> => {
     this.#store.resetIngestOrder();
-    await this.#restoreStateDumps(dumps);
+    await this.#restoreStateDumps(dumps.map((path) => ({ path })));
   };
 
-  #restoreStateDumps = async (dumps: string[]): Promise<void> =>
+  #recordArtifactsDump = (dump: ReportArtifactsDump): void => {
+    this.#artifactsDumps.push(dump);
+  };
+
+  #recordGlobalAttachment = (filePath: string, name: string): void => {
+    const absoluteFilePath = resolve(filePath);
+
+    if (!this.#globalAttachmentFilesByPath.has(absoluteFilePath)) {
+      this.#globalAttachmentFilesByPath.set(absoluteFilePath, {
+        name,
+        path: normalizeReportArtifactPath(absoluteFilePath),
+      });
+    }
+  };
+
+  #restoreStateDumps = async (dumps: RestoreStateDumpInput[]): Promise<void> =>
     measurePerf(PERF_METRIC_NAMES.restoreStateTotal, async () => {
-      for (const dump of dumps) {
+      for (const { displayPath, path: dump } of dumps) {
+        const artifactDumpPath = displayPath ?? normalizeReportArtifactPath(dump);
+
         await measurePerf(PERF_METRIC_NAMES.restoreStateDump, async () => {
           if (!existsSync(dump)) {
             console.error(`Failed to restore state from "${dump}", continuing without it`);
             console.error("Dump file does not exist");
+            this.#recordArtifactsDump({
+              path: artifactDumpPath,
+              status: "missing",
+              error: "Dump file does not exist",
+            });
             return;
           }
 
@@ -823,18 +914,25 @@ export class AllureReport {
 
                 if (nestedDumpEntries.length > 0) {
                   const nestedDumpsTempDir = await mkdtemp(join(tmpdir(), `${basename(dump, ".zip")}-nested-`));
-                  const nestedDumpPaths: string[] = [];
+                  const nestedDumps: RestoreStateDumpInput[] = [];
 
                   this.#dumpTempDirs.push(nestedDumpsTempDir);
 
                   for (const [entryName] of nestedDumpEntries) {
-                    const nestedDumpPath = join(nestedDumpsTempDir, `${nestedDumpPaths.length}-${basename(entryName)}`);
+                    const nestedDumpPath = join(nestedDumpsTempDir, `${nestedDumps.length}-${basename(entryName)}`);
 
                     await writeFile(nestedDumpPath, await dumpArchive.entryData(entryName));
-                    nestedDumpPaths.push(nestedDumpPath);
+                    nestedDumps.push({
+                      displayPath: `${artifactDumpPath}!/${normalizeZipEntryPath(entryName)}`,
+                      path: nestedDumpPath,
+                    });
                   }
 
-                  await this.#restoreStateDumps(nestedDumpPaths);
+                  this.#recordArtifactsDump({
+                    path: artifactDumpPath,
+                    status: "expanded",
+                  });
+                  await this.#restoreStateDumps(nestedDumps);
                   return;
                 }
               }
@@ -963,6 +1061,10 @@ export class AllureReport {
               );
 
               console.info(`Successfully restored state from "${dump}"`);
+              this.#recordArtifactsDump({
+                path: artifactDumpPath,
+                status: "restored",
+              });
             } catch (err) {
               restoreError = err;
               throw err;
@@ -979,6 +1081,11 @@ export class AllureReport {
           } catch (err) {
             console.error(`Failed to restore state from "${dump}", continuing without it`);
             console.error(errorDetails(err));
+            this.#recordArtifactsDump({
+              path: artifactDumpPath,
+              status: "failed",
+              error: artifactErrorMessage(err, dump),
+            });
           }
         });
       }
@@ -1088,6 +1195,31 @@ export class AllureReport {
     const qualityGateResults = await this.#store.qualityGateResults();
 
     await this.#reportFiles.addFile(QUALITY_GATE_RESULTS_FILENAME, Buffer.from(JSON.stringify(qualityGateResults)));
+  };
+
+  #finishArtifactsManifest = async (): Promise<void> => {
+    if (
+      this.#artifactsDumps.length === 0 &&
+      this.#globalAttachmentPatterns.length === 0 &&
+      this.#globalAttachmentFilesByPath.size === 0
+    ) {
+      return;
+    }
+
+    const manifest: ReportArtifactsManifest = {
+      schemaVersion: 1,
+      dumps: this.#artifactsDumps,
+      globalAttachments: {
+        patterns: this.#globalAttachmentPatterns,
+        files: [...this.#globalAttachmentFilesByPath.values()],
+      },
+    };
+
+    try {
+      await writeFile(join(this.#output, ARTIFACTS_MANIFEST_FILENAME), JSON.stringify(manifest));
+    } catch (err) {
+      console.error("Failed to write Allure artifacts manifest", err);
+    }
   };
 
   #generateRootSummary = async (): Promise<void> => {
@@ -1203,6 +1335,8 @@ export class AllureReport {
 
         await rm(reportPath, { recursive: true });
       }
+
+      await this.#finishArtifactsManifest();
 
       // remove all dump temp dirs
       for (const dir of this.#dumpTempDirs) {

--- a/packages/core/src/utils/artifacts.ts
+++ b/packages/core/src/utils/artifacts.ts
@@ -1,0 +1,57 @@
+import { realpathSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
+
+export const ARTIFACTS_MANIFEST_FILENAME = "artifacts.json";
+
+export type ReportArtifact = {
+  name: string;
+  path: string;
+};
+
+export type ReportArtifactsManifest = ReportArtifact[];
+
+export type RestoreStateDumpInput = {
+  artifactPath?: string;
+  path: string;
+  recordArtifact?: boolean;
+};
+
+const existingRealPath = (filePath: string): string => {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return filePath;
+  }
+};
+
+export const normalizeArtifactPath = (filePath: string, cwd: string): string => {
+  const path = relative(resolve(cwd), resolve(cwd, filePath)).split(sep).join("/");
+
+  return path || ".";
+};
+
+export const createReportArtifact = (filePath: string, cwd: string, name = basename(filePath)): ReportArtifact => ({
+  name,
+  path: normalizeArtifactPath(filePath, cwd),
+});
+
+export const deduplicateDumpInputs = (dumps: RestoreStateDumpInput[], cwd: string): RestoreStateDumpInput[] => {
+  const seen = new Set<string>();
+
+  return dumps.reduce<RestoreStateDumpInput[]>((acc, dump) => {
+    const absolutePath = resolve(cwd, dump.path);
+    const dedupeKey = existingRealPath(absolutePath);
+
+    if (seen.has(dedupeKey)) {
+      return acc;
+    }
+
+    seen.add(dedupeKey);
+    acc.push({
+      ...dump,
+      path: absolutePath,
+    });
+
+    return acc;
+  }, []);
+};

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -1295,6 +1295,12 @@ describe("readConfig", () => {
     } catch {}
   });
 
+  it("should preserve the requested working directory", async () => {
+    const config = await readConfig(fixturesDir);
+
+    expect(config.cwd).toBe(resolve(fixturesDir));
+  });
+
   it("should read a .js config", async () => {
     const configName = "config.js";
     const configContent = "export default { name: 'Foo' };";

--- a/packages/core/test/report.dumpRestore.test.ts
+++ b/packages/core/test/report.dumpRestore.test.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { createWriteStream, existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -19,6 +19,20 @@ import { AllureReport } from "../src/report.js";
 import { PERF_METRIC_NAMES, perfMetricsFileName, resetPerfMetrics } from "../src/utils/perf.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const ARTIFACTS_MANIFEST_FILENAME = "artifacts.json";
+
+const outsideCwdManifestPath = (filePath: string): string => `<outside-cwd>/${basename(filePath)}`;
+
+const readArtifactsManifest = async (output: string) => {
+  return JSON.parse(await readFile(join(output, ARTIFACTS_MANIFEST_FILENAME), "utf8")) as {
+    schemaVersion: 1;
+    dumps: { path: string; status: string; error?: string }[];
+    globalAttachments: {
+      patterns: string[];
+      files: { name: string; path: string }[];
+    };
+  };
+};
 
 const readPerfMetrics = async (output: string, reportUuid: string) =>
   JSON.parse(await readFile(join(output, perfMetricsFileName(reportUuid)), "utf8"));
@@ -136,6 +150,138 @@ describe("AllureReport.restoreState (dump zip)", () => {
 
     await step("restore a dump with a safe attachment entry", async () => {
       await expect(report.restoreState([zipPath])).resolves.toBeUndefined();
+    });
+  });
+
+  it("writes a local artifacts manifest for restored dump files", async () => {
+    const dir = await tempDir();
+    const zipPath = join(dir, "state.zip");
+    const output = join(dir, "report");
+
+    await writeDumpZip(zipPath, []);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+      },
+      { plugins: {} },
+    );
+    const report = new AllureReport(config);
+
+    await report.restoreState([zipPath]);
+    await report.start();
+    await report.done();
+
+    await expect(readArtifactsManifest(output)).resolves.toEqual({
+      schemaVersion: 1,
+      dumps: [
+        {
+          path: outsideCwdManifestPath(zipPath),
+          status: "restored",
+        },
+      ],
+      globalAttachments: {
+        patterns: [],
+        files: [],
+      },
+    });
+  });
+
+  it("records missing and failed dump restore attempts in the local artifacts manifest", async () => {
+    const dir = await tempDir();
+    const missingZipPath = join(dir, "missing.zip");
+    const brokenZipPath = join(dir, "broken.zip");
+    const validZipPath = join(dir, "valid.zip");
+    const output = join(dir, "report");
+    const consoleErrorSpy = vi.spyOn(nodeConsole, "error").mockImplementation(() => {});
+
+    await writeZip(brokenZipPath, [
+      {
+        name: AllureStoreDumpFiles.TestResults,
+        data: Buffer.from("{}", "utf8"),
+      },
+    ]);
+    await writeDumpZip(validZipPath, []);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+      },
+      { plugins: {} },
+    );
+    const report = new AllureReport(config);
+
+    try {
+      await report.restoreState([missingZipPath, brokenZipPath, validZipPath]);
+      await report.start();
+      await report.done();
+
+      const manifest = await readArtifactsManifest(output);
+
+      expect(manifest.dumps).toEqual([
+        {
+          path: outsideCwdManifestPath(missingZipPath),
+          status: "missing",
+          error: "Dump file does not exist",
+        },
+        {
+          path: outsideCwdManifestPath(brokenZipPath),
+          status: "failed",
+          error: expect.stringContaining("Missing required dump entry"),
+        },
+        {
+          path: outsideCwdManifestPath(validZipPath),
+          status: "restored",
+        },
+      ]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("records nested dump archives in the local artifacts manifest", async () => {
+    const dir = await tempDir();
+    const nestedZipPath = join(dir, "nested.zip");
+    const outerZipPath = join(dir, "artifact.zip");
+    const output = join(dir, "report");
+    const nestedEntryName = "allure-results-macos-latest.zip";
+
+    await writeDumpZip(nestedZipPath, []);
+    await writeZip(outerZipPath, [
+      {
+        name: nestedEntryName,
+        data: await readFile(nestedZipPath),
+      },
+    ]);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+      },
+      { plugins: {} },
+    );
+    const report = new AllureReport(config);
+
+    await report.restoreState([outerZipPath]);
+    await report.start();
+    await report.done();
+
+    const outerManifestPath = outsideCwdManifestPath(outerZipPath);
+
+    await expect(readArtifactsManifest(output)).resolves.toMatchObject({
+      dumps: [
+        {
+          path: outerManifestPath,
+          status: "expanded",
+        },
+        {
+          path: `${outerManifestPath}!/${nestedEntryName}`,
+          status: "restored",
+        },
+      ],
     });
   });
 

--- a/packages/core/test/report.dumpRestore.test.ts
+++ b/packages/core/test/report.dumpRestore.test.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { createWriteStream, existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -21,17 +21,13 @@ import { PERF_METRIC_NAMES, perfMetricsFileName, resetPerfMetrics } from "../src
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ARTIFACTS_MANIFEST_FILENAME = "artifacts.json";
 
-const outsideCwdManifestPath = (filePath: string): string => `<outside-cwd>/${basename(filePath)}`;
+const manifestPath = (cwd: string, filePath: string): string => relative(cwd, filePath).split(sep).join("/");
 
 const readArtifactsManifest = async (output: string) => {
   return JSON.parse(await readFile(join(output, ARTIFACTS_MANIFEST_FILENAME), "utf8")) as {
-    schemaVersion: 1;
-    dumps: { path: string; status: string; error?: string }[];
-    globalAttachments: {
-      patterns: string[];
-      files: { name: string; path: string }[];
-    };
-  };
+    name: string;
+    path: string;
+  }[];
 };
 
 const readPerfMetrics = async (output: string, reportUuid: string) =>
@@ -118,8 +114,14 @@ beforeEach(async () => {
 describe("AllureReport.restoreState (dump zip)", () => {
   const zipPaths: string[] = [];
   const tempDirs: string[] = [];
+  let previousCwd: string;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+  });
 
   afterEach(async () => {
+    process.chdir(previousCwd);
     vi.restoreAllMocks();
     delete process.env.ALLURE_PERF_METRICS;
     resetPerfMetrics();
@@ -159,13 +161,14 @@ describe("AllureReport.restoreState (dump zip)", () => {
     const output = join(dir, "report");
 
     await writeDumpZip(zipPath, []);
+    process.chdir(dir);
 
     const config = await resolveConfig(
       {
         name: "Allure Report",
         output,
       },
-      { plugins: {} },
+      { cwd: dir, plugins: {} },
     );
     const report = new AllureReport(config);
 
@@ -173,22 +176,79 @@ describe("AllureReport.restoreState (dump zip)", () => {
     await report.start();
     await report.done();
 
-    await expect(readArtifactsManifest(output)).resolves.toEqual({
-      schemaVersion: 1,
-      dumps: [
-        {
-          path: outsideCwdManifestPath(zipPath),
-          status: "restored",
-        },
-      ],
-      globalAttachments: {
-        patterns: [],
-        files: [],
+    await expect(readArtifactsManifest(output)).resolves.toEqual([
+      {
+        name: "state.zip",
+        path: "state.zip",
       },
-    });
+    ]);
   });
 
-  it("records missing and failed dump restore attempts in the local artifacts manifest", async () => {
+  it("writes dump paths outside the generation cwd as relative paths", async () => {
+    const cwd = await tempDir();
+    const outsideDir = await tempDir();
+    const zipPath = join(outsideDir, "state.zip");
+    const output = join(cwd, "report");
+
+    await writeDumpZip(zipPath, []);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+      },
+      { cwd, plugins: {} },
+    );
+    const report = new AllureReport(config);
+
+    await report.restoreState([zipPath]);
+    await report.start();
+    await report.done();
+
+    await expect(readArtifactsManifest(output)).resolves.toEqual([
+      {
+        name: "state.zip",
+        path: manifestPath(cwd, zipPath),
+      },
+    ]);
+  });
+
+  it("deduplicates dump files before restoring them", async () => {
+    const dir = await tempDir();
+    const zipPath = join(dir, "state.zip");
+    const output = join(dir, "report");
+    const consoleInfoSpy = vi.spyOn(nodeConsole, "info").mockImplementation(() => {});
+
+    await writeDumpZip(zipPath, []);
+    process.chdir(dir);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+      },
+      { cwd: dir, plugins: {} },
+    );
+    const report = new AllureReport(config);
+
+    try {
+      await report.restoreState([zipPath, zipPath]);
+      await report.start();
+      await report.done();
+
+      await expect(readArtifactsManifest(output)).resolves.toEqual([
+        {
+          name: "state.zip",
+          path: "state.zip",
+        },
+      ]);
+      expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleInfoSpy.mockRestore();
+    }
+  });
+
+  it("omits missing and failed dump restore attempts from the local artifacts manifest", async () => {
     const dir = await tempDir();
     const missingZipPath = join(dir, "missing.zip");
     const brokenZipPath = join(dir, "broken.zip");
@@ -203,13 +263,14 @@ describe("AllureReport.restoreState (dump zip)", () => {
       },
     ]);
     await writeDumpZip(validZipPath, []);
+    process.chdir(dir);
 
     const config = await resolveConfig(
       {
         name: "Allure Report",
         output,
       },
-      { plugins: {} },
+      { cwd: dir, plugins: {} },
     );
     const report = new AllureReport(config);
 
@@ -220,20 +281,10 @@ describe("AllureReport.restoreState (dump zip)", () => {
 
       const manifest = await readArtifactsManifest(output);
 
-      expect(manifest.dumps).toEqual([
+      expect(manifest).toEqual([
         {
-          path: outsideCwdManifestPath(missingZipPath),
-          status: "missing",
-          error: "Dump file does not exist",
-        },
-        {
-          path: outsideCwdManifestPath(brokenZipPath),
-          status: "failed",
-          error: expect.stringContaining("Missing required dump entry"),
-        },
-        {
-          path: outsideCwdManifestPath(validZipPath),
-          status: "restored",
+          name: "valid.zip",
+          path: "valid.zip",
         },
       ]);
     } finally {
@@ -255,13 +306,14 @@ describe("AllureReport.restoreState (dump zip)", () => {
         data: await readFile(nestedZipPath),
       },
     ]);
+    process.chdir(dir);
 
     const config = await resolveConfig(
       {
         name: "Allure Report",
         output,
       },
-      { plugins: {} },
+      { cwd: dir, plugins: {} },
     );
     const report = new AllureReport(config);
 
@@ -269,20 +321,12 @@ describe("AllureReport.restoreState (dump zip)", () => {
     await report.start();
     await report.done();
 
-    const outerManifestPath = outsideCwdManifestPath(outerZipPath);
-
-    await expect(readArtifactsManifest(output)).resolves.toMatchObject({
-      dumps: [
-        {
-          path: outerManifestPath,
-          status: "expanded",
-        },
-        {
-          path: `${outerManifestPath}!/${nestedEntryName}`,
-          status: "restored",
-        },
-      ],
-    });
+    await expect(readArtifactsManifest(output)).resolves.toEqual([
+      {
+        name: "artifact.zip",
+        path: manifestPath(dir, outerZipPath),
+      },
+    ]);
   });
 
   it("writes opt-in dump restore perf metrics", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -1,7 +1,7 @@
 import console from "node:console";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, sep } from "node:path";
+import { join, relative, sep } from "node:path";
 import { setTimeout } from "node:timers/promises";
 
 import type { TestResult } from "@allurereport/core-api";
@@ -33,17 +33,13 @@ const allureServiceConfig = (overrides: Partial<typeof defaultUploadConfig> = {}
   ...overrides,
 });
 
-const normalizeManifestPath = (filePath: string): string => filePath.split(sep).join("/");
+const manifestPath = (cwd: string, filePath: string): string => relative(cwd, filePath).split(sep).join("/");
 
 const readArtifactsManifest = async (output: string) => {
   return JSON.parse(await readFile(join(output, ARTIFACTS_MANIFEST_FILENAME), "utf8")) as {
-    schemaVersion: 1;
-    dumps: { path: string; status: string; error?: string }[];
-    globalAttachments: {
-      patterns: string[];
-      files: { name: string; path: string }[];
-    };
-  };
+    name: string;
+    path: string;
+  }[];
 };
 
 vi.mock("@allurereport/service", async (importOriginal) => {
@@ -1142,12 +1138,7 @@ describe("report", () => {
     await allureReport.start();
     await allureReport.done();
 
-    await expect(readArtifactsManifest(output)).resolves.toMatchObject({
-      globalAttachments: {
-        patterns: ["*.log"],
-        files: [{ name: "workflow.log", path: "workflow.log" }],
-      },
-    });
+    await expect(readArtifactsManifest(output)).resolves.toEqual([{ name: "workflow.log", path: "workflow.log" }]);
     expect(AllureServiceClientMock.prototype.uploadReport).toHaveBeenCalled();
     for (const [params] of (AllureServiceClientMock.prototype.uploadReport as Mock).mock.calls) {
       expect(params.files).not.toHaveProperty(ARTIFACTS_MANIFEST_FILENAME);
@@ -1522,7 +1513,7 @@ describe("report", () => {
     expect((attachments[0] as unknown as Attachment)?.name).toBe("duplicated.log");
   });
 
-  it("should ignore absolute global attachments outside working directory", async () => {
+  it("should attach absolute global attachments outside working directory", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "allure3-global-attachments-cwd-"));
     const outsideDir = await mkdtemp(join(tmpdir(), "allure3-global-attachments-outside-"));
     const insideFile = join(cwd, "inside.log");
@@ -1538,8 +1529,6 @@ describe("report", () => {
       globalAttachments: [outsideFile, "*.log"],
     });
 
-    expect(isAbsolute(outsideFile)).toBe(true);
-
     const allureReport = new AllureReport(config);
 
     await allureReport.start();
@@ -1547,11 +1536,10 @@ describe("report", () => {
     const attachments = await allureReport.store.allGlobalAttachments();
     const names = attachments.map((a) => (a as unknown as Attachment).name).sort();
 
-    expect(names).toEqual(["inside.log"]);
-    expect(names).not.toContain("outside.log");
+    expect(names).toEqual(["inside.log", "outside.log"]);
   });
 
-  it("should ignore possibly sensitive files outside working directory", async () => {
+  it("should attach explicitly configured files outside working directory", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "allure3-global-attachments-sensitive-cwd-"));
     const outsideRoot = await mkdtemp(join(tmpdir(), "allure3-global-attachments-sensitive-outside-"));
     const insideFile = join(cwd, "artifacts", "safe.txt");
@@ -1576,8 +1564,7 @@ describe("report", () => {
     const attachments = await allureReport.store.allGlobalAttachments();
     const names = attachments.map((a) => (a as unknown as Attachment).name).sort();
 
-    expect(names).toEqual(["safe.txt"]);
-    expect(names).not.toContain("token.txt");
+    expect(names).toEqual(["safe.txt", "token.txt"]);
   });
 
   it("should write global attachments to the local artifacts manifest", async () => {
@@ -1602,7 +1589,7 @@ describe("report", () => {
         output,
         globalAttachments,
       },
-      { plugins: {} },
+      { cwd, plugins: {} },
     );
     const allureReport = new AllureReport(config);
 
@@ -1611,8 +1598,11 @@ describe("report", () => {
 
     const manifest = await readArtifactsManifest(output);
 
-    expect(manifest.globalAttachments.patterns).toEqual(globalAttachments);
-    expect(manifest.globalAttachments.files.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
+    expect(manifest.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
+      {
+        name: "outside.log",
+        path: manifestPath(cwd, outsideFile),
+      },
       {
         name: "nested.txt",
         path: "artifacts/nested.txt",
@@ -1622,7 +1612,6 @@ describe("report", () => {
         path: "global.log",
       },
     ]);
-    expect(manifest.globalAttachments.files.map(({ path }) => path)).not.toContain(normalizeManifestPath(outsideFile));
   });
 
   it("should not fail when the local artifacts manifest cannot be written", async () => {

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -1,7 +1,7 @@
 import console from "node:console";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, sep } from "node:path";
 import { setTimeout } from "node:timers/promises";
 
 import type { TestResult } from "@allurereport/core-api";
@@ -26,11 +26,25 @@ const defaultUploadConfig = {
   uploadMaxAttempts: 5,
   uploadMaxSimultaneousFailures: 5,
 };
+const ARTIFACTS_MANIFEST_FILENAME = "artifacts.json";
 const allureServiceConfig = (overrides: Partial<typeof defaultUploadConfig> = {}) => ({
   accessToken: validAccessToken,
   ...defaultUploadConfig,
   ...overrides,
 });
+
+const normalizeManifestPath = (filePath: string): string => filePath.split(sep).join("/");
+
+const readArtifactsManifest = async (output: string) => {
+  return JSON.parse(await readFile(join(output, ARTIFACTS_MANIFEST_FILENAME), "utf8")) as {
+    schemaVersion: 1;
+    dumps: { path: string; status: string; error?: string }[];
+    globalAttachments: {
+      patterns: string[];
+      files: { name: string; path: string }[];
+    };
+  };
+};
 
 vi.mock("@allurereport/service", async (importOriginal) => {
   const utils = await import("./utils.js");
@@ -1104,6 +1118,66 @@ describe("report", () => {
     expect(uploadedRootFiles).toEqual([{ "test-results.json": expect.any(String) }]);
   });
 
+  it("should keep the local artifacts manifest out of remote report uploads", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "allure3-artifacts-manifest-upload-"));
+    const output = join(cwd, "report");
+    const attachment = join(cwd, "workflow.log");
+    const p1 = createPlugin("p1", true, { publish: true });
+
+    await writeFile(attachment, "workflow");
+    process.chdir(cwd);
+
+    const config = await resolveConfig({ name: "Allure Report", output, globalAttachments: ["*.log"] });
+
+    config.plugins = [p1];
+    (p1.plugin.done as Mock).mockImplementation(async (context) => {
+      await context.reportFiles.addFile("index.html", Buffer.from("index"));
+    });
+
+    const allureReport = new AllureReport({
+      ...config,
+      allureService: allureServiceConfig(),
+    });
+
+    await allureReport.start();
+    await allureReport.done();
+
+    await expect(readArtifactsManifest(output)).resolves.toMatchObject({
+      globalAttachments: {
+        patterns: ["*.log"],
+        files: [{ name: "workflow.log", path: "workflow.log" }],
+      },
+    });
+    expect(AllureServiceClientMock.prototype.uploadReport).toHaveBeenCalled();
+    for (const [params] of (AllureServiceClientMock.prototype.uploadReport as Mock).mock.calls) {
+      expect(params.files).not.toHaveProperty(ARTIFACTS_MANIFEST_FILENAME);
+    }
+  });
+
+  it("should not write an empty local artifacts manifest", async () => {
+    const output = await mkdtemp(join(tmpdir(), "allure3-empty-artifacts-manifest-"));
+    const p1 = createPlugin("p1");
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+      },
+      { plugins: {} },
+    );
+
+    config.plugins = [p1];
+    (p1.plugin.done as Mock).mockImplementation(async (context) => {
+      await context.reportFiles.addFile("index.html", Buffer.from("index"));
+    });
+
+    const allureReport = new AllureReport(config);
+
+    await allureReport.start();
+    await allureReport.done();
+
+    await expect(readFile(join(output, ARTIFACTS_MANIFEST_FILENAME), "utf8")).rejects.toThrow();
+  });
+
   const verifyUploadOptionsForwarding = async (uploadConcurrency?: number) => {
     const p1 = createPlugin("p1", true, { publish: true });
     const config = await resolveConfig({ name: "Allure Report" });
@@ -1504,6 +1578,87 @@ describe("report", () => {
 
     expect(names).toEqual(["safe.txt"]);
     expect(names).not.toContain("token.txt");
+  });
+
+  it("should write global attachments to the local artifacts manifest", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "allure3-global-attachments-manifest-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "allure3-global-attachments-manifest-outside-"));
+    const output = join(cwd, "report");
+    const first = join(cwd, "global.log");
+    const second = join(cwd, "artifacts", "nested.txt");
+    const outsideFile = join(outsideRoot, "outside.log");
+    const globalAttachments = ["*.log", "**/*.log", "artifacts/**/*.txt", outsideFile];
+
+    await writeFile(first, "first");
+    await mkdir(join(cwd, "artifacts"), { recursive: true });
+    await writeFile(second, "second");
+    await writeFile(outsideFile, "outside");
+
+    process.chdir(cwd);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+        globalAttachments,
+      },
+      { plugins: {} },
+    );
+    const allureReport = new AllureReport(config);
+
+    await allureReport.start();
+    await allureReport.done();
+
+    const manifest = await readArtifactsManifest(output);
+
+    expect(manifest.globalAttachments.patterns).toEqual(globalAttachments);
+    expect(manifest.globalAttachments.files.sort((a, b) => a.path.localeCompare(b.path))).toEqual([
+      {
+        name: "nested.txt",
+        path: "artifacts/nested.txt",
+      },
+      {
+        name: "global.log",
+        path: "global.log",
+      },
+    ]);
+    expect(manifest.globalAttachments.files.map(({ path }) => path)).not.toContain(normalizeManifestPath(outsideFile));
+  });
+
+  it("should not fail when the local artifacts manifest cannot be written", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "allure3-artifacts-manifest-write-failure-"));
+    const output = join(cwd, "report");
+    const attachment = join(cwd, "workflow.log");
+    const p1 = createPlugin("p1");
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await writeFile(attachment, "workflow");
+    process.chdir(cwd);
+
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+        globalAttachments: ["*.log"],
+      },
+      { plugins: {} },
+    );
+
+    config.plugins = [p1];
+    (p1.plugin.done as Mock).mockImplementation(async (context) => {
+      await mkdir(join(output, ARTIFACTS_MANIFEST_FILENAME), { recursive: true });
+      await context.reportFiles.addFile("index.html", Buffer.from("index"));
+    });
+
+    const allureReport = new AllureReport(config);
+
+    try {
+      await allureReport.start();
+      await expect(allureReport.done()).resolves.toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to write Allure artifacts manifest", expect.any(Error));
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("should coalesce realtime updates without dropping events", { timeout: 10000 }, async () => {


### PR DESCRIPTION
- Add a local-only `artifacts.json` manifest for report generation artifacts.
- Record dump restore outcomes, including missing, failed, restored, and nested expanded dumps.
- Record runtime-config global attachment patterns and matched in-cwd files.


#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
