### PR TITLE
fix(cli): publish standalone quality gate results before finalizing

### DIFF
--- a/packages/cli/src/commands/qualityGate.ts
+++ b/packages/cli/src/commands/qualityGate.ts
@@ -170,13 +170,17 @@ export class QualityGateCommand extends Command {
       await allureReport.readDirectory(directory);
     }
 
-    await allureReport.done();
-
     const allTrs = await allureReport.store.allTestResults({ includeRetries: false });
     const validationResults = await allureReport.validate({
       trs: allTrs,
       environment: resolvedEnvironment?.id,
     });
+
+    if (validationResults.results.length > 0) {
+      allureReport.realtimeDispatcher.sendQualityGateResults(validationResults.results);
+    }
+
+    await allureReport.done();
 
     if (validationResults.results.length === 0) {
       exit(0);

--- a/packages/cli/test/commands/qualityGate.test.ts
+++ b/packages/cli/test/commands/qualityGate.test.ts
@@ -132,6 +132,42 @@ describe("quality-gate command", () => {
     expect(exit).toHaveBeenCalledWith(0);
   });
 
+  it("should publish final quality gate results before report finalization", async () => {
+    (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
+    (readConfig as Mock).mockResolvedValueOnce({
+      plugins: [],
+      qualityGate: fixtures.qualityGateConfig,
+    });
+    AllureReportMock.prototype.hasQualityGate = true;
+    AllureReportMock.prototype.realtimeSubscriber = {
+      onTestResults: () => {},
+    };
+    AllureReportMock.prototype.store = {
+      allTestResults: vi.fn().mockResolvedValue([{ id: "failed-1", status: "failed" }]),
+      testResultById: vi.fn(),
+    };
+    (AllureReportMock.prototype.validate as unknown as Mock).mockResolvedValueOnce({
+      results: fixtures.qualityGateValidationResults,
+    });
+
+    await run(QualityGateCommand, [
+      "quality-gate",
+      "--cwd",
+      fixtures.cwd,
+      "--config",
+      fixtures.config,
+      fixtures.resultsDir,
+    ]);
+
+    expect(AllureReportMock.prototype.realtimeDispatcher.sendQualityGateResults).toHaveBeenCalledWith(
+      fixtures.qualityGateValidationResults,
+    );
+    expect(
+      (AllureReportMock.prototype.realtimeDispatcher.sendQualityGateResults as Mock).mock.invocationCallOrder[0],
+    ).toBeLessThan((AllureReportMock.prototype.done as unknown as Mock).mock.invocationCallOrder[0]);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
   it("should exit with code 1 on fast-fail during realtime validation", async () => {
     (glob as unknown as Mock).mockResolvedValueOnce(["./allure-results/"]);
     (readConfig as Mock).mockResolvedValueOnce({ plugins: [] });


### PR DESCRIPTION
## Summary
- Publish final standalone `quality-gate` validation results before `AllureReport.done()`.
- Keep CLI output/exit behavior unchanged while allowing report-root `quality-gate.json` to include failed rules.


#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure3
