### PR TITLE
fix(service): avoid double encoding params

### DIFF
--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -52,9 +52,9 @@ export class AllureServiceClient implements AllureServiceApiClient {
     const { repo, branch, limit } = payload ?? {};
     const { history } = await this.#client.get<{ history: HistoryDataPoint[] }>("/api/history", {
       params: {
-        limit: limit ? encodeURIComponent(limit) : undefined,
-        repo: repo ? encodeURIComponent(repo) : undefined,
-        branch: branch ? encodeURIComponent(branch) : undefined,
+        limit,
+        repo,
+        branch,
       },
     });
 

--- a/packages/service/test/history.test.ts
+++ b/packages/service/test/history.test.ts
@@ -95,8 +95,8 @@ describe("AllureRemoteHistory", () => {
       expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
         params: {
           limit: undefined,
-          repo: encodeURIComponent(fixtures.repo),
-          branch: encodeURIComponent(fixtures.branch),
+          repo: fixtures.repo,
+          branch: fixtures.branch,
         },
       });
       expect(result).toEqual([fixtures.historyDataPoint]);
@@ -139,9 +139,9 @@ describe("AllureRemoteHistory", () => {
 
       expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
         params: {
-          limit: "10",
-          repo: encodeURIComponent(fixtures.repo),
-          branch: encodeURIComponent(fixtures.branch),
+          limit: 10,
+          repo: fixtures.repo,
+          branch: fixtures.branch,
         },
       });
       expect(result).toEqual([fixtures.historyDataPoint]);
@@ -155,8 +155,8 @@ describe("AllureRemoteHistory", () => {
       expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
         params: {
           limit: undefined,
-          repo: encodeURIComponent(fixtures.repo),
-          branch: encodeURIComponent("feature"),
+          repo: fixtures.repo,
+          branch: "feature",
         },
       });
       expect(result).toEqual([fixtures.historyDataPoint]);
@@ -170,8 +170,8 @@ describe("AllureRemoteHistory", () => {
       expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
         params: {
           limit: undefined,
-          repo: encodeURIComponent("other-repo"),
-          branch: encodeURIComponent("feature"),
+          repo: "other-repo",
+          branch: "feature",
         },
       });
       expect(result).toEqual([fixtures.historyDataPoint]);

--- a/packages/service/test/service.test.ts
+++ b/packages/service/test/service.test.ts
@@ -151,8 +151,8 @@ describe("AllureServiceClient", () => {
       expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
         params: {
           limit: undefined,
-          repo: encodeURIComponent(fixtures.repo),
-          branch: encodeURIComponent(fixtures.branch),
+          repo: fixtures.repo,
+          branch: fixtures.branch,
         },
       });
       expect(res).toEqual([fixtures.history]);
@@ -169,29 +169,12 @@ describe("AllureServiceClient", () => {
 
       expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
         params: {
-          limit: "10",
-          repo: encodeURIComponent(fixtures.repo),
-          branch: encodeURIComponent(fixtures.branch),
+          limit: 10,
+          repo: fixtures.repo,
+          branch: fixtures.branch,
         },
       });
       expect(res).toEqual([fixtures.history]);
-    });
-
-    it("should encode branch name in URL", async () => {
-      HttpClientMock.prototype.get.mockResolvedValue({ history: [] });
-
-      await serviceClient.downloadHistory({
-        repo: fixtures.repo,
-        branch: "feature/test-branch",
-      });
-
-      expect(HttpClientMock.prototype.get).toHaveBeenCalledWith("/api/history", {
-        params: {
-          limit: undefined,
-          repo: encodeURIComponent(fixtures.repo),
-          branch: encodeURIComponent("feature/test-branch"),
-        },
-      });
     });
   });
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

Closes #899 

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Axios does all encoding, no need to do it

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
