### PR TITLE
Add option to set history url base for local history provider

### DIFF
--- a/packages/cli/src/commands/allure2.ts
+++ b/packages/cli/src/commands/allure2.ts
@@ -65,6 +65,10 @@ export class Allure2Command extends Command {
     description: "The path to history file",
   });
 
+  historyUrlBase = Option.String("--history-url-base", {
+    description: "The public base URL of the generated report directory",
+  });
+
   knownIssues = Option.String("--known-issues", {
     description: "Path to known issues file",
   });
@@ -81,6 +85,7 @@ export class Allure2Command extends Command {
       name: this.reportName,
       resolutions: { knownIssuesPath: this.knownIssues },
       historyPath: this.historyPath,
+      ...(this.historyUrlBase !== undefined ? { historyUrlBase: this.historyUrlBase } : {}),
     });
     const { resultDirectories, patterns } = await resolveAndFindResultsDirs(cwd, this.resultsDir, config.resultsDir);
 

--- a/packages/cli/src/commands/awesome.ts
+++ b/packages/cli/src/commands/awesome.ts
@@ -73,6 +73,10 @@ export class AwesomeCommand extends Command {
     description: "The path to history file",
   });
 
+  historyUrlBase = Option.String("--history-url-base", {
+    description: "The public base URL of the generated report directory",
+  });
+
   knownIssues = Option.String("--known-issues", {
     description: "Path to known issues file",
   });
@@ -94,6 +98,7 @@ export class AwesomeCommand extends Command {
       name: this.reportName,
       resolutions: { knownIssuesPath: this.knownIssues },
       historyPath: this.historyPath,
+      ...(this.historyUrlBase !== undefined ? { historyUrlBase: this.historyUrlBase } : {}),
       hideLabels,
     });
     const { resultDirectories, patterns } = await resolveAndFindResultsDirs(cwd, this.resultsDir, config.resultsDir);

--- a/packages/cli/src/commands/classic.ts
+++ b/packages/cli/src/commands/classic.ts
@@ -65,6 +65,10 @@ export class ClassicCommand extends Command {
     description: "The path to history file",
   });
 
+  historyUrlBase = Option.String("--history-url-base", {
+    description: "The public base URL of the generated report directory",
+  });
+
   knownIssues = Option.String("--known-issues", {
     description: "Path to known issues file",
   });
@@ -81,6 +85,7 @@ export class ClassicCommand extends Command {
       name: this.reportName,
       resolutions: { knownIssuesPath: this.knownIssues },
       historyPath: this.historyPath,
+      ...(this.historyUrlBase !== undefined ? { historyUrlBase: this.historyUrlBase } : {}),
     });
     const { resultDirectories, patterns } = await resolveAndFindResultsDirs(cwd, this.resultsDir, config.resultsDir);
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -72,6 +72,10 @@ export class GenerateCommand extends Command {
     description: "Limits the number of history entries to keep (default: unlimited)",
   });
 
+  historyUrlBase = Option.String("--history-url-base", {
+    description: "The public base URL of the generated report directory",
+  });
+
   hideLabels = Option.Array("--hide-labels", {
     description: "Hide labels by exact name in generated reports. Repeat the option for multiple labels",
   });
@@ -92,6 +96,7 @@ export class GenerateCommand extends Command {
       port: this.port,
       hideLabels,
       historyLimit: this.historyLimit !== undefined ? parseInt(this.historyLimit, 10) : undefined,
+      ...(this.historyUrlBase !== undefined ? { historyUrlBase: this.historyUrlBase } : {}),
       resolutions: { knownIssuesPath: this.knownIssues },
     });
 

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -42,6 +42,10 @@ export class HistoryCommand extends Command {
     description: "Limits the number of history entries to keep (default: unlimited)",
   });
 
+  historyUrlBase = Option.String("--history-url-base", {
+    description: "The public base URL of the generated report directory",
+  });
+
   reportName = Option.String("--report-name,--name", {
     description: "The report name",
   });
@@ -57,13 +61,17 @@ export class HistoryCommand extends Command {
       return;
     }
 
-    const config = await resolveConfig({
-      historyPath: this.historyPath ?? "history.jsonl",
-      historyLimit: this.historyLimit ? Number(this.historyLimit) : undefined,
-      name: this.reportName ?? "Allure Report",
-      // disable all plugins
-      plugins: {},
-    });
+    const config = await resolveConfig(
+      {
+        historyPath: this.historyPath ?? "history.jsonl",
+        historyUrlBase: this.historyUrlBase ?? rawConfig.historyUrlBase,
+        historyLimit: this.historyLimit ? Number(this.historyLimit) : undefined,
+        name: this.reportName ?? "Allure Report",
+        // disable all plugins
+        plugins: {},
+      },
+      { plugins: {} },
+    );
 
     const allureReport = new AllureReport(config);
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -94,6 +94,10 @@ export class RunCommand extends Command {
     description: "Limits the number of history entries to keep (default: unlimited)",
   });
 
+  historyUrlBase = Option.String("--history-url-base", {
+    description: "The public base URL of the generated report directory",
+  });
+
   hideLabels = Option.Array("--hide-labels", {
     description: "Hide labels by exact name in generated reports. Repeat the option for multiple labels",
   });
@@ -167,6 +171,7 @@ export class RunCommand extends Command {
       port: this.port,
       hideLabels,
       historyLimit: this.historyLimit !== undefined ? parseInt(this.historyLimit, 10) : undefined,
+      ...(this.historyUrlBase !== undefined ? { historyUrlBase: this.historyUrlBase } : {}),
       resolutions: { knownIssuesPath: this.knownIssues },
     });
     const resultsPatterns = resolveResultsPatterns(this.resultsDir ?? [], config.resultsDir);

--- a/packages/cli/test/commands/allure2.test.ts
+++ b/packages/cli/test/commands/allure2.test.ts
@@ -132,6 +132,8 @@ describe("allure2 command", () => {
       "baz",
       "--history-path",
       "qux",
+      "--history-url-base",
+      "https://bucket.example/runs/42",
       "./allure-results",
     ]);
 
@@ -141,6 +143,7 @@ describe("allure2 command", () => {
       output: "bar",
       resolutions: { knownIssuesPath: "baz" },
       historyPath: "qux",
+      historyUrlBase: "https://bucket.example/runs/42",
     });
   });
 

--- a/packages/cli/test/commands/awesome.test.ts
+++ b/packages/cli/test/commands/awesome.test.ts
@@ -137,6 +137,8 @@ describe("awesome command", () => {
       "baz",
       "--history-path",
       "qux",
+      "--history-url-base",
+      "https://bucket.example/runs/42",
       "./allure-results",
     ]);
 
@@ -146,6 +148,7 @@ describe("awesome command", () => {
       output: "bar",
       resolutions: { knownIssuesPath: "baz" },
       historyPath: "qux",
+      historyUrlBase: "https://bucket.example/runs/42",
     });
   });
 

--- a/packages/cli/test/commands/classic.test.ts
+++ b/packages/cli/test/commands/classic.test.ts
@@ -133,6 +133,8 @@ describe("classic command", () => {
       "baz",
       "--history-path",
       "qux",
+      "--history-url-base",
+      "https://bucket.example/runs/42",
       "./allure-results",
     ]);
 
@@ -142,6 +144,7 @@ describe("classic command", () => {
       output: "bar",
       resolutions: { knownIssuesPath: "baz" },
       historyPath: "qux",
+      historyUrlBase: "https://bucket.example/runs/42",
     });
   });
 

--- a/packages/cli/test/commands/generate.test.ts
+++ b/packages/cli/test/commands/generate.test.ts
@@ -114,7 +114,16 @@ describe("generate command", () => {
     (readConfig as Mock).mockResolvedValueOnce({ open: false });
     (generate as Mock).mockResolvedValue(undefined);
 
-    await run(GenerateCommand, ["generate", "--output", "foo", "--report-name", "bar", "baz"]);
+    await run(GenerateCommand, [
+      "generate",
+      "--output",
+      "foo",
+      "--report-name",
+      "bar",
+      "--history-url-base",
+      "https://bucket.example/runs/42",
+      "baz",
+    ]);
 
     expect(readConfig).toHaveBeenCalledTimes(1);
     expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
@@ -124,6 +133,7 @@ describe("generate command", () => {
       port: undefined,
       hideLabels: undefined,
       historyLimit: undefined,
+      historyUrlBase: "https://bucket.example/runs/42",
       resolutions: { knownIssuesPath: undefined },
     });
     expect(generate).toHaveBeenCalledWith(

--- a/packages/cli/test/commands/history.test.ts
+++ b/packages/cli/test/commands/history.test.ts
@@ -1,0 +1,78 @@
+import { AllureReport, readRawConfig, resolveConfig } from "@allurereport/core";
+import { epic, feature, label, story } from "allure-js-commons";
+import { run } from "clipanion";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HistoryCommand } from "../../src/commands/history.js";
+import { resolveAndFindResultsDirs } from "../../src/utils/resultsPatterns.js";
+
+vi.mock("@allurereport/core", async () => {
+  const { AllureReportMock } = await import("../utils.js");
+
+  return {
+    AllureReport: AllureReportMock,
+    readRawConfig: vi.fn(),
+    resolveConfig: vi.fn(),
+  };
+});
+vi.mock("../../src/utils/resultsPatterns.js", () => ({
+  resolveAndFindResultsDirs: vi.fn(),
+}));
+
+beforeEach(async () => {
+  await epic("coverage");
+  await feature("cli-commands");
+  await story("history");
+  await label("coverage", "cli-commands");
+  vi.clearAllMocks();
+  (readRawConfig as Mock).mockResolvedValue({});
+  (resolveConfig as Mock).mockResolvedValue({ plugins: [] });
+  (resolveAndFindResultsDirs as Mock).mockResolvedValue({
+    resultDirectories: ["/tmp/allure-results"],
+    patterns: ["/tmp/allure-results"],
+  });
+});
+
+describe("history command", () => {
+  it("should pass the CLI history URL base and disable report plugins", async () => {
+    await run(HistoryCommand, [
+      "history",
+      "--history-path",
+      "history.jsonl",
+      "--history-url-base",
+      "https://bucket.example/runs/42",
+      "/tmp/allure-results",
+    ]);
+
+    expect(resolveConfig).toHaveBeenCalledWith(
+      {
+        historyPath: "history.jsonl",
+        historyUrlBase: "https://bucket.example/runs/42",
+        historyLimit: undefined,
+        name: "Allure Report",
+        plugins: {},
+      },
+      { plugins: {} },
+    );
+    expect(AllureReport).toHaveBeenCalledWith({ plugins: [] });
+  });
+
+  it("should use historyUrlBase from config when the CLI option is absent", async () => {
+    (readRawConfig as Mock).mockResolvedValue({
+      historyUrlBase: "https://bucket.example/runs/config",
+    });
+
+    await run(HistoryCommand, ["history", "/tmp/allure-results"]);
+
+    expect(resolveConfig).toHaveBeenCalledWith(
+      {
+        historyPath: "history.jsonl",
+        historyUrlBase: "https://bucket.example/runs/config",
+        historyLimit: undefined,
+        name: "Allure Report",
+        plugins: {},
+      },
+      { plugins: {} },
+    );
+  });
+});

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -387,7 +387,16 @@ describe("run command", () => {
       plugins: [],
     });
 
-    await run(RunCommand, ["run", "--known-issues", "known.json", "--", "npm", "test"]);
+    await run(RunCommand, [
+      "run",
+      "--known-issues",
+      "known.json",
+      "--history-url-base",
+      "https://bucket.example/runs/42",
+      "--",
+      "npm",
+      "test",
+    ]);
 
     expect(readConfig).toHaveBeenCalledWith(expect.any(String), undefined, {
       output: undefined,
@@ -396,6 +405,7 @@ describe("run command", () => {
       port: undefined,
       hideLabels: undefined,
       historyLimit: undefined,
+      historyUrlBase: "https://bucket.example/runs/42",
       resolutions: { knownIssuesPath: "known.json" },
     });
   });

--- a/packages/core-api/src/history.ts
+++ b/packages/core-api/src/history.ts
@@ -39,10 +39,13 @@ export interface HistoryDataPoint {
   url: string;
 }
 
+export type HistoryTestResultUrlResolver = (historyUrl: string, pluginId: string, historicalResultId: string) => string;
+
 /**
  * Provides ability to load and update report history
  */
 export interface AllureHistory {
   readHistory(params?: { repo?: string; branch?: string }): Promise<HistoryDataPoint[]>;
   appendHistory(history: HistoryDataPoint): Promise<void>;
+  resolveTestResultUrl?: HistoryTestResultUrlResolver;
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -32,6 +32,7 @@ export interface ConfigOverride {
   port?: Config["port"];
   hideLabels?: Config["hideLabels"];
   historyPath?: Config["historyPath"];
+  historyUrlBase?: Config["historyUrlBase"];
   historyLimit?: Config["historyLimit"];
   resolutions?: Pick<NonNullable<Config["resolutions"]>, "knownIssuesPath">;
   plugins?: Config["plugins"];
@@ -165,6 +166,7 @@ export const validateConfig = (config: Config) => {
     "port",
     "hideLabels",
     "historyPath",
+    "historyUrlBase",
     "historyLimit",
     "resolutions",
     "plugins",
@@ -324,6 +326,7 @@ export const resolveConfig = async (config: Config, override: ConfigOverride = {
   const port = override.port ?? config.port ?? undefined;
   const hideLabels = override.hideLabels ?? config.hideLabels;
   const historyPath = override.historyPath ?? config.historyPath;
+  const historyUrlBase = override.historyUrlBase ?? config.historyUrlBase;
   const historyLimit = override.historyLimit ?? config.historyLimit;
   const appendHistory = config.appendHistory ?? true;
   const configuredKnownIssuesPath = override.resolutions?.knownIssuesPath ?? config.resolutions?.knownIssuesPath;
@@ -378,6 +381,7 @@ export const resolveConfig = async (config: Config, override: ConfigOverride = {
     appendHistory,
     historyLimit,
     historyPath: historyPath ? resolve(historyPath) : undefined,
+    historyUrlBase,
     reportFiles: new FileSystemReportFiles(output),
     plugins: pluginInstances,
     defaultLabels: config.defaultLabels ?? {},

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -90,23 +90,14 @@ export const normalizeHistoryUrlBase = (historyUrlBase: string): string => {
     throw new Error(`Invalid historyUrlBase ${JSON.stringify(historyUrlBase)}: fragments are not allowed`);
   }
 
+  if (/\.html\/?$/iu.test(url.pathname)) {
+    throw new Error(
+      `Invalid historyUrlBase ${JSON.stringify(historyUrlBase)}: expected a base URL, not an HTML document`,
+    );
+  }
+
+  // Always add trailing / at the end of pathname
   url.pathname = `${url.pathname.replace(/\/+$/u, "")}/`;
-
-  return url.toString();
-};
-
-export const buildLocalHistoryUrl = (historyUrl: string, pluginId: string, historicalResultId: string): string => {
-  if (!historyUrl) {
-    return "";
-  }
-
-  const url = new URL(historyUrl);
-
-  if (url.pathname.endsWith("/")) {
-    url.pathname = `${url.pathname}${pluginId}/index.html`;
-  }
-
-  url.hash = historicalResultId;
 
   return url.toString();
 };
@@ -150,7 +141,21 @@ export class AllureLocalHistory implements AllureHistory {
     },
   ) {}
 
-  resolveTestResultUrl = buildLocalHistoryUrl;
+  resolveTestResultUrl(historyUrl: string, pluginId: string, historicalResultId: string): string {
+    if (!historyUrl) {
+      return "";
+    }
+
+    const url = new URL(historyUrl);
+
+    if (url.pathname.endsWith("/")) {
+      url.pathname = `${url.pathname}${pluginId}/index.html`;
+    }
+
+    url.hash = historicalResultId;
+
+    return url.toString();
+  }
 
   async readHistory() {
     if (this.#cachedHistory.length > 0) {

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -77,6 +77,48 @@ const metricsToHistoryValues = (metrics: MetricSample[]): Record<string, number>
   );
 };
 
+export const normalizeHistoryUrlBase = (historyUrlBase: string): string => {
+  let url: URL;
+
+  try {
+    url = new URL(historyUrlBase);
+  } catch (cause) {
+    throw new Error(`Invalid historyUrlBase ${JSON.stringify(historyUrlBase)}: expected an absolute URL`, { cause });
+  }
+
+  if (url.href.includes("#")) {
+    throw new Error(`Invalid historyUrlBase ${JSON.stringify(historyUrlBase)}: fragments are not allowed`);
+  }
+
+  url.pathname = `${url.pathname.replace(/\/+$/u, "")}/`;
+
+  return url.toString();
+};
+
+export const buildLocalHistoryUrl = (historyUrl: string, pluginId: string, historicalResultId: string): string => {
+  if (!historyUrl) {
+    return "";
+  }
+
+  const url = new URL(historyUrl);
+
+  if (url.pathname.endsWith("/")) {
+    url.pathname = `${url.pathname}${pluginId}/index.html`;
+  }
+
+  url.hash = historicalResultId;
+
+  return url.toString();
+};
+
+export const setHistoryDataPointUrl = (point: HistoryDataPoint, url: string): HistoryDataPoint => ({
+  ...point,
+  url,
+  testResults: Object.fromEntries(
+    Object.entries(point.testResults).map(([historyId, item]) => [historyId, { ...item, url }]),
+  ),
+});
+
 export const createHistory = (
   reportUuid: string,
   reportName: string = "Allure Report",
@@ -107,6 +149,8 @@ export class AllureLocalHistory implements AllureHistory {
       limit?: number;
     },
   ) {}
+
+  resolveTestResultUrl = buildLocalHistoryUrl;
 
   async readHistory() {
     if (this.#cachedHistory.length > 0) {

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -47,7 +47,7 @@ import pLimit from "p-limit";
 import ZipWriteStream from "zip-stream";
 
 import type { FullConfig, PluginInstance } from "./api.js";
-import { AllureLocalHistory, createHistory } from "./history.js";
+import { AllureLocalHistory, createHistory, normalizeHistoryUrlBase, setHistoryDataPointUrl } from "./history.js";
 import { DefaultPluginState, PluginFiles } from "./plugin.js";
 import { QualityGate, type QualityGateState } from "./qualityGate/index.js";
 import { writeKnownIssues } from "./resolutions.js";
@@ -135,6 +135,7 @@ export class AllureReport {
   readonly #hideLabels: FullConfig["hideLabels"];
   readonly #output: string;
   readonly #history: AllureHistory | undefined;
+  readonly #historyUrlBase: string | undefined;
   readonly #appendHistory: boolean;
   readonly #allureServiceClient: AllureServiceApiClient | undefined;
   readonly #qualityGate: QualityGate | undefined;
@@ -169,6 +170,7 @@ export class AllureReport {
       reportFiles,
       realTime,
       historyPath,
+      historyUrlBase,
       historyLimit,
       appendHistory,
       defaultLabels = {},
@@ -223,6 +225,9 @@ export class AllureReport {
     }
 
     this.#categories = normalizeCategoriesConfig(categories);
+
+    this.#historyUrlBase =
+      !this.#allureServiceClient && historyPath && historyUrlBase ? normalizeHistoryUrlBase(historyUrlBase) : undefined;
 
     if (this.#allureServiceClient) {
       this.#history = new AllureRemoteHistory({
@@ -1243,9 +1248,20 @@ export class AllureReport {
         outputDirFiles.map(async (file) => ({ file, stats: await lstat(join(this.#output, file)) })),
       );
       const outputDirectoryEntries = outputEntries.filter(({ stats }) => stats.isDirectory());
+      const shouldFlattenOutput = outputDirectoryEntries.length === 1;
+
+      if (this.#historyUrlBase) {
+        const historyUrl = new URL(this.#historyUrlBase);
+
+        if (shouldFlattenOutput) {
+          historyUrl.pathname = `${historyUrl.pathname}index.html`;
+        }
+
+        this.#historyDataPoint = setHistoryDataPointUrl(this.#historyDataPoint!, historyUrl.toString());
+      }
 
       // if there is a single report directory in the output directory, move it to the root and prevent summary generation
-      if (outputDirectoryEntries.length === 1) {
+      if (shouldFlattenOutput) {
         const reportPath = join(this.#output, outputDirectoryEntries[0].file);
         const reportContent = await readdir(reportPath);
 

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -239,6 +239,13 @@ describe("validateConfig", () => {
     });
   });
 
+  it("should allow historyUrlBase", () => {
+    expect(validateConfig({ historyUrlBase: "https://bucket.example/runs/42" })).toEqual({
+      valid: true,
+      fields: [],
+    });
+  });
+
   it("should allow resultsDir", () => {
     expect(validateConfig({ resultsDir: "./allure-results" })).toEqual({
       valid: true,
@@ -552,6 +559,21 @@ describe("resolveConfig", () => {
     const resolved = await resolveConfig(fixture, { historyPath: "./custom/history.jsonl" });
 
     expect(resolved.historyPath).toEqual(resolve("./custom/history.jsonl"));
+  });
+
+  it("should return the configured history URL base", async () => {
+    const resolved = await resolveConfig({ historyUrlBase: "https://bucket.example/runs/42" });
+
+    expect(resolved.historyUrlBase).toBe("https://bucket.example/runs/42");
+  });
+
+  it("should allow the history URL base to be overridden", async () => {
+    const resolved = await resolveConfig(
+      { historyUrlBase: "https://bucket.example/runs/config" },
+      { historyUrlBase: "https://bucket.example/runs/cli" },
+    );
+
+    expect(resolved.historyUrlBase).toBe("https://bucket.example/runs/cli");
   });
 
   it("should not set default known issues path when no known issues policy is configured", async () => {

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -8,13 +8,7 @@ import type { HistoryDataPoint, TestCase, TestResult } from "@allurereport/core-
 import { epic, feature, label, story } from "allure-js-commons";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import {
-  AllureLocalHistory,
-  buildLocalHistoryUrl,
-  createHistory,
-  normalizeHistoryUrlBase,
-  setHistoryDataPointUrl,
-} from "../src/history.js";
+import { AllureLocalHistory, createHistory, normalizeHistoryUrlBase, setHistoryDataPointUrl } from "../src/history.js";
 import { getDataPath } from "./utils.js";
 
 beforeEach(async () => {
@@ -666,17 +660,20 @@ describe("local history URLs", () => {
 
   it.each([
     {
-      name: "multi-report directory",
+      name: "url with base directory",
       url: "https://bucket.example/runs/42/?token=x",
       expected: "https://bucket.example/runs/42/custom-awesome/index.html?token=x#old-result",
     },
     {
-      name: "flattened entry document",
+      name: "url with exact report",
       url: "https://bucket.example/runs/42/index.html?token=x",
       expected: "https://bucket.example/runs/42/index.html?token=x#old-result",
     },
     { name: "blank URL", url: "", expected: "" },
   ])("should resolve $name", ({ url, expected }) => {
-    expect(buildLocalHistoryUrl(url, "custom-awesome", "old-result")).toBe(expected);
+    const historyPath = getDataPath("empty.jsonl");
+    const history = new AllureLocalHistory({ historyPath });
+
+    expect(history.resolveTestResultUrl(url, "custom-awesome", "old-result")).toBe(expected);
   });
 });

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -8,7 +8,13 @@ import type { HistoryDataPoint, TestCase, TestResult } from "@allurereport/core-
 import { epic, feature, label, story } from "allure-js-commons";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import { AllureLocalHistory, createHistory } from "../src/history.js";
+import {
+  AllureLocalHistory,
+  buildLocalHistoryUrl,
+  createHistory,
+  normalizeHistoryUrlBase,
+  setHistoryDataPointUrl,
+} from "../src/history.js";
 import { getDataPath } from "./utils.js";
 
 beforeEach(async () => {
@@ -608,5 +614,69 @@ describe("createHistory", () => {
 
     expect(history.url).toBe(remoteUrl);
     expect(history.testResults["history-id"].url).toBe(remoteUrl);
+  });
+});
+
+describe("local history URLs", () => {
+  it.each([
+    ["https://bucket.example/runs/42", "https://bucket.example/runs/42/"],
+    ["https://bucket.example/runs/42/?token=x", "https://bucket.example/runs/42/?token=x"],
+    ["file:///tmp/reports/42", "file:///tmp/reports/42/"],
+  ])("should normalize a run-directory base: %s", (input, expected) => {
+    expect(normalizeHistoryUrlBase(input)).toBe(expected);
+  });
+
+  it("should reject a relative base", () => {
+    expect(() => normalizeHistoryUrlBase("runs/42")).toThrowError(/Invalid historyUrlBase.*absolute URL/u);
+  });
+
+  it("should reject a base fragment", () => {
+    expect(() => normalizeHistoryUrlBase("https://bucket.example/runs/42#current")).toThrowError(
+      /Invalid historyUrlBase.*fragment/u,
+    );
+  });
+
+  it("should replace run and test URLs without mutating the source history point", () => {
+    const source: HistoryDataPoint = {
+      uuid: "run-1",
+      name: "Run 1",
+      timestamp: 1,
+      knownTestCaseIds: [],
+      metrics: {},
+      url: "",
+      testResults: {
+        stable: {
+          id: "old-result",
+          name: "historical test",
+          status: "passed",
+          url: "",
+        },
+      },
+    };
+
+    const updated = setHistoryDataPointUrl(source, "https://bucket.example/runs/42/index.html");
+
+    expect(updated.url).toBe("https://bucket.example/runs/42/index.html");
+    expect(updated.testResults.stable.url).toBe("https://bucket.example/runs/42/index.html");
+    expect(updated).not.toBe(source);
+    expect(updated.testResults.stable).not.toBe(source.testResults.stable);
+    expect(source.url).toBe("");
+    expect(source.testResults.stable.url).toBe("");
+  });
+
+  it.each([
+    {
+      name: "multi-report directory",
+      url: "https://bucket.example/runs/42/?token=x",
+      expected: "https://bucket.example/runs/42/custom-awesome/index.html?token=x#old-result",
+    },
+    {
+      name: "flattened entry document",
+      url: "https://bucket.example/runs/42/index.html?token=x",
+      expected: "https://bucket.example/runs/42/index.html?token=x#old-result",
+    },
+    { name: "blank URL", url: "", expected: "" },
+  ])("should resolve $name", ({ url, expected }) => {
+    expect(buildLocalHistoryUrl(url, "custom-awesome", "old-result")).toBe(expected);
   });
 });

--- a/packages/core/test/report.test.ts
+++ b/packages/core/test/report.test.ts
@@ -1,10 +1,10 @@
 import console from "node:console";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { setTimeout } from "node:timers/promises";
 
-import type { TestResult } from "@allurereport/core-api";
+import type { HistoryDataPoint, TestResult } from "@allurereport/core-api";
 import { type Plugin, type QualityGateRule, md5 } from "@allurereport/plugin-api";
 import AwesomePlugin from "@allurereport/plugin-awesome";
 import { BufferResultFile, type ResultsReader } from "@allurereport/reader-api";
@@ -404,6 +404,134 @@ describe("report", () => {
 
     expect(historyContent).not.toEqual(initialHistoryContent);
     expect(historyContent.startsWith(initialHistoryContent)).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "flattened output",
+      pluginIds: ["awesome"],
+      expected: "https://bucket.example/runs/42/index.html?token=x",
+    },
+    {
+      name: "multi-report output",
+      pluginIds: ["awesome", "classic"],
+      expected: "https://bucket.example/runs/42/?token=x",
+    },
+    {
+      name: "history-only output",
+      pluginIds: [],
+      expected: "https://bucket.example/runs/42/?token=x",
+    },
+  ])("should persist the actual URL for $name", async ({ pluginIds, expected }) => {
+    const root = await mkdtemp(join(tmpdir(), "allure3-history-url-base-"));
+    const output = join(root, "report");
+    const historyPath = join(root, "history.jsonl");
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output,
+        historyPath,
+        historyUrlBase: "https://bucket.example/runs/42?token=x",
+      },
+      { plugins: {} },
+    );
+    const plugins = pluginIds.map((id) => {
+      const plugin = createPlugin(id);
+
+      plugin.plugin.done.mockImplementation(async (context) => {
+        await context.reportFiles.addFile("index.html", Buffer.from(id));
+      });
+
+      return plugin;
+    });
+
+    config.plugins = plugins;
+
+    try {
+      const allureReport = new AllureReport(config);
+
+      await allureReport.start();
+      await allureReport.store.visitTestResult(
+        {
+          uuid: "current-result",
+          name: "current test",
+          fullName: "suite.current test",
+          status: "passed",
+        },
+        { readerId: "report.test.ts" },
+      );
+      await allureReport.done();
+
+      const point = JSON.parse((await readFile(historyPath, "utf8")).trim()) as HistoryDataPoint;
+
+      expect(point.url).toBe(expected);
+      expect(Object.values(point.testResults)).toHaveLength(1);
+      expect(Object.values(point.testResults)[0].url).toBe(expected);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("should append local history when no report plugins are enabled", async () => {
+    const root = await mkdtemp(join(tmpdir(), "allure3-history-url-base-empty-output-"));
+    const historyPath = join(root, "history.jsonl");
+    const config = await resolveConfig(
+      {
+        name: "Allure Report",
+        output: join(root, "report"),
+        historyPath,
+        historyUrlBase: "https://bucket.example/runs/42",
+      },
+      { plugins: {} },
+    );
+
+    try {
+      const allureReport = new AllureReport(config);
+
+      await allureReport.start();
+      await allureReport.done();
+
+      const point = JSON.parse((await readFile(historyPath, "utf8")).trim()) as HistoryDataPoint;
+
+      expect(point.url).toBe("https://bucket.example/runs/42/");
+      expect(point.testResults).toEqual({});
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("should validate historyUrlBase only for the effective local provider", async () => {
+    const root = await mkdtemp(join(tmpdir(), "allure3-history-url-base-validation-"));
+
+    try {
+      const localConfig = await resolveConfig(
+        { output: join(root, "local"), historyPath: join(root, "history.jsonl") },
+        { plugins: {} },
+      );
+      const noHistoryConfig = await resolveConfig({ output: join(root, "none") }, { plugins: {} });
+      const serviceConfig = await resolveConfig(
+        {
+          output: join(root, "service"),
+          historyPath: join(root, "ignored-history.jsonl"),
+          allureService: allureServiceConfig(),
+        },
+        { plugins: {} },
+      );
+
+      expect(() => new AllureReport({ ...localConfig, historyUrlBase: "relative/path" })).toThrowError(
+        /Invalid historyUrlBase.*absolute URL/u,
+      );
+      expect(
+        () => new AllureReport({ ...localConfig, historyUrlBase: "https://bucket.example/runs/42#current" }),
+      ).toThrowError(/Invalid historyUrlBase.*fragment/u);
+      expect(
+        () => new AllureReport({ ...localConfig, historyUrlBase: "https://bucket.example/runs/42#" }),
+      ).toThrowError(/Invalid historyUrlBase.*fragment/u);
+      expect(() => new AllureReport({ ...noHistoryConfig, historyUrlBase: "relative/path" })).not.toThrow();
+      expect(() => new AllureReport({ ...serviceConfig, historyUrlBase: "relative/path" })).not.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("should read result directory files with bounded concurrency", async () => {

--- a/packages/e2e/test/allure-awesome/features/history.test.ts
+++ b/packages/e2e/test/allure-awesome/features/history.test.ts
@@ -1,3 +1,10 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import type { HistoryDataPoint } from "@allurereport/core-api";
+import AwesomePlugin from "@allurereport/plugin-awesome";
 import { expect, test } from "@playwright/test";
 import { epic, feature, label, Stage, Status, story } from "allure-js-commons";
 
@@ -40,6 +47,7 @@ const fixtures = {
 
 test.describe("history", () => {
   let bootstrap: ReportBootstrap;
+  let multiBootstrap: ReportBootstrap;
   let treePage: TreePage;
   let testResultPage: TestResultPage;
 
@@ -55,12 +63,17 @@ test.describe("history", () => {
     await page.goto(bootstrap.url);
   });
 
+  const sequentialHistoryPath = resolve(tmpdir(), `allure-history-${randomUUID()}.jsonl`);
+
   test.afterAll(async () => {
     await bootstrap?.shutdown?.();
+    await multiBootstrap?.shutdown?.();
+    await rm(sequentialHistoryPath, { force: true });
   });
 
   test.describe("without history", () => {
     test.beforeAll(async () => {
+      await bootstrap?.shutdown?.();
       bootstrap = await bootstrapReport({
         reportConfig: { ...fixtures.reportConfig },
         testResults: [...fixtures.testResults],
@@ -78,6 +91,7 @@ test.describe("history", () => {
 
   test.describe("with local history", () => {
     test.beforeAll(async () => {
+      await bootstrap?.shutdown?.();
       bootstrap = await bootstrapReport({
         reportConfig: { ...fixtures.reportConfig },
         history: [...fixtures.history],
@@ -97,10 +111,11 @@ test.describe("history", () => {
     });
   });
 
-  test.describe("with remote history", () => {
+  test.describe("with local history containing an exact report URL", () => {
     const historicalResultId = "7d99d8872696437419752cf967fe6592";
 
     test.beforeAll(async () => {
+      await bootstrap?.shutdown?.();
       bootstrap = await bootstrapReport({
         reportConfig: { ...fixtures.reportConfig },
         history: [
@@ -124,7 +139,7 @@ test.describe("history", () => {
       await treePage.clickNthLeaf(0);
       await testResultPage.historyTabLocator.click();
 
-      const expectedUrl = `${fixtures.url}/awesome#${historicalResultId}`;
+      const expectedUrl = `${fixtures.url}#${historicalResultId}`;
       const historyLinks = testResultPage.historyItemLocator.nth(0).getByRole("link");
       const previousLink = testResultPage.prevStatusLocator.nth(0).getByRole("link");
 
@@ -139,6 +154,115 @@ test.describe("history", () => {
       await expect(previousLink).toHaveCount(1);
       await expect(previousLink).toBeVisible();
       await expect(previousLink).toHaveAttribute("href", expectedUrl);
+    });
+  });
+
+  test.describe("with sequential flattened and multi-report generations", () => {
+    const flatBase = "https://bucket.example/runs/flat";
+    const multiBase = "https://bucket.example/runs/multi";
+    const finalBase = "https://bucket.example/runs/final";
+    const flatResultId = "flat-result";
+    const multiResultId = "multi-result";
+    const finalResultId = "final-result";
+    const results = [flatResultId, multiResultId, finalResultId].map((uuid, index) =>
+      makeTestResult({
+        name: testName,
+        fullName,
+        historyId,
+        uuid,
+        status: index === 1 ? Status.FAILED : Status.PASSED,
+        stage: Stage.FINISHED,
+        start: 1_000 + index * 1_000,
+        stop: 1_500 + index * 1_000,
+      }),
+    );
+
+    test.beforeAll(async () => {
+      await bootstrap?.shutdown?.();
+
+      const first = await bootstrapReport(
+        {
+          reportConfig: { ...fixtures.reportConfig, historyUrlBase: flatBase },
+          historyPath: sequentialHistoryPath,
+          testResults: [results[0]],
+        },
+        { singleFile: true },
+      );
+      await first.shutdown?.();
+
+      multiBootstrap = await bootstrapReport({
+        reportConfig: { ...fixtures.reportConfig, historyUrlBase: multiBase },
+        historyPath: sequentialHistoryPath,
+        testResults: [results[1]],
+        additionalPlugins: [
+          {
+            id: "secondary",
+            enabled: true,
+            plugin: new AwesomePlugin(),
+            options: {},
+          },
+        ],
+      });
+
+      bootstrap = await bootstrapReport(
+        {
+          reportConfig: { ...fixtures.reportConfig, historyUrlBase: finalBase },
+          historyPath: sequentialHistoryPath,
+          testResults: [results[2]],
+        },
+        { singleFile: true },
+      );
+    });
+
+    test("should persist exact URLs and render historical links without duplication", async ({ page }) => {
+      const historyDataPoints = (await readFile(sequentialHistoryPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as HistoryDataPoint);
+      const flatDataPoint = historyDataPoints.find(({ url }) => url === `${flatBase}/index.html`);
+      const multiDataPoint = historyDataPoints.find(({ url }) => url === `${multiBase}/`);
+      const finalDataPoint = historyDataPoints.find(({ url }) => url === `${finalBase}/index.html`);
+      const [flatHistoryResult] = Object.values(flatDataPoint?.testResults ?? {});
+      const [multiHistoryResult] = Object.values(multiDataPoint?.testResults ?? {});
+      const [finalHistoryResult] = Object.values(finalDataPoint?.testResults ?? {});
+
+      expect(flatHistoryResult).toBeDefined();
+      expect(multiHistoryResult).toBeDefined();
+      expect(finalHistoryResult).toBeDefined();
+      expect(flatHistoryResult?.url).toBe(`${flatBase}/index.html`);
+      expect(multiHistoryResult?.url).toBe(`${multiBase}/`);
+      expect(finalHistoryResult?.url).toBe(`${finalBase}/index.html`);
+      expect(new Set([flatHistoryResult?.id, multiHistoryResult?.id, finalHistoryResult?.id]).size).toBe(3);
+
+      const flatHistoryLink = `${flatHistoryResult?.url}#${flatHistoryResult?.id}`;
+      const multiHistoryLink = `${multiHistoryResult?.url}awesome/index.html#${multiHistoryResult?.id}`;
+
+      await page.goto(`${multiBootstrap.url}/awesome/index.html`);
+      await treePage.clickNthLeaf(0);
+      await testResultPage.historyTabLocator.click();
+
+      await expect(testResultPage.historyItemLocator).toHaveCount(1);
+      const multiReportHistoryLinks = testResultPage.historyItemLocator.nth(0).getByRole("link");
+      const multiReportPreviousLink = testResultPage.prevStatusLocator.nth(0).getByRole("link");
+
+      await expect(multiReportHistoryLinks).toHaveCount(2);
+      await expect(multiReportHistoryLinks.nth(0)).toHaveAttribute("href", flatHistoryLink);
+      await expect(multiReportHistoryLinks.nth(1)).toHaveAttribute("href", flatHistoryLink);
+      await expect(multiReportPreviousLink).toHaveAttribute("href", flatHistoryLink);
+
+      await page.goto(bootstrap.url);
+      await treePage.clickNthLeaf(0);
+      await testResultPage.historyTabLocator.click();
+
+      await expect(testResultPage.historyItemLocator).toHaveCount(2);
+      const historyLinks = testResultPage.historyItemLocator.getByRole("link");
+      const hrefs = await historyLinks.evaluateAll((links) => links.map((link) => link.getAttribute("href")));
+
+      expect(new Set(hrefs)).toEqual(new Set([flatHistoryLink, multiHistoryLink]));
+
+      const previousLink = testResultPage.prevStatusLocator.nth(0).getByRole("link");
+
+      await expect(previousLink).toHaveAttribute("href", multiHistoryLink);
     });
   });
 });

--- a/packages/e2e/test/allure-awesome/utils/index.ts
+++ b/packages/e2e/test/allure-awesome/utils/index.ts
@@ -1,3 +1,4 @@
+import type { FullConfig } from "@allurereport/core";
 import type { TestError } from "@allurereport/core-api";
 import type { ExitCode } from "@allurereport/plugin-api";
 import AwesomePlugin, { type AwesomePluginOptions } from "@allurereport/plugin-awesome";
@@ -11,6 +12,7 @@ import {
 
 export type BootstrapReportParams = Omit<GeneratorParams, "rootDir" | "reportDir" | "resultsDir" | "reportConfig"> & {
   reportConfig: ReportConfig;
+  additionalPlugins?: NonNullable<FullConfig["plugins"]>;
   globals?: {
     exitCode?: ExitCode;
     errors?: TestError[];
@@ -20,8 +22,10 @@ export type BootstrapReportParams = Omit<GeneratorParams, "rootDir" | "reportDir
 };
 
 export const bootstrapReport = async (params: BootstrapReportParams, pluginConfig?: AwesomePluginOptions) => {
+  const { additionalPlugins = [], ...generatorParams } = params;
+
   return baseBootstrapReport({
-    ...params,
+    ...generatorParams,
     reportConfig: {
       ...params.reportConfig,
       plugins: [
@@ -33,6 +37,7 @@ export const bootstrapReport = async (params: BootstrapReportParams, pluginConfi
             ...pluginConfig,
           },
         },
+        ...additionalPlugins,
       ],
     },
   });

--- a/packages/e2e/test/utils/index.ts
+++ b/packages/e2e/test/utils/index.ts
@@ -18,6 +18,7 @@ export type GeneratorParams = {
   rootDir: string;
   reportDir: string;
   resultsDir: string;
+  historyPath?: string;
   testResults?: Partial<TestResult>[];
   rawTestResults?: Partial<TestResult>[];
   rawTestResultContainers?: {
@@ -59,6 +60,7 @@ export const generateReport = async (payload: GeneratorParams) => {
     rootDir,
     reportDir,
     resultsDir,
+    historyPath: providedHistoryPath,
     testResults = [],
     rawTestResults = [],
     rawTestResultContainers = [],
@@ -68,13 +70,14 @@ export const generateReport = async (payload: GeneratorParams) => {
     qualityGateResults,
   } = payload;
   const hasHistory = history.length > 0;
-  const historyPath = resolve(rootDir, `history-${randomUUID()}.jsonl`);
+  const useHistory = Boolean(providedHistoryPath) || hasHistory;
+  const historyPath = providedHistoryPath ?? resolve(rootDir, `history-${randomUUID()}.jsonl`);
 
-  if (!existsSync(historyPath)) {
+  if (useHistory && !existsSync(historyPath)) {
     await writeFile(historyPath, "");
   }
 
-  if (hasHistory) {
+  if (!providedHistoryPath && hasHistory) {
     await writeFile(historyPath, history.map((item) => JSON.stringify(item)).join("\n"), { encoding: "utf-8" });
   }
 
@@ -82,7 +85,7 @@ export const generateReport = async (payload: GeneratorParams) => {
     ...reportConfig,
     output: reportDir,
     reportFiles: new FileSystemReportFiles(reportDir),
-    historyPath: hasHistory ? historyPath : undefined,
+    historyPath: useHistory ? historyPath : undefined,
   });
   const runtime = new ReporterRuntime({
     writer: new FileSystemWriter({

--- a/packages/plugin-api/src/config.ts
+++ b/packages/plugin-api/src/config.ts
@@ -18,6 +18,7 @@ export interface Config {
   port?: string;
   hideLabels?: (string | RegExp)[];
   historyPath?: string;
+  historyUrlBase?: string;
   historyLimit?: number;
   resolutions?: ResolutionsConfig;
   defaultLabels?: DefaultLabelsConfig;

--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -70,7 +70,6 @@ import { generateCharts, getPieChartValues } from "@allurereport/web-commons";
 import Handlebars from "handlebars";
 
 import { convertFixtureResult, convertTestResult } from "./converters.js";
-import { buildServiceHistoryUrl } from "./history.js";
 import type { AwesomeOptions, TemplateManifest } from "./model.js";
 import type { AwesomeDataWriter, ReportFile } from "./writer.js";
 
@@ -170,7 +169,6 @@ export const generateTestResults = async (
 ) => {
   let convertedTrs: ReportTestResult[] = [];
   const related = await store.relatedByTestResultIds(trs.map(({ id }) => id));
-  const resolveHistoryUrl = options.resolveHistoryUrl ?? buildServiceHistoryUrl;
 
   for (const tr of trs) {
     const trFixtures = related.fixturesByTrId.get(tr.id) ?? [];
@@ -184,7 +182,7 @@ export const generateTestResults = async (
 
     convertedTr.history = (related.historyByTrId.get(tr.id) ?? []).map((item) => ({
       ...item,
-      url: resolveHistoryUrl(item.url, options.pluginId, item.id),
+      url: options.resolveHistoryUrl?.(item.url, options.pluginId, item.id) ?? "",
     }));
     convertedTr.retries = related.retriesByTrId.get(tr.id) ?? [];
     convertedTr.retriesCount = convertedTr.retries.length;

--- a/packages/plugin-awesome/src/generators.ts
+++ b/packages/plugin-awesome/src/generators.ts
@@ -5,6 +5,7 @@ import {
   type AttachmentLink,
   type EnvironmentIdentity,
   type EnvironmentItem,
+  type HistoryTestResultUrlResolver,
   type MetricSample,
   type ResolutionCategory,
   type Statistic,
@@ -164,10 +165,12 @@ export const generateTestResults = async (
   options: {
     pluginId: string;
     hideLabels?: readonly (string | RegExp)[];
+    resolveHistoryUrl?: HistoryTestResultUrlResolver;
   },
 ) => {
   let convertedTrs: ReportTestResult[] = [];
   const related = await store.relatedByTestResultIds(trs.map(({ id }) => id));
+  const resolveHistoryUrl = options.resolveHistoryUrl ?? buildServiceHistoryUrl;
 
   for (const tr of trs) {
     const trFixtures = related.fixturesByTrId.get(tr.id) ?? [];
@@ -181,7 +184,7 @@ export const generateTestResults = async (
 
     convertedTr.history = (related.historyByTrId.get(tr.id) ?? []).map((item) => ({
       ...item,
-      url: buildServiceHistoryUrl(item.url, options.pluginId, item.id),
+      url: resolveHistoryUrl(item.url, options.pluginId, item.id),
     }));
     convertedTr.retries = related.retriesByTrId.get(tr.id) ?? [];
     convertedTr.retriesCount = convertedTr.retries.length;

--- a/packages/plugin-awesome/src/plugin.ts
+++ b/packages/plugin-awesome/src/plugin.ts
@@ -192,6 +192,7 @@ export class AwesomePlugin implements Plugin {
     const convertedTrs = await generateTestResults(this.#writer!, store, allTrs, {
       pluginId: context.id,
       hideLabels,
+      resolveHistoryUrl: context.history?.resolveTestResultUrl,
     });
 
     applyCategoriesToTestResults(convertedTrs, categories);

--- a/packages/plugin-awesome/test/generators.test.ts
+++ b/packages/plugin-awesome/test/generators.test.ts
@@ -416,6 +416,47 @@ describe("generateMetricsWidget", () => {
 });
 
 describe("generateTestResults", () => {
+  const historyFixture = (history: HistoryTestResult[]) => {
+    const testResult = mockTestResult("tr-1", "current test", "passed");
+    const writer: AwesomeDataWriter = {
+      writeData: vi.fn().mockResolvedValue(undefined),
+      writeWidget: vi.fn().mockResolvedValue(undefined),
+      writeTestCase: vi.fn().mockResolvedValue(undefined),
+      writeAttachment: vi.fn().mockResolvedValue(undefined),
+    };
+    const store = {
+      relatedByTestResultIds: vi.fn().mockResolvedValue({
+        attachmentsByTrId: new Map([["tr-1", []]]),
+        fixturesByTrId: new Map([["tr-1", []]]),
+        historyByTrId: new Map([["tr-1", history]]),
+        retriesByTrId: new Map([["tr-1", []]]),
+      }),
+      resolutionIssueByTestResultId: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AllureStore;
+
+    return { testResult, writer, store };
+  };
+
+  it("should use the selected history provider resolver", async () => {
+    const item: HistoryTestResult = Object.freeze({
+      id: "old-result",
+      name: "historical test",
+      status: "passed",
+      url: "https://bucket.example/runs/42/",
+    });
+    const resolveHistoryUrl = vi.fn(() => "https://bucket.example/runs/42/awesome/index.html#old-result");
+    const { writer, store, testResult } = historyFixture([item]);
+
+    const [converted] = await generateTestResults(writer, store, [testResult], {
+      pluginId: "awesome",
+      resolveHistoryUrl,
+    });
+
+    expect(resolveHistoryUrl).toHaveBeenCalledWith(item.url, "awesome", item.id);
+    expect(converted.history[0].url).toBe("https://bucket.example/runs/42/awesome/index.html#old-result");
+    expect(item.url).toBe("https://bucket.example/runs/42/");
+  });
+
   it("should sort setup and teardown fixtures by start time", async () => {
     const testResult = mockTestResult("tr-1", "test", "passed");
     const writer: AwesomeDataWriter = {

--- a/packages/service/src/history.ts
+++ b/packages/service/src/history.ts
@@ -13,6 +13,19 @@ export class AllureRemoteHistory implements AllureHistory {
     },
   ) {}
 
+  resolveTestResultUrl(historyUrl: string, pluginId: string, historicalResultId: string): string {
+    if (!historyUrl) {
+      return "";
+    }
+
+    const { origin, pathname } = new URL(historyUrl);
+    // Service history does not perform folder flattening, always add pluginId to the constructed url
+    const navigateUrl = new URL([pathname, pluginId].join("/"), origin);
+    navigateUrl.hash = historicalResultId;
+
+    return navigateUrl.toString();
+  }
+
   async readHistory(params?: { repo?: string; branch?: string }) {
     const { limit } = this.params;
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

This adds a new historyBaseUrl configuration option which allows to fully control history url creation when local history provider is used (user fully controls how reports are hosted and thus can provide the base url for correct history url creation)
#### Checklist

- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>