### PR TITLE
Disable Publish PR reports for fork PR and pack TestOps CI overrides

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
     needs: [lint, test]
     name: Build report
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && contains(fromJSON('["success","failure"]'), needs.test.result) && needs.lint.result != 'failure' }}
+    if: ${{ always() && !cancelled() && contains(fromJSON('["success","failure"]'), needs.test.result) && needs.lint.result != 'failure' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/update-allure-bundle-baseline-command.yml
+++ b/.github/workflows/update-allure-bundle-baseline-command.yml
@@ -56,18 +56,9 @@ jobs:
 
           pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
           state="$(printf '%s' "${pr_json}" | jq -r '.state')"
-          head_repo="$(printf '%s' "${pr_json}" | jq -r '.head.repo.full_name // empty')"
-          is_fork="$(printf '%s' "${pr_json}" | jq -r '.head.repo.fork // true')"
 
           if [[ "${state}" != "open" ]]; then
             message="Cannot update baseline: PR #${PR_NUMBER} is not open (state=${state})."
-            echo "::error::${message}"
-            gh pr comment "${PR_NUMBER}" --body "${message}" || true
-            exit 0
-          fi
-
-          if [[ "${head_repo}" != "${GITHUB_REPOSITORY}" || "${is_fork}" == "true" ]]; then
-            message="Cannot update baseline on fork PRs. Push a baseline commit from the fork, or re-open as a same-repo branch."
             echo "::error::${message}"
             gh pr comment "${PR_NUMBER}" --body "${message}" || true
             exit 0

--- a/.github/workflows/update-allure-bundle-baseline.yml
+++ b/.github/workflows/update-allure-bundle-baseline.yml
@@ -19,8 +19,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: update-bundle-baseline-${{ inputs.pr_number }}
@@ -30,11 +28,17 @@ jobs:
   gate:
     name: Validate request
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       head_ref: ${{ steps.resolve.outputs.head_ref }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
+      head_repo: ${{ steps.resolve.outputs.head_repo }}
+      can_push: ${{ steps.resolve.outputs.can_push }}
       actor: ${{ steps.resolve.outputs.actor }}
     steps:
       - name: Resolve PR and authorize
@@ -81,12 +85,15 @@ jobs:
             exit 0
           fi
 
-          if [[ "${head_repo}" != "${GITHUB_REPOSITORY}" || "${is_fork}" == "true" ]]; then
-            message="Cannot update baseline on fork PRs. Push a baseline commit from the fork, or re-open as a same-repo branch."
-            echo "::error::${message}"
-            gh pr comment "${PR_NUMBER}" --body "${message}" || true
-            echo "should_run=false" >> "${GITHUB_OUTPUT}"
-            exit 0
+          if [[ -z "${head_repo}" ]]; then
+            echo "::error::Cannot resolve the head repository for PR #${PR_NUMBER}."
+            exit 1
+          fi
+
+          if [[ "${head_repo}" == "${GITHUB_REPOSITORY}" && "${is_fork}" != "true" ]]; then
+            can_push=true
+          else
+            can_push=false
           fi
 
           {
@@ -94,16 +101,21 @@ jobs:
             echo "pr_number=${PR_NUMBER}"
             echo "head_ref=${head_ref}"
             echo "head_sha=${head_sha}"
+            echo "head_repo=${head_repo}"
+            echo "can_push=${can_push}"
             echo "actor=${REQUESTER}"
           } >> "${GITHUB_OUTPUT}"
 
-          echo "Authorized @${REQUESTER} for PR #${PR_NUMBER} (${head_ref}@${head_sha})"
+          echo "Authorized @${REQUESTER} for PR #${PR_NUMBER} (${head_repo}:${head_ref}@${head_sha}, can_push=${can_push})"
 
   measure:
     name: Measure and write baseline
     needs: gate
     if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     container:
       image: node:24-bookworm
     outputs:
@@ -121,6 +133,7 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
+          repository: ${{ needs.gate.outputs.head_repo }}
           ref: ${{ needs.gate.outputs.head_sha }}
           persist-credentials: false
 
@@ -201,11 +214,54 @@ jobs:
             echo "delta_total_mb=$(signed_mb "${delta_total_mb}")"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Stage baseline artifact
+      - name: Validate and stage baseline artifact
         if: steps.measure.outputs.changed == 'true'
         run: |
-          mkdir -p .ci-artifacts
-          cp .github/allure-bundle-size.baseline.json .ci-artifacts/allure-bundle-size.baseline.json
+          set -euo pipefail
+
+          command -v jq >/dev/null || (apt-get update -qq && apt-get install -y -qq jq >/dev/null)
+
+          SRC=".github/allure-bundle-size.baseline.json"
+          DEST_DIR=".ci-artifacts"
+          DEST="${DEST_DIR}/allure-bundle-size.baseline.json"
+
+          if [[ ! -f "${SRC}" || -L "${SRC}" ]]; then
+            echo "::error::The updated baseline must be one regular JSON file."
+            exit 1
+          fi
+
+          if [[ "$(wc -c < "${SRC}" | tr -d ' ')" -gt 4096 ]]; then
+            echo "::error::The updated baseline is unexpectedly large."
+            exit 1
+          fi
+
+          jq -e '
+            type == "object" and
+            (keys | sort) == ([
+              "depsBytes",
+              "internalClosureCount",
+              "measuredAt",
+              "rootPackage",
+              "selfBytes",
+              "totalBytes"
+            ] | sort) and
+            .rootPackage == "allure" and
+            (.measuredAt | type == "string") and
+            (.internalClosureCount | type == "number" and floor == . and . >= 0) and
+            (.selfBytes | type == "number" and floor == . and . >= 0) and
+            (.depsBytes | type == "number" and floor == . and . >= 0) and
+            (.totalBytes | type == "number" and floor == . and . >= 0) and
+            .totalBytes == (.selfBytes + .depsBytes)
+          ' "${SRC}" >/dev/null
+
+          rm -rf "${DEST_DIR}"
+          mkdir -p "${DEST_DIR}"
+          jq '.' "${SRC}" > "${DEST}"
+
+          if [[ "$(find "${DEST_DIR}" -type f | wc -l | tr -d ' ')" != "1" ]]; then
+            echo "::error::The baseline artifact contains unexpected files."
+            exit 1
+          fi
 
       - name: Upload updated baseline
         if: steps.measure.outputs.changed == 'true'
@@ -232,6 +288,8 @@ jobs:
       needs.gate.outputs.should_run == 'true' &&
       needs.measure.result == 'failure'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Comment failure
         env:
@@ -253,8 +311,11 @@ jobs:
   commit:
     name: Commit baseline to PR branch
     needs: [gate, measure]
-    if: needs.gate.outputs.should_run == 'true'
+    if: needs.gate.outputs.should_run == 'true' && needs.gate.outputs.can_push == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Comment when baseline unchanged
         if: needs.measure.outputs.changed != 'true'
@@ -338,6 +399,49 @@ jobs:
           name: updated-allure-bundle-size-baseline
           path: .ci-artifacts
 
+      - name: Validate updated baseline
+        if: needs.measure.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+
+          BASELINE_PATH=".ci-artifacts/allure-bundle-size.baseline.json"
+          if [[ ! -f "${BASELINE_PATH}" || -L "${BASELINE_PATH}" ]]; then
+            echo "::error::The baseline artifact must contain one regular JSON file."
+            exit 1
+          fi
+
+          if [[ "$(find .ci-artifacts -type f | wc -l | tr -d ' ')" != "1" ]]; then
+            echo "::error::The baseline artifact contains unexpected files."
+            exit 1
+          fi
+
+          if [[ "$(wc -c < "${BASELINE_PATH}" | tr -d ' ')" -gt 4096 ]]; then
+            echo "::error::The baseline artifact is unexpectedly large."
+            exit 1
+          fi
+
+          jq -e '
+            type == "object" and
+            (keys | sort) == ([
+              "depsBytes",
+              "internalClosureCount",
+              "measuredAt",
+              "rootPackage",
+              "selfBytes",
+              "totalBytes"
+            ] | sort) and
+            .rootPackage == "allure" and
+            (.measuredAt | type == "string") and
+            (.internalClosureCount | type == "number" and floor == . and . >= 0) and
+            (.selfBytes | type == "number" and floor == . and . >= 0) and
+            (.depsBytes | type == "number" and floor == . and . >= 0) and
+            (.totalBytes | type == "number" and floor == . and . >= 0) and
+            .totalBytes == (.selfBytes + .depsBytes)
+          ' "${BASELINE_PATH}" >/dev/null
+
+          jq '.' "${BASELINE_PATH}" > "${BASELINE_PATH}.validated"
+          mv "${BASELINE_PATH}.validated" "${BASELINE_PATH}"
+
       - name: Commit and push baseline
         id: push
         if: needs.measure.outputs.changed == 'true'
@@ -357,6 +461,11 @@ jobs:
           git config user.email "${GIT_COMMIT_AUTHOR_EMAIL}"
 
           git add -- .github/allure-bundle-size.baseline.json
+          if [[ "$(git diff --cached --name-only)" != ".github/allure-bundle-size.baseline.json" ]]; then
+            echo "::error::Unexpected files were staged for the baseline update."
+            exit 1
+          fi
+
           if git diff --cached --quiet; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -425,5 +534,92 @@ jobs:
           | Total | ${BEFORE_TOTAL} MB | ${AFTER_TOTAL} MB | ${DELTA_TOTAL} MB |
 
           Triggered by @${ACTOR} via \`/update-bundle-baseline\`.
+          EOF
+          )"
+
+  handoff-fork:
+    name: Provide baseline update for fork PR
+    needs: [gate, measure]
+    if: >
+      needs.gate.outputs.should_run == 'true' &&
+      needs.gate.outputs.can_push != 'true' &&
+      needs.measure.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Verify PR head has not moved
+        id: verify-head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+          EXPECTED_SHA: ${{ needs.gate.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          current_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          if [[ "${current_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "current=false" >> "${GITHUB_OUTPUT}"
+            gh pr comment "${PR_NUMBER}" --body "The PR head moved after the bundle-size measurement. Please run \`/update-bundle-baseline\` again."
+            exit 0
+          fi
+
+          echo "current=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Comment when baseline unchanged
+        if: steps.verify-head.outputs.current == 'true' && needs.measure.outputs.changed != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+          ACTOR: ${{ needs.gate.outputs.actor }}
+          SELF: ${{ needs.measure.outputs.after_self_mb }}
+          DEPS: ${{ needs.measure.outputs.after_deps_mb }}
+          TOTAL: ${{ needs.measure.outputs.after_total_mb }}
+        run: |
+          set -euo pipefail
+          gh pr comment "${PR_NUMBER}" --body "$(cat <<EOF
+          Baseline already matches the current measurement for this PR head.
+
+          | Metric | Size |
+          | --- | ---: |
+          | Allure code | ${SELF} MB |
+          | Deps | ${DEPS} MB |
+          | Total | ${TOTAL} MB |
+
+          Requested by @${ACTOR}.
+          EOF
+          )"
+
+      - name: Comment with fork update instructions
+        if: steps.verify-head.outputs.current == 'true' && needs.measure.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+          ACTOR: ${{ needs.gate.outputs.actor }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BEFORE_SELF: ${{ needs.measure.outputs.before_self_mb }}
+          BEFORE_DEPS: ${{ needs.measure.outputs.before_deps_mb }}
+          BEFORE_TOTAL: ${{ needs.measure.outputs.before_total_mb }}
+          AFTER_SELF: ${{ needs.measure.outputs.after_self_mb }}
+          AFTER_DEPS: ${{ needs.measure.outputs.after_deps_mb }}
+          AFTER_TOTAL: ${{ needs.measure.outputs.after_total_mb }}
+          DELTA_SELF: ${{ needs.measure.outputs.delta_self_mb }}
+          DELTA_DEPS: ${{ needs.measure.outputs.delta_deps_mb }}
+          DELTA_TOTAL: ${{ needs.measure.outputs.delta_total_mb }}
+        run: |
+          set -euo pipefail
+          gh pr comment "${PR_NUMBER}" --body "$(cat <<EOF
+          Measured an updated Allure bundle size baseline for this fork PR at \`${HEAD_SHA}\`.
+
+          GitHub does not allow this workflow to push the update to a contributor-owned fork. Please download the \`updated-allure-bundle-size-baseline\` artifact from the [workflow run](${RUN_URL}), replace \`.github/allure-bundle-size.baseline.json\` with the downloaded file, and push the change to this PR branch.
+
+          | Metric | Before | After | Δ |
+          | --- | ---: | ---: | ---: |
+          | Allure code | ${BEFORE_SELF} MB | ${AFTER_SELF} MB | ${DELTA_SELF} MB |
+          | Deps | ${BEFORE_DEPS} MB | ${AFTER_DEPS} MB | ${DELTA_DEPS} MB |
+          | Total | ${BEFORE_TOTAL} MB | ${AFTER_TOTAL} MB | ${DELTA_TOTAL} MB |
+
+          Requested by @${ACTOR} via \`/update-bundle-baseline\`.
           EOF
           )"

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -63,6 +63,7 @@ const config = {
     testops: {
       options: {
         launchName: `Allure 3 GitHub actions run (${new Date().toISOString()})`,
+        gitFlow: true,
       },
     },
   },

--- a/packages/ci/src/detectors/github.ts
+++ b/packages/ci/src/detectors/github.ts
@@ -2,7 +2,7 @@ import { join } from "node:path/posix";
 
 import { type CiDescriptor, CiType, GitProvider } from "@allurereport/core-api";
 
-import { resolveGithubPullRequestNumber } from "../helpers/github.js";
+import { resolveGithubPullRequestContext, resolveGithubPullRequestNumber } from "../helpers/github.js";
 import { stripRefsHeads } from "../helpers/gitProvider.js";
 import { getEnv } from "../utils.js";
 
@@ -37,7 +37,23 @@ const getSourceBranch = (): string => {
     return headRef;
   }
 
+  const pullRequestHeadRef = resolveGithubPullRequestContext()?.headRef;
+
+  if (pullRequestHeadRef) {
+    return pullRequestHeadRef;
+  }
+
   return isTagRef() ? "" : getBranchFromRef();
+};
+
+const getTargetBranch = (): string => {
+  const baseRef = getEnv("GITHUB_BASE_REF");
+
+  if (baseRef) {
+    return baseRef;
+  }
+
+  return resolveGithubPullRequestContext()?.baseRef ?? "";
 };
 
 export const github: CiDescriptor = {
@@ -131,7 +147,7 @@ export const github: CiDescriptor = {
   },
 
   get targetBranch() {
-    return getEnv("GITHUB_BASE_REF") || undefined;
+    return getTargetBranch() || undefined;
   },
 
   get pullRequest() {

--- a/packages/ci/src/helpers/github.ts
+++ b/packages/ci/src/helpers/github.ts
@@ -5,11 +5,30 @@ import { getEnv } from "../utils.js";
 const PULL_REQUEST_REF_NAME_RE = /^(\d+)\/merge$/;
 const PULL_REQUEST_MERGE_REF_RE = /^refs\/pull\/(\d+)\/merge$/;
 
-type GithubPullRequestEvent = {
+type GithubPullRequestEventFields = {
   number?: number | string;
-  pull_request?: {
-    number?: number | string;
+  head?: {
+    ref?: string;
   };
+  base?: {
+    ref?: string;
+  };
+};
+
+type GithubEvent = {
+  number?: number | string;
+  pull_request?: GithubPullRequestEventFields;
+  workflow_run?: {
+    event?: string;
+    head_branch?: string;
+    pull_requests?: GithubPullRequestEventFields[];
+  };
+};
+
+export type GithubPullRequestContext = {
+  number: string;
+  headRef?: string;
+  baseRef?: string;
 };
 
 const normalizePullRequestNumber = (value: number | string | undefined): string => {
@@ -20,53 +39,96 @@ const normalizePullRequestNumber = (value: number | string | undefined): string 
   return String(value);
 };
 
-export const parsePullRequestNumberFromEventJson = (content: string): string => {
-  try {
-    const event = JSON.parse(content) as GithubPullRequestEvent;
+const nonBlank = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
 
-    return normalizePullRequestNumber(event?.number ?? event?.pull_request?.number);
+  return trimmed ? trimmed : undefined;
+};
+
+const contextFromPullRequestFields = (
+  pullRequest: GithubPullRequestEventFields | undefined,
+  fallbackNumber?: number | string,
+): GithubPullRequestContext | undefined => {
+  const number = normalizePullRequestNumber(pullRequest?.number ?? fallbackNumber);
+
+  if (!number) {
+    return undefined;
+  }
+
+  return {
+    number,
+    headRef: nonBlank(pullRequest?.head?.ref),
+    baseRef: nonBlank(pullRequest?.base?.ref),
+  };
+};
+
+export const parsePullRequestContextFromEventJson = (content: string): GithubPullRequestContext | undefined => {
+  try {
+    const event = JSON.parse(content) as GithubEvent;
+    const fromPullRequest = contextFromPullRequestFields(event.pull_request, event.number);
+
+    if (fromPullRequest) {
+      return fromPullRequest;
+    }
+
+    const workflowPullRequests = event.workflow_run?.pull_requests;
+
+    if (!Array.isArray(workflowPullRequests) || workflowPullRequests.length === 0) {
+      return undefined;
+    }
+
+    return contextFromPullRequestFields(workflowPullRequests[0]);
   } catch {
-    return "";
+    return undefined;
   }
 };
 
-const readPullRequestNumberFromEventPath = (): string => {
+export const parsePullRequestNumberFromEventJson = (content: string): string => {
+  return parsePullRequestContextFromEventJson(content)?.number ?? "";
+};
+
+const readPullRequestContextFromEventPath = (): GithubPullRequestContext | undefined => {
   const eventPath = getEnv("GITHUB_EVENT_PATH");
 
   if (!eventPath) {
-    return "";
+    return undefined;
   }
 
   try {
     const content = readFileSync(eventPath, "utf-8");
 
-    return parsePullRequestNumberFromEventJson(content);
+    return parsePullRequestContextFromEventJson(content);
   } catch {
-    return "";
+    return undefined;
   }
 };
 
-export const resolveGithubPullRequestNumber = (): string => {
+export const resolveGithubPullRequestContext = (): GithubPullRequestContext | undefined => {
   const refName = getEnv("GITHUB_REF_NAME") || "";
   const refNameMatch = refName.match(PULL_REQUEST_REF_NAME_RE);
 
   if (refNameMatch) {
-    return refNameMatch[1];
+    return {
+      number: refNameMatch[1],
+      headRef: nonBlank(getEnv("GITHUB_HEAD_REF")),
+      baseRef: nonBlank(getEnv("GITHUB_BASE_REF")),
+    };
   }
 
   const githubRef = getEnv("GITHUB_REF") || "";
   const mergeRefMatch = githubRef.match(PULL_REQUEST_MERGE_REF_RE);
 
   if (mergeRefMatch) {
-    return mergeRefMatch[1];
+    return {
+      number: mergeRefMatch[1],
+      headRef: nonBlank(getEnv("GITHUB_HEAD_REF")),
+      baseRef: nonBlank(getEnv("GITHUB_BASE_REF")),
+    };
   }
 
-  const headRef = getEnv("GITHUB_HEAD_REF");
-  const baseRef = getEnv("GITHUB_BASE_REF");
+  return readPullRequestContextFromEventPath();
+};
 
-  if (headRef && baseRef) {
-    return readPullRequestNumberFromEventPath();
-  }
-
-  return "";
+export const resolveGithubPullRequestNumber = (): string => {
+  return resolveGithubPullRequestContext()?.number ?? "";
 };

--- a/packages/ci/test/githubPullRequest.test.ts
+++ b/packages/ci/test/githubPullRequest.test.ts
@@ -2,7 +2,12 @@ import { readFileSync } from "node:fs";
 
 import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { parsePullRequestNumberFromEventJson, resolveGithubPullRequestNumber } from "../src/helpers/github.js";
+import {
+  parsePullRequestContextFromEventJson,
+  parsePullRequestNumberFromEventJson,
+  resolveGithubPullRequestContext,
+  resolveGithubPullRequestNumber,
+} from "../src/helpers/github.js";
 import { getEnv } from "../src/utils.js";
 
 vi.mock("../src/utils.js", () => ({
@@ -40,6 +45,76 @@ describe("parsePullRequestNumberFromEventJson", () => {
 
   it("returns empty string when pull_request.number is missing", () => {
     expect(parsePullRequestNumberFromEventJson(JSON.stringify({ pull_request: { title: "No number" } }))).toBe("");
+  });
+
+  it("returns pull request number from workflow_run.pull_requests", () => {
+    expect(
+      parsePullRequestNumberFromEventJson(
+        JSON.stringify({
+          workflow_run: {
+            event: "pull_request",
+            pull_requests: [{ number: 920, head: { ref: "feat/x" }, base: { ref: "main" } }],
+          },
+        }),
+      ),
+    ).toBe("920");
+  });
+});
+
+describe("parsePullRequestContextFromEventJson", () => {
+  it("returns head and base refs from pull_request payload", () => {
+    expect(
+      parsePullRequestContextFromEventJson(
+        JSON.stringify({
+          pull_request: {
+            number: 12,
+            head: { ref: "feature/foo" },
+            base: { ref: "main" },
+          },
+        }),
+      ),
+    ).toEqual({
+      number: "12",
+      headRef: "feature/foo",
+      baseRef: "main",
+    });
+  });
+
+  it("returns head and base refs from workflow_run.pull_requests", () => {
+    expect(
+      parsePullRequestContextFromEventJson(
+        JSON.stringify({
+          workflow_run: {
+            event: "pull_request",
+            head_branch: "feature/foo",
+            pull_requests: [
+              {
+                number: 33,
+                head: { ref: "feature/foo" },
+                base: { ref: "main" },
+              },
+            ],
+          },
+        }),
+      ),
+    ).toEqual({
+      number: "33",
+      headRef: "feature/foo",
+      baseRef: "main",
+    });
+  });
+
+  it("returns undefined when workflow_run.pull_requests is empty", () => {
+    expect(
+      parsePullRequestContextFromEventJson(
+        JSON.stringify({
+          workflow_run: {
+            event: "pull_request",
+            pull_requests: [],
+          },
+        }),
+      ),
+    ).toBeUndefined();
   });
 });
 
@@ -164,21 +239,30 @@ describe("resolveGithubPullRequestNumber", () => {
     expect(resolveGithubPullRequestNumber()).toBe("");
   });
 
-  it("returns empty string when only one of head/base refs is set", () => {
+  it("resolves pull request id from workflow_run event without head/base env refs", () => {
     (getEnv as Mock).mockImplementation((key: string) => {
-      if (key === "GITHUB_HEAD_REF") {
-        return "feature/foo";
-      }
+      const env: Record<string, string> = {
+        GITHUB_EVENT_PATH: "/tmp/event.json",
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_REF_NAME: "main",
+      };
 
-      if (key === "GITHUB_EVENT_PATH") {
-        return "/tmp/event.json";
-      }
-
-      return "";
+      return env[key] ?? "";
     });
-    (readFileSync as Mock).mockReturnValue(JSON.stringify({ pull_request: { number: 77 } }));
+    (readFileSync as Mock).mockReturnValue(
+      JSON.stringify({
+        workflow_run: {
+          event: "pull_request",
+          pull_requests: [{ number: 897, head: { ref: "fix/x" }, base: { ref: "main" } }],
+        },
+      }),
+    );
 
-    expect(resolveGithubPullRequestNumber()).toBe("");
-    expect(readFileSync).not.toHaveBeenCalled();
+    expect(resolveGithubPullRequestNumber()).toBe("897");
+    expect(resolveGithubPullRequestContext()).toEqual({
+      number: "897",
+      headRef: "fix/x",
+      baseRef: "main",
+    });
   });
 });

--- a/packages/plugin-testops/src/gitFlow/LaunchGitFlow.ts
+++ b/packages/plugin-testops/src/gitFlow/LaunchGitFlow.ts
@@ -2,6 +2,7 @@ import type { CiDescriptor } from "@allurereport/core-api";
 import { collectGitFacts, isGitAvailable } from "@allurereport/git";
 
 import type { Logger } from "../logger.js";
+import { applyGitFactsOverrides } from "../utils/ciOverrides.js";
 import { buildGitFlowContext, shouldAttachGitFlow } from "./context.js";
 import { projectLaunchGitContext, type ClassifiedGitFlowContext } from "./projection.js";
 import type { GitFlowContext, LaunchGitContextDto } from "./types.js";
@@ -31,12 +32,19 @@ export class LaunchGitFlow {
       return undefined;
     }
 
-    if (!isGitAvailable()) {
-      this.#logger.warn("git CLI is not available; continuing upload without git context");
+    const gitAvailable = isGitAvailable();
+    const collected = gitAvailable ? collectGitFacts({ ancestorLimit: this.#ancestorLimit }) : undefined;
+    const facts = applyGitFactsOverrides(collected);
+
+    if (!facts?.commit) {
+      if (!gitAvailable) {
+        this.#logger.warn("git CLI is not available; continuing upload without git context");
+      } else {
+        this.#logger.warn("Git Flow metadata could not be collected; continuing upload without git context");
+      }
       return undefined;
     }
 
-    const facts = collectGitFacts({ ancestorLimit: this.#ancestorLimit });
     const gitFlowContext = buildGitFlowContext({
       ci: this.#ci,
       facts,

--- a/packages/plugin-testops/src/utils/ciOverrides.ts
+++ b/packages/plugin-testops/src/utils/ciOverrides.ts
@@ -1,10 +1,21 @@
 import { env } from "node:process";
 
-import type { CiDescriptor } from "@allurereport/core-api";
+import { GitProvider, type CiDescriptor, type GitFacts, type GitPullRequestRef } from "@allurereport/core-api";
 
-type OverridableField = "jobUid" | "jobUrl" | "jobName" | "jobRunUid" | "jobRunUrl" | "jobRunName" | "jobRunBranch";
+type OverridableStringField =
+  | "jobUid"
+  | "jobUrl"
+  | "jobName"
+  | "jobRunUid"
+  | "jobRunUrl"
+  | "jobRunName"
+  | "jobRunBranch"
+  | "sourceBranch"
+  | "targetBranch"
+  | "pullRequestName"
+  | "pullRequestUrl";
 
-const OVERRIDABLE_FIELDS: readonly [OverridableField, string][] = [
+const OVERRIDABLE_STRING_FIELDS: readonly [OverridableStringField, string][] = [
   ["jobUid", "ALLURE_JOB_UID"],
   ["jobUrl", "ALLURE_JOB_URL"],
   ["jobName", "ALLURE_JOB_NAME"],
@@ -12,18 +23,176 @@ const OVERRIDABLE_FIELDS: readonly [OverridableField, string][] = [
   ["jobRunUrl", "ALLURE_JOB_RUN_URL"],
   ["jobRunName", "ALLURE_JOB_RUN_NAME"],
   ["jobRunBranch", "ALLURE_JOB_RUN_BRANCH"],
+  ["sourceBranch", "ALLURE_CI_SOURCE_BRANCH"],
+  ["targetBranch", "ALLURE_CI_TARGET_BRANCH"],
+  ["pullRequestName", "ALLURE_CI_PULL_REQUEST_TITLE"],
+  ["pullRequestUrl", "ALLURE_CI_PULL_REQUEST_URL"],
 ];
 
-export const applyCiOverrides = (ci: CiDescriptor): CiDescriptor => {
-  const overrides: Partial<Record<OverridableField, string>> = {};
+const GIT_PROVIDER_VALUES = new Set<string>(Object.values(GitProvider));
 
-  for (const [field, envVar] of OVERRIDABLE_FIELDS) {
-    const value = env[envVar];
+const nonBlank = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+
+  return trimmed ? trimmed : undefined;
+};
+
+const parseGitProvider = (value: string | undefined): GitProvider | undefined => {
+  const normalized = nonBlank(value)?.toLowerCase();
+
+  if (!normalized || !GIT_PROVIDER_VALUES.has(normalized)) {
+    return undefined;
+  }
+
+  return normalized as GitProvider;
+};
+
+const parseFirstParentAncestors = (value: string | undefined): string[] | undefined => {
+  const raw = nonBlank(value);
+
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  return raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+};
+
+/**
+ * Merges PR id/url/title when an id is available (env or existing).
+ * Returns undefined when no id exists — caller must not replace `ci.pullRequest`.
+ */
+const resolvePullRequestOverride = (ci: CiDescriptor): GitPullRequestRef | undefined => {
+  const id = nonBlank(env.ALLURE_CI_PULL_REQUEST_ID) ?? nonBlank(ci.pullRequest?.id);
+  const url = nonBlank(env.ALLURE_CI_PULL_REQUEST_URL) ?? ci.pullRequest?.url;
+  const title = nonBlank(env.ALLURE_CI_PULL_REQUEST_TITLE) ?? ci.pullRequest?.title;
+
+  if (!id) {
+    return undefined;
+  }
+
+  return {
+    id,
+    url,
+    title,
+  };
+};
+
+/**
+ * Builds repository override from slug and/or URL env.
+ * Slug comes only from `ALLURE_CI_REPOSITORY_SLUG` or existing `ci.repository.slug`
+ * (never from repoName). Without a resolvable slug, returns undefined.
+ */
+const resolveRepositoryOverride = (
+  ci: CiDescriptor,
+  repositorySlugOverride: string | undefined,
+  repositoryUrlOverride: string | undefined,
+): CiDescriptor["repository"] | undefined => {
+  if (!repositorySlugOverride && !repositoryUrlOverride) {
+    return undefined;
+  }
+
+  const slug = repositorySlugOverride ?? nonBlank(ci.repository?.slug);
+
+  if (!slug) {
+    return undefined;
+  }
+
+  return {
+    slug,
+    url: repositoryUrlOverride ?? ci.repository?.url,
+  };
+};
+
+export const applyCiOverrides = (ci: CiDescriptor): CiDescriptor => {
+  const overrides: Partial<Record<OverridableStringField, string>> = {};
+
+  for (const [field, envVar] of OVERRIDABLE_STRING_FIELDS) {
+    const value = nonBlank(env[envVar]);
 
     if (value) {
       overrides[field] = value;
     }
   }
 
-  return Object.keys(overrides).length > 0 ? { ...ci, ...overrides } : ci;
+  const repoNameOverride = nonBlank(env.ALLURE_CI_REPO_NAME);
+  const repositorySlugOverride = nonBlank(env.ALLURE_CI_REPOSITORY_SLUG);
+  const repositoryUrlOverride = nonBlank(env.ALLURE_CI_REPOSITORY_URL);
+  const providerOverride = parseGitProvider(env.ALLURE_CI_GIT_PROVIDER);
+  const repository = resolveRepositoryOverride(ci, repositorySlugOverride, repositoryUrlOverride);
+
+  const hasPullRequestEnv = Boolean(
+    nonBlank(env.ALLURE_CI_PULL_REQUEST_ID) ||
+    nonBlank(env.ALLURE_CI_PULL_REQUEST_URL) ||
+    nonBlank(env.ALLURE_CI_PULL_REQUEST_TITLE),
+  );
+  // Only merge the pullRequest object when an id can be resolved; URL/title-only
+  // updates still flow through OVERRIDABLE_STRING_FIELDS without clearing pullRequest.
+  const pullRequest = hasPullRequestEnv ? resolvePullRequestOverride(ci) : undefined;
+  const hasPullRequestObjectOverride = pullRequest !== undefined;
+  const hasRepoNameOverride = Boolean(repoNameOverride);
+  const hasRepositoryOverride = repository !== undefined;
+  const hasProviderOverride = providerOverride !== undefined;
+
+  if (
+    Object.keys(overrides).length === 0 &&
+    !hasPullRequestObjectOverride &&
+    !hasRepoNameOverride &&
+    !hasRepositoryOverride &&
+    !hasProviderOverride
+  ) {
+    return ci;
+  }
+
+  return {
+    ...ci,
+    ...overrides,
+    ...(hasRepoNameOverride ? { repoName: repoNameOverride } : {}),
+    ...(hasRepositoryOverride ? { repository } : {}),
+    ...(hasProviderOverride ? { provider: providerOverride } : {}),
+    ...(hasPullRequestObjectOverride ? { pullRequest } : {}),
+  };
+};
+
+/**
+ * Applies ALLURE_CI_COMMIT / ALLURE_CI_FIRST_PARENT_ANCESTORS on top of collected git facts.
+ * Keeps first-parent ancestors only when the commit is unchanged or ancestors are provided via env.
+ */
+export const applyGitFactsOverrides = (facts: GitFacts | undefined): GitFacts | undefined => {
+  const commitOverride = nonBlank(env.ALLURE_CI_COMMIT);
+  const ancestorsOverride = parseFirstParentAncestors(env.ALLURE_CI_FIRST_PARENT_ANCESTORS);
+
+  if (!commitOverride && ancestorsOverride === undefined) {
+    return facts;
+  }
+
+  if (commitOverride) {
+    if (!facts) {
+      return {
+        commit: commitOverride,
+        firstParentAncestors: ancestorsOverride ?? [],
+        branch: undefined,
+      };
+    }
+
+    const commitUnchanged = facts.commit === commitOverride;
+
+    return {
+      ...facts,
+      commit: commitOverride,
+      firstParentAncestors:
+        ancestorsOverride !== undefined ? ancestorsOverride : commitUnchanged ? facts.firstParentAncestors : [],
+    };
+  }
+
+  if (!facts?.commit) {
+    return facts;
+  }
+
+  return {
+    ...facts,
+    firstParentAncestors: ancestorsOverride!,
+  };
 };

--- a/packages/plugin-testops/test/ciOverrides.test.ts
+++ b/packages/plugin-testops/test/ciOverrides.test.ts
@@ -1,8 +1,9 @@
-import type { CiDescriptor } from "@allurereport/core-api";
+import type { CiDescriptor, GitFacts } from "@allurereport/core-api";
+import { GitProvider } from "@allurereport/core-api";
 import { epic, feature, label, story } from "allure-js-commons";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { applyCiOverrides } from "../src/utils/ciOverrides.js";
+import { applyCiOverrides, applyGitFactsOverrides } from "../src/utils/ciOverrides.js";
 
 beforeEach(async () => {
   await epic("coverage");
@@ -24,7 +25,14 @@ const baseCi = {
   jobRunUrl: "https://ci.example.com/job/run",
   jobRunName: "detected-run-name",
   jobRunBranch: "detected-branch",
+  repoName: "detected-repo",
 } as unknown as CiDescriptor;
+
+const baseFacts = {
+  commit: "a".repeat(40),
+  branch: "feature/local",
+  firstParentAncestors: ["b".repeat(40), "c".repeat(40)],
+} satisfies GitFacts;
 
 describe("applyCiOverrides", () => {
   it("returns the descriptor unchanged when no override env vars are set", () => {
@@ -72,5 +80,248 @@ describe("applyCiOverrides", () => {
     vi.stubEnv("ALLURE_JOB_UID", "");
 
     expect(applyCiOverrides(baseCi)).toEqual(baseCi);
+  });
+
+  it("overrides source and target branches", () => {
+    vi.stubEnv("ALLURE_CI_SOURCE_BRANCH", "feature/foo");
+    vi.stubEnv("ALLURE_CI_TARGET_BRANCH", "main");
+
+    expect(applyCiOverrides(baseCi)).toEqual({
+      ...baseCi,
+      sourceBranch: "feature/foo",
+      targetBranch: "main",
+    });
+  });
+
+  it("overrides pull request metadata", () => {
+    vi.stubEnv("ALLURE_CI_PULL_REQUEST_ID", "920");
+    vi.stubEnv("ALLURE_CI_PULL_REQUEST_URL", "https://github.com/org/repo/pull/920");
+    vi.stubEnv("ALLURE_CI_PULL_REQUEST_TITLE", "Pull request #920");
+
+    expect(applyCiOverrides(baseCi)).toEqual({
+      ...baseCi,
+      pullRequestName: "Pull request #920",
+      pullRequestUrl: "https://github.com/org/repo/pull/920",
+      pullRequest: {
+        id: "920",
+        url: "https://github.com/org/repo/pull/920",
+        title: "Pull request #920",
+      },
+    });
+  });
+
+  it("keeps existing pull request fields when only the id is overridden", () => {
+    const withPullRequest = {
+      ...baseCi,
+      pullRequest: {
+        id: "1",
+        url: "https://github.com/org/repo/pull/1",
+        title: "Old title",
+      },
+    } as unknown as CiDescriptor;
+
+    vi.stubEnv("ALLURE_CI_PULL_REQUEST_ID", "920");
+
+    expect(applyCiOverrides(withPullRequest)).toEqual({
+      ...withPullRequest,
+      pullRequest: {
+        id: "920",
+        url: "https://github.com/org/repo/pull/1",
+        title: "Old title",
+      },
+    });
+  });
+
+  it("keeps existing pullRequest id/title when only the URL is overridden", () => {
+    const withPullRequest = {
+      ...baseCi,
+      pullRequest: {
+        id: "1",
+        url: "https://github.com/org/repo/pull/1",
+        title: "Old title",
+      },
+    } as unknown as CiDescriptor;
+
+    vi.stubEnv("ALLURE_CI_PULL_REQUEST_URL", "https://github.com/org/repo/pull/1?updated=1");
+
+    expect(applyCiOverrides(withPullRequest)).toEqual({
+      ...withPullRequest,
+      pullRequestUrl: "https://github.com/org/repo/pull/1?updated=1",
+      pullRequest: {
+        id: "1",
+        url: "https://github.com/org/repo/pull/1?updated=1",
+        title: "Old title",
+      },
+    });
+  });
+
+  it("does not create pullRequest when only the URL is overridden and no id exists", () => {
+    vi.stubEnv("ALLURE_CI_PULL_REQUEST_URL", "https://github.com/org/repo/pull/920");
+
+    expect(applyCiOverrides(baseCi)).toEqual({
+      ...baseCi,
+      pullRequestUrl: "https://github.com/org/repo/pull/920",
+    });
+    expect(applyCiOverrides(baseCi).pullRequest).toBeUndefined();
+  });
+
+  it("overrides repository.slug via ALLURE_CI_REPOSITORY_SLUG while keeping existing repository.url", () => {
+    const withRepository = {
+      ...baseCi,
+      repository: {
+        slug: "old-org/old-repo",
+        url: "https://github.com/old-org/old-repo",
+      },
+    } as unknown as CiDescriptor;
+
+    vi.stubEnv("ALLURE_CI_REPOSITORY_SLUG", "org/repo");
+
+    expect(applyCiOverrides(withRepository)).toEqual({
+      ...withRepository,
+      repository: {
+        slug: "org/repo",
+        url: "https://github.com/old-org/old-repo",
+      },
+    });
+  });
+
+  it("overrides repoName alone without changing repository.slug", () => {
+    const withRepository = {
+      ...baseCi,
+      repository: {
+        slug: "old-org/old-repo",
+        url: "https://github.com/old-org/old-repo",
+      },
+    } as unknown as CiDescriptor;
+
+    vi.stubEnv("ALLURE_CI_REPO_NAME", "short-repo");
+
+    expect(applyCiOverrides(withRepository)).toEqual({
+      ...withRepository,
+      repoName: "short-repo",
+    });
+  });
+
+  it("overrides repository.url and keeps existing slug when slug override is unset", () => {
+    const withRepository = {
+      ...baseCi,
+      repository: {
+        slug: "org/repo",
+        url: "https://github.com/org/repo",
+      },
+    } as unknown as CiDescriptor;
+
+    vi.stubEnv("ALLURE_CI_REPOSITORY_URL", "https://github.com/org/repo.git");
+
+    expect(applyCiOverrides(withRepository)).toEqual({
+      ...withRepository,
+      repository: {
+        slug: "org/repo",
+        url: "https://github.com/org/repo.git",
+      },
+    });
+  });
+
+  it("does not create a repository object when only the URL is overridden and no slug exists", () => {
+    vi.stubEnv("ALLURE_CI_REPOSITORY_URL", "https://github.com/org/repo");
+
+    expect(applyCiOverrides(baseCi)).toEqual(baseCi);
+    expect(applyCiOverrides(baseCi).repository).toBeUndefined();
+  });
+
+  it("overrides provider with a case-insensitive GitProvider value", () => {
+    vi.stubEnv("ALLURE_CI_GIT_PROVIDER", "GiTHuB");
+
+    expect(applyCiOverrides(baseCi)).toEqual({
+      ...baseCi,
+      provider: GitProvider.Github,
+    });
+  });
+
+  it("ignores invalid git provider overrides", () => {
+    vi.stubEnv("ALLURE_CI_GIT_PROVIDER", "svn");
+
+    expect(applyCiOverrides(baseCi)).toEqual(baseCi);
+  });
+});
+
+describe("applyGitFactsOverrides", () => {
+  it("returns facts unchanged when no git override env vars are set", () => {
+    expect(applyGitFactsOverrides(baseFacts)).toEqual(baseFacts);
+  });
+
+  it("overrides commit and keeps ancestors when the commit is unchanged", () => {
+    vi.stubEnv("ALLURE_CI_COMMIT", baseFacts.commit);
+
+    expect(applyGitFactsOverrides(baseFacts)).toEqual(baseFacts);
+  });
+
+  it("overrides commit alone and clears stale ancestors", () => {
+    const commit = "d".repeat(40);
+
+    vi.stubEnv("ALLURE_CI_COMMIT", commit);
+
+    expect(applyGitFactsOverrides(baseFacts)).toEqual({
+      ...baseFacts,
+      commit,
+      firstParentAncestors: [],
+    });
+  });
+
+  it("overrides commit and ancestors together", () => {
+    const commit = "d".repeat(40);
+    const parent = "e".repeat(40);
+
+    vi.stubEnv("ALLURE_CI_COMMIT", commit);
+    vi.stubEnv("ALLURE_CI_FIRST_PARENT_ANCESTORS", `${parent}, ${"f".repeat(40)}`);
+
+    expect(applyGitFactsOverrides(baseFacts)).toEqual({
+      ...baseFacts,
+      commit,
+      firstParentAncestors: [parent, "f".repeat(40)],
+    });
+  });
+
+  it("synthesizes minimal facts when commit is set and no collected facts exist", () => {
+    const commit = "d".repeat(40);
+
+    vi.stubEnv("ALLURE_CI_COMMIT", commit);
+
+    expect(applyGitFactsOverrides(undefined)).toEqual({
+      commit,
+      firstParentAncestors: [],
+      branch: undefined,
+    });
+  });
+
+  it("synthesizes facts with ancestors when commit and ancestors are set without collected facts", () => {
+    const commit = "d".repeat(40);
+    const parent = "e".repeat(40);
+
+    vi.stubEnv("ALLURE_CI_COMMIT", commit);
+    vi.stubEnv("ALLURE_CI_FIRST_PARENT_ANCESTORS", parent);
+
+    expect(applyGitFactsOverrides(undefined)).toEqual({
+      commit,
+      firstParentAncestors: [parent],
+      branch: undefined,
+    });
+  });
+
+  it("applies ancestors-only override to existing facts", () => {
+    const parent = "e".repeat(40);
+
+    vi.stubEnv("ALLURE_CI_FIRST_PARENT_ANCESTORS", parent);
+
+    expect(applyGitFactsOverrides(baseFacts)).toEqual({
+      ...baseFacts,
+      firstParentAncestors: [parent],
+    });
+  });
+
+  it("ignores ancestors-only override when no facts exist", () => {
+    vi.stubEnv("ALLURE_CI_FIRST_PARENT_ANCESTORS", "e".repeat(40));
+
+    expect(applyGitFactsOverrides(undefined)).toBeUndefined();
   });
 });

--- a/packages/plugin-testops/test/features/launch-git-flow.test.ts
+++ b/packages/plugin-testops/test/features/launch-git-flow.test.ts
@@ -120,6 +120,76 @@ describe("Launch git flow", () => {
     );
   });
 
+  it("attaches git context from ALLURE_CI_COMMIT when git CLI is unavailable", async () => {
+    const commit = "a".repeat(40);
+
+    vi.mocked(isGitAvailable).mockReturnValue(false);
+    vi.stubEnv("ALLURE_CI_COMMIT", commit);
+    vi.stubEnv("ALLURE_CI_REPO_NAME", "myorg/myrepo");
+    vi.stubEnv("ALLURE_CI_GIT_PROVIDER", "github");
+    vi.stubEnv("ALLURE_CI_SOURCE_BRANCH", "feature");
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(collectGitFacts).not.toHaveBeenCalled();
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(fixtures.launchName, fixtures.launchTags, {
+      contextType: "branch",
+      repository: {
+        providerType: "github",
+        name: "myorg/myrepo",
+        url: "https://github.com/myorg/myrepo.git",
+      },
+      commit: {
+        hash: commit,
+        url: `https://github.com/myorg/myrepo/commit/${commit}`,
+        lineage: undefined,
+      },
+      branch: {
+        name: "feature",
+        url: "https://github.com/myorg/myrepo/tree/feature",
+      },
+    });
+  });
+
+  it("replaces collected commit and clears stale ancestors via ALLURE_CI_COMMIT", async () => {
+    const collectedCommit = "a".repeat(40);
+    const overrideCommit = "d".repeat(40);
+    const parent = "b".repeat(40);
+
+    const ci = {
+      ...githubCi,
+      provider: GitProvider.Github,
+      repository: { slug: "myorg/myrepo" },
+      sourceBranch: "feature",
+    };
+    (detect as Mock).mockReturnValue(ci);
+    vi.mocked(collectGitFacts).mockReturnValue({
+      commit: collectedCommit,
+      firstParentAncestors: [parent],
+    });
+    vi.stubEnv("ALLURE_CI_COMMIT", overrideCommit);
+
+    await startPlugin({ gitFlow: true } as TestOpsPluginOptions);
+
+    expect(TestOpsClientMock.prototype.createLaunch).toHaveBeenCalledWith(fixtures.launchName, fixtures.launchTags, {
+      contextType: "branch",
+      repository: {
+        providerType: "github",
+        name: "myorg/myrepo",
+        url: "https://github.com/myorg/myrepo.git",
+      },
+      commit: {
+        hash: overrideCommit,
+        url: `https://github.com/myorg/myrepo/commit/${overrideCommit}`,
+        lineage: undefined,
+      },
+      branch: {
+        name: "feature",
+        url: "https://github.com/myorg/myrepo/tree/feature",
+      },
+    });
+  });
+
   it("posts branch git context on createLaunch", async () => {
     const commit = "a".repeat(40);
     const parent = "b".repeat(40);


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

- Skip PR Allure report publishing on PRs from forks as this job requires secrets and permissions not available in fork PRs context.
- Enable `gitFlow` in `allurerc.mjs`
- Extend GitHub CI detection for `workflow_run` PR context, and expand TestOps overrides (`ALLURE_CI_*` for git/PR/repo/commit, `ALLURE_JOB_*` for job identity) so the publisher can attribute launches to the original Build project run
- Allow `/update-bundle-baseline` on forks with measure + artifact/PR-comment handoff instead of pushing to the fork

<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
