### PR TITLE
fix(web-awesome): respect stepTreeExpansion for fixture scenarios

### DIFF
--- a/packages/e2e/test/allure-awesome/test/stepsSubtreeToggle.test.ts
+++ b/packages/e2e/test/allure-awesome/test/stepsSubtreeToggle.test.ts
@@ -9,6 +9,7 @@ let treePage: TreePage;
 let testResultPage: TestResultPage;
 
 const now = Date.now();
+const testResultUuid = "step-toggle-test-result";
 
 test.beforeEach(async ({ page, browserName }) => {
   await label("env", browserName);
@@ -26,8 +27,9 @@ test.beforeEach(async ({ page, browserName }) => {
         appendHistory: false,
         knownIssuesPath: undefined,
       },
-      testResults: [
+      rawTestResults: [
         {
+          uuid: testResultUuid,
           name: "step toggle test",
           fullName: "sample.js#step toggle test",
           historyId: "step-toggle",
@@ -75,6 +77,31 @@ test.beforeEach(async ({ page, browserName }) => {
           ],
         },
       ],
+      rawTestResultContainers: [
+        {
+          children: [testResultUuid],
+          befores: [
+            {
+              name: "setup fixture",
+              status: Status.PASSED,
+              stage: Stage.FINISHED,
+              start: now,
+              stop: now + 50,
+              steps: [],
+            },
+          ],
+          afters: [
+            {
+              name: "teardown fixture",
+              status: Status.PASSED,
+              stage: Stage.FINISHED,
+              start: now + 950,
+              stop: now + 1000,
+              steps: [],
+            },
+          ],
+        },
+      ],
     },
     {
       stepTreeExpansion: "collapsed",
@@ -87,6 +114,24 @@ test.beforeEach(async ({ page, browserName }) => {
 
 test.afterAll(async () => {
   await bootstrap?.shutdown?.();
+});
+
+test("should collapse setup, body and teardown sections by default", async () => {
+  const setupFixture = testResultPage.getStepByName("setup fixture");
+  const level1Step = testResultPage.getStepByName("level 1");
+  const teardownFixture = testResultPage.getStepByName("teardown fixture");
+
+  await expect(setupFixture.locator).toHaveCount(0);
+  await expect(level1Step.locator).toHaveCount(0);
+  await expect(teardownFixture.locator).toHaveCount(0);
+
+  await testResultPage.setupDropdownLocator.click();
+  await expect(setupFixture.locator).toHaveCount(1);
+
+  await testResultPage.teardownDropdownLocator.click();
+  await expect(teardownFixture.locator).toHaveCount(1);
+
+  await expect(level1Step.locator).toHaveCount(0);
 });
 
 test("should cycle body subtree toggle state like categories", async () => {

--- a/packages/e2e/test/pageObjects/TestResult.ts
+++ b/packages/e2e/test/pageObjects/TestResult.ts
@@ -45,6 +45,8 @@ export class TestResultPage extends CommonPage {
   prevStatusLocator: Locator;
 
   linksLocator: Locator;
+  setupDropdownLocator: Locator;
+  teardownDropdownLocator: Locator;
   stepsSubtreeToggleLocator: Locator;
 
   constructor(readonly page: Page) {
@@ -89,6 +91,8 @@ export class TestResultPage extends CommonPage {
     this.prevStatusLocator = page.getByTestId("test-result-prev-status");
 
     this.linksLocator = page.getByTestId("test-result-meta-links");
+    this.setupDropdownLocator = page.getByTestId("test-result-setup-dropdown");
+    this.teardownDropdownLocator = page.getByTestId("test-result-teardown-dropdown");
     this.stepsSubtreeToggleLocator = page.getByTestId("test-result-steps-subtree-toggle");
   }
 

--- a/packages/e2e/test/utils/index.ts
+++ b/packages/e2e/test/utils/index.ts
@@ -20,6 +20,13 @@ export type GeneratorParams = {
   resultsDir: string;
   testResults?: Partial<TestResult>[];
   rawTestResults?: Partial<TestResult>[];
+  rawTestResultContainers?: {
+    uuid?: string;
+    name?: string;
+    children?: string[];
+    befores?: Record<string, unknown>[];
+    afters?: Record<string, unknown>[];
+  }[];
   attachments?: { source: string; content: Buffer }[];
   reportConfig?: Omit<FullConfig, "output" | "reportFiles" | "historyPath" | "port" | "open">;
   globals?: {
@@ -54,6 +61,7 @@ export const generateReport = async (payload: GeneratorParams) => {
     resultsDir,
     testResults = [],
     rawTestResults = [],
+    rawTestResultContainers = [],
     attachments = [],
     history = [],
     globals,
@@ -89,6 +97,10 @@ export const generateReport = async (payload: GeneratorParams) => {
 
   for (const tr of rawTestResults) {
     await writeFile(resolve(resultsDir, `${randomUUID()}-result.json`), JSON.stringify(tr));
+  }
+
+  for (const container of rawTestResultContainers) {
+    await writeFile(resolve(resultsDir, `${randomUUID()}-container.json`), JSON.stringify(container));
   }
 
   for (const attachment of attachments) {

--- a/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrSetup/index.tsx
@@ -5,9 +5,13 @@ import type { ReportTestResult } from "types";
 
 import { fixtureResultToTrStepItem } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
+import {
+  getStepTreeExpansionPolicy,
+  isOpenByDefaultForPolicy,
+} from "@/components/TestResult/TrSteps/stepTreeExpansion";
 import { TrStep } from "@/components/TestResult/TrSteps/TrStep";
 import { useI18n } from "@/stores/locale";
-import { collapsedTrees, toggleTree } from "@/stores/tree";
+import { isTreeOpened, toggleTree } from "@/stores/tree";
 import { trOverviewFocusAttrs, trOverviewHeaderFocusClass } from "@/utils/trOverviewFocus";
 
 import * as styles from "@/components/TestResult/TrSteps/styles.scss";
@@ -19,21 +23,24 @@ export type TrSetupProps = {
 
 export const TrSetup: FunctionalComponent<TrSetupProps> = ({ setup, id }) => {
   const setupId = id ? `${id}-setup` : null;
-  const isEarlyCollapsed = setupId ? Boolean(!collapsedTrees.value.has(setupId)) : true;
-  const [isOpened, setIsOpen] = useState<boolean>(isEarlyCollapsed);
+  const openedByDefault = isOpenByDefaultForPolicy(getStepTreeExpansionPolicy(), true);
+  const [isAnonymousOpened, setIsAnonymousOpened] = useState<boolean>(openedByDefault);
+  const isOpened = setupId ? isTreeOpened(setupId, openedByDefault) : isAnonymousOpened;
 
   const handleClick = () => {
-    setIsOpen(!isOpened);
-
     if (setupId) {
-      toggleTree(setupId);
+      toggleTree(setupId, openedByDefault);
+      return;
     }
+
+    setIsAnonymousOpened(!isAnonymousOpened);
   };
   const { t } = useI18n("execution");
 
   return (
     <div className={styles["test-result-steps"]}>
       <TrDropdown
+        data-testid="test-result-setup-dropdown"
         className={trOverviewHeaderFocusClass(setupId)}
         {...trOverviewFocusAttrs(setupId)}
         icon={allureIcons.lineTimeClockStopwatch}

--- a/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
+++ b/packages/web-awesome/src/components/TestResult/TrTeardown/index.tsx
@@ -1,13 +1,16 @@
 import { allureIcons } from "@allurereport/web-components";
 import type { FunctionalComponent } from "preact";
-import { useState } from "preact/hooks";
 import type { ReportTestResult } from "types";
 
 import { fixtureResultToTrStepItem } from "@/components/TestResult/bodyItems";
 import { TrDropdown } from "@/components/TestResult/TrDropdown";
+import {
+  getStepTreeExpansionPolicy,
+  isOpenByDefaultForPolicy,
+} from "@/components/TestResult/TrSteps/stepTreeExpansion";
 import { TrStep } from "@/components/TestResult/TrSteps/TrStep";
 import { useI18n } from "@/stores/locale";
-import { collapsedTrees, toggleTree } from "@/stores/tree";
+import { isTreeOpened, toggleTree } from "@/stores/tree";
 import { trOverviewFocusAttrs, trOverviewHeaderFocusClass } from "@/utils/trOverviewFocus";
 
 import * as styles from "@/components/TestResult/TrSteps/styles.scss";
@@ -19,14 +22,12 @@ export type TrTeardownProps = {
 
 export const TrTeardown: FunctionalComponent<TrTeardownProps> = ({ teardown, id }) => {
   const teardownId = id ? `${id}-teardown` : null;
-  const isEarlyCollapsed = teardownId ? !collapsedTrees.value.has(teardownId) : true;
-  const [isOpened, setIsOpen] = useState<boolean>(isEarlyCollapsed);
+  const openedByDefault = isOpenByDefaultForPolicy(getStepTreeExpansionPolicy(), true);
+  const isOpened = teardownId ? isTreeOpened(teardownId, openedByDefault) : openedByDefault;
 
   const handleClick = () => {
-    setIsOpen(!isOpened);
-
     if (teardownId) {
-      toggleTree(teardownId);
+      toggleTree(teardownId, openedByDefault);
     }
   };
 
@@ -35,6 +36,7 @@ export const TrTeardown: FunctionalComponent<TrTeardownProps> = ({ teardown, id 
   return (
     <div className={styles["test-result-steps"]}>
       <TrDropdown
+        data-testid="test-result-teardown-dropdown"
         className={trOverviewHeaderFocusClass(teardownId)}
         {...trOverviewFocusAttrs(teardownId)}
         icon={allureIcons.lineHelpersFlag}

--- a/packages/web-awesome/src/utils/flattenTestResultOverview.ts
+++ b/packages/web-awesome/src/utils/flattenTestResultOverview.ts
@@ -5,6 +5,7 @@ import { hasTestLevelErrorContent } from "@/components/TestResult/bodyItems";
 import {
   getStepTreeExpansionPolicy,
   hasStepContent,
+  isOpenByDefaultForPolicy,
   isStepOpenedByDefault,
   type StepTreeExpansion,
 } from "@/components/TestResult/TrSteps/stepTreeExpansion";
@@ -133,11 +134,12 @@ export const flattenTestResultOverview = (input: FlattenTestResultOverviewInput)
     lastSectionId = id;
     return id;
   };
+  const fixtureSectionOpenedByDefault = isOpenByDefaultForPolicy(policy, true);
 
   if (hasSetup) {
-    const setupId = appendSection("setup");
+    const setupId = appendSection("setup", fixtureSectionOpenedByDefault);
 
-    if (isGroupOpened(setupId, true) && setupBodyItems.length > 0) {
+    if (isGroupOpened(setupId, fixtureSectionOpenedByDefault) && setupBodyItems.length > 0) {
       const setupSteps = flattenBodyItems(setupBodyItems, 1, setupId, policy, isGroupOpened);
       result.push(...setupSteps);
 
@@ -171,9 +173,9 @@ export const flattenTestResultOverview = (input: FlattenTestResultOverviewInput)
   }
 
   if (hasTeardown) {
-    const teardownId = appendSection("teardown");
+    const teardownId = appendSection("teardown", fixtureSectionOpenedByDefault);
 
-    if (isGroupOpened(teardownId, true) && teardownBodyItems.length > 0) {
+    if (isGroupOpened(teardownId, fixtureSectionOpenedByDefault) && teardownBodyItems.length > 0) {
       result.push(...flattenBodyItems(teardownBodyItems, 1, teardownId, policy, isGroupOpened));
     }
   }

--- a/packages/web-awesome/test/components/TestResult/TrSetupTeardown.test.tsx
+++ b/packages/web-awesome/test/components/TestResult/TrSetupTeardown.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render } from "@testing-library/preact";
+import type { ReportFixtureResult } from "types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+});
+
+import { TrSetup } from "@/components/TestResult/TrSetup";
+import { TrTeardown } from "@/components/TestResult/TrTeardown";
+import { collapsedTrees, expandedTrees } from "@/stores/tree";
+
+const setupFixture: ReportFixtureResult = {
+  id: "fixture-before-1",
+  type: "before",
+  name: "before fixture",
+  status: "passed",
+  steps: [],
+};
+
+const teardownFixture: ReportFixtureResult = {
+  id: "fixture-after-1",
+  type: "after",
+  name: "after fixture",
+  status: "passed",
+  steps: [],
+};
+
+describe("components > TestResult > TrSetup and TrTeardown", () => {
+  beforeEach(() => {
+    cleanup();
+    collapsedTrees.value = new Set();
+    expandedTrees.value = new Set();
+    globalThis.allureReportOptions = { stepTreeExpansion: "expand_failed_only" } as any;
+  });
+
+  it("collapses setup and teardown sections by default when stepTreeExpansion is collapsed", () => {
+    globalThis.allureReportOptions = { stepTreeExpansion: "collapsed" } as any;
+
+    const view = render(
+      <>
+        <TrSetup id="test-result" setup={[setupFixture]} />
+        <TrTeardown id="test-result" teardown={[teardownFixture]} />
+      </>,
+    );
+
+    expect(view.queryByText("before fixture")).not.toBeInTheDocument();
+    expect(view.queryByText("after fixture")).not.toBeInTheDocument();
+  });
+
+  it("opens collapsed setup and teardown sections when toggled", () => {
+    globalThis.allureReportOptions = { stepTreeExpansion: "collapsed" } as any;
+
+    const view = render(
+      <>
+        <TrSetup id="test-result" setup={[setupFixture]} />
+        <TrTeardown id="test-result" teardown={[teardownFixture]} />
+      </>,
+    );
+
+    fireEvent.click(view.getByText("Set up"));
+    fireEvent.click(view.getByText("Tear down"));
+
+    expect(view.getByText("before fixture")).toBeInTheDocument();
+    expect(view.getByText("after fixture")).toBeInTheDocument();
+  });
+});

--- a/packages/web-awesome/test/utils/flattenTestResultOverview.test.ts
+++ b/packages/web-awesome/test/utils/flattenTestResultOverview.test.ts
@@ -54,4 +54,42 @@ describe("flattenTestResultOverview", () => {
 
     expect(flat.map((node) => node.id)).toEqual(["tr-2-steps"]);
   });
+
+  it("hides setup and teardown children when the step expansion policy is collapsed", () => {
+    const flat = flattenTestResultOverview({
+      testResultId: "tr-3",
+      hasSetup: true,
+      setupBodyItems: [
+        {
+          type: "step",
+          item: {
+            stepId: "setup-fixture",
+            name: "Setup fixture",
+            status: "passed",
+          },
+          bodyItems: [],
+          suppressInlineError: false,
+        },
+      ],
+      bodyItems: [],
+      hasTeardown: true,
+      teardownBodyItems: [
+        {
+          type: "step",
+          item: {
+            stepId: "teardown-fixture",
+            name: "Teardown fixture",
+            status: "passed",
+          },
+          bodyItems: [],
+          suppressInlineError: false,
+        },
+      ],
+      isGroupOpened: (_id, openedByDefault) => openedByDefault,
+      stepExpansionPolicy: "collapsed",
+    });
+
+    expect(flat.map((node) => node.id)).toEqual(["tr-3-setup", "tr-3-teardown"]);
+    expect(flat.map((node) => node.openedByDefault)).toEqual([false, false]);
+  });
 });


### PR DESCRIPTION
fixes setup and teardown accordions in Awesome report so they honor `stepTreeExpansion: "collapsed"` the same way the main test body steps do.

issue: https://github.com/allure-framework/allure3/issues/913

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
